### PR TITLE
feat(integrations): add Azure DevOps and Jira integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 *.log
 .DS_Store
+.specclaw/.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+You are the assistant for the **specclaw** project.
+
+Working directory: this is a git checkout of git@github.com:chan4lk/specclaw.git (base branch `main`). Commands run from here.
+You can use Bash freely (auto permission mode). Useful binaries on PATH: git, gh (GitHub CLI), node/npm, bun, python.
+
+# Git workflow
+
+- Always `git pull --ff-only origin main` before starting work.
+- Make changes on a feature branch — never commit directly to `main`. Branch names: `claude/<short-task>` or `<operator-handle>/<topic>`.
+- Stage and commit small focused units. Use clear commit messages with the *why*, not just the *what*.
+- Push the branch (`git push -u origin <branch>`). Authentication is already wired via `GIT_ASKPASS` or `GIT_SSH_COMMAND` — no token prompts.
+- Open a pull request with `gh pr create --base main --title "..." --body "..."`. Reply in Discord with the PR URL.
+- For small fixes, request review in the PR body or `@mention` the operator.
+
+# Cloning additional repos
+
+If you need to look at another repo: `git clone <url>` into a sibling directory under `~/.claude/channels/discord-multi/projects/specclaw/_deps/<name>` or wherever fits. Don't pollute this working tree with unrelated code.
+
+# Discord conventions
+
+Inbound messages arrive wrapped in `<channel source="discord" ...>BODY</channel>` envelopes — BODY is what the operator typed. Respond by calling `mcp__mcd__reply` with `{ text, reply_to? }`. Do NOT call `mcp__discord__reply`. Don't print transcript text outside the reply tool — Discord users only see what `mcp__mcd__reply` emits. Keep replies brief; for long output, post the highlights and offer to dig in.
+
+Other tools (`mcp__mcd__react`, `mcp__mcd__edit_message`, `mcp__mcd__download_attachment`, `mcp__mcd__fetch_messages`) are available when useful — for example `download_attachment` to grab an inbound file, or `react` for a fast acknowledgment before a long task.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -460,6 +460,58 @@ Create a GitHub PR for a verified change. Requires verify-report.md (build + ver
    - **Saves URL:** appends `**PR:** <url>` to `status.md`.
 3. Report the PR URL to the user.
 
+### `specclaw auth azdo`
+**Trigger:** "specclaw auth azdo", "set up azure devops", "configure ADO", "azdo auth"
+
+Interactive Azure DevOps authentication setup. Guides the user to create a PAT, validates it, and saves credentials.
+
+1. **Run:** `bash skill/scripts/auth-azdo.sh .specclaw`
+   - Prompts for org name, project name, repo name
+   - Guides user to `https://dev.azure.com/<org>/_usersSettings/tokens` to create a PAT
+   - Required scopes: Code (Read & Write), Work Items (Read & Write)
+   - Validates the token via ADO REST API
+   - Saves org/project/repo to `config.yaml` under `azdo:` section; token to `.specclaw/.env` (gitignored)
+2. Report success and suggest `specclaw pr azdo <change>` as next step.
+
+### `specclaw auth jira`
+**Trigger:** "specclaw auth jira", "set up jira", "configure jira", "jira auth"
+
+Interactive Jira authentication setup. Guides the user to create an Atlassian API token, validates it, and saves credentials.
+
+1. **Run:** `bash skill/scripts/auth-jira.sh .specclaw`
+   - Prompts for domain (e.g. `mycompany.atlassian.net`), email, project key, issue type
+   - Guides user to `https://id.atlassian.com/manage-profile/security/api-tokens`
+   - Validates credentials and project key via Jira REST API
+   - Saves domain/email/project_key/issue_type to `config.yaml` under `jira:` section; token to `.specclaw/.env` (gitignored)
+2. Report success and suggest `specclaw issue <change>` as next step.
+
+### `specclaw pr azdo <change>`
+**Trigger:** "specclaw pr azdo", "create ADO PR", "azure devops pull request", "open PR in ADO"
+
+Create an Azure DevOps pull request for a verified change. Mirrors `specclaw pr` but targets ADO Repos via REST API instead of GitHub.
+
+1. **Validate:** Run `bash skill/scripts/validate-change.sh .specclaw <change> pr`. Fails if verify-report.md is missing.
+2. **Run:** `bash skill/scripts/azdo-pr.sh .specclaw <change>`
+   - Requires `AZDO_TOKEN`, `AZDO_ORG`, `AZDO_PROJECT`, `AZDO_REPO` (set via `specclaw auth azdo`)
+   - **Test policy:** same gate as `specclaw pr` — prompts once, enforces on all runs
+   - **PR creation:** builds title (≤128 chars) from `proposal.md`, description from `spec.md` + `verify-report.md`, calls ADO REST API
+   - **Saves URL:** appends `**ADO PR:** <url>` to `status.md`
+3. Report the ADO PR URL to the user.
+
+### `specclaw issue <change>`
+**Trigger:** "specclaw issue", "create jira issue", "jira ticket", "open jira story"
+
+Create a Jira issue from a specclaw proposal. Requires `proposal.md` (run `specclaw propose` first).
+
+1. **Check:** if Jira issue already exists in `status.md`, warn and skip (idempotent).
+2. **Run:** `bash skill/scripts/jira-issue.sh .specclaw <change>`
+   - Requires `JIRA_TOKEN`, `JIRA_URL`, `JIRA_EMAIL`, `JIRA_PROJECT` (set via `specclaw auth jira`)
+   - Builds summary (≤255 chars) from first non-header line of `proposal.md`
+   - Builds description (ADF format) from `proposal.md` + `spec.md` (if present)
+   - Creates issue via Jira REST API v3
+   - **Saves:** appends `**Jira Issue:** [KEY](url)` to `status.md`
+3. Report the Jira issue key and URL to the user.
+
 ### `specclaw status`
 **Trigger:** "specclaw status", "project status", "what's the progress"
 

--- a/skill/scripts/auth-azdo.sh
+++ b/skill/scripts/auth-azdo.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# auth-azdo.sh — Interactive Azure DevOps auth setup
+# Guides user to PAT creation page, validates token, saves to .specclaw/.env + config.yaml
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: auth-azdo.sh <specclaw_dir>
+
+Set up Azure DevOps authentication for specclaw. Guides you to:
+  1. Enter org + project + repo names
+  2. Open the PAT creation page in your browser
+  3. Paste the generated token
+  4. Validates and saves credentials
+
+Arguments:
+  specclaw_dir   Path to the .specclaw directory
+EOF
+  exit 0
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+if [[ $# -lt 1 ]]; then
+  echo "ERROR: Expected argument: <specclaw_dir>" >&2
+  exit 1
+fi
+
+SPECCLAW_DIR="$1"
+CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
+AUTH_FILE="$SPECCLAW_DIR/.env"
+
+[[ -d "$SPECCLAW_DIR" ]] || { echo "ERROR: specclaw directory not found: $SPECCLAW_DIR" >&2; exit 1; }
+[[ -f "$CONFIG_FILE" ]]  || { echo "ERROR: config.yaml not found — run: specclaw init" >&2; exit 1; }
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+env_set() {
+  local key="$1" val="$2"
+  if [[ -f "$AUTH_FILE" ]] && grep -q "^${key}=" "$AUTH_FILE" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$AUTH_FILE"
+  else
+    echo "${key}=${val}" >> "$AUTH_FILE"
+  fi
+}
+
+yaml_set_azdo() {
+  local key="$1" val="$2"
+  if grep -q '^azdo:' "$CONFIG_FILE" 2>/dev/null; then
+    if grep -qE "^[[:space:]]+${key}:" "$CONFIG_FILE" 2>/dev/null; then
+      sed -i "s|^\([[:space:]]*\)${key}:.*|\1${key}: \"${val}\"|" "$CONFIG_FILE"
+    else
+      sed -i "/^azdo:/a\\  ${key}: \"${val}\"" "$CONFIG_FILE"
+    fi
+  else
+    printf '\n# Azure DevOps integration\nazdo:\n  enabled: true\n  org: ""\n  project: ""\n  repo: ""\n' >> "$CONFIG_FILE"
+    yaml_set_azdo "$key" "$val"
+  fi
+}
+
+ensure_gitignored() {
+  local gitignore
+  gitignore="$(cd "$SPECCLAW_DIR/.." && git rev-parse --show-toplevel 2>/dev/null)/.gitignore"
+  if [[ -f "$gitignore" ]] && ! grep -q '\.specclaw/\.env' "$gitignore" 2>/dev/null; then
+    echo ".specclaw/.env" >> "$gitignore"
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "SpecClaw — Azure DevOps Auth Setup"
+  echo "===================================="
+  echo ""
+
+  echo -n "Azure DevOps org name (part after dev.azure.com/ — e.g. 'mycompany'): "
+  read -r ORG </dev/tty
+  [[ -n "$ORG" ]] || die "Org name required"
+
+  echo -n "Project name (e.g. 'MyProject'): "
+  read -r PROJECT </dev/tty
+  [[ -n "$PROJECT" ]] || die "Project name required"
+
+  echo -n "Repository name (e.g. 'my-repo'): "
+  read -r REPO </dev/tty
+  [[ -n "$REPO" ]] || die "Repository name required"
+
+  echo ""
+  echo "─────────────────────────────────────────────────────────────────"
+  echo "Now create a Personal Access Token:"
+  echo ""
+  echo "  Open → https://dev.azure.com/${ORG}/_usersSettings/tokens"
+  echo ""
+  echo "  Token settings:"
+  echo "    Name:        specclaw (or any label)"
+  echo "    Expiration:  90 days recommended"
+  echo "    Scopes:      Custom defined"
+  echo "      ✓ Code          → Read & Write"
+  echo "      ✓ Work Items    → Read & Write"
+  echo "      (Pull Requests are covered under Code scope)"
+  echo ""
+  echo "  Click 'Create' then copy the token shown."
+  echo "─────────────────────────────────────────────────────────────────"
+  echo ""
+  echo -n "Paste your PAT here (hidden): "
+  read -rs TOKEN </dev/tty
+  echo ""
+  [[ -n "$TOKEN" ]] || die "Token required"
+
+  echo "Validating..."
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u ":${TOKEN}" \
+    "https://dev.azure.com/${ORG}/_apis/projects/${PROJECT}?api-version=7.1") || true
+
+  case "$HTTP_CODE" in
+    200) echo "✅ Token valid — project '${PROJECT}' confirmed" ;;
+    401) die "Token invalid or expired — check scopes and try again" ;;
+    404) die "Project '${PROJECT}' not found in org '${ORG}' — check names" ;;
+    *)   die "Validation failed (HTTP ${HTTP_CODE}) — check org/project and token" ;;
+  esac
+
+  yaml_set_azdo "enabled" "true"
+  yaml_set_azdo "org"     "$ORG"
+  yaml_set_azdo "project" "$PROJECT"
+  yaml_set_azdo "repo"    "$REPO"
+
+  env_set "AZDO_TOKEN"   "$TOKEN"
+  env_set "AZDO_ORG"     "$ORG"
+  env_set "AZDO_PROJECT" "$PROJECT"
+  env_set "AZDO_REPO"    "$REPO"
+
+  ensure_gitignored
+
+  echo ""
+  echo "✅ Azure DevOps auth saved."
+  echo "   Org:     $ORG"
+  echo "   Project: $PROJECT"
+  echo "   Repo:    $REPO"
+  echo "   Token:   stored in ${AUTH_FILE} (gitignored)"
+  echo ""
+  echo "Next: 'specclaw pr <change>' to create an ADO pull request."
+}
+
+main

--- a/skill/scripts/auth-jira.sh
+++ b/skill/scripts/auth-jira.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# auth-jira.sh — Interactive Jira auth setup
+# Guides user to API token page, validates credentials, saves to .specclaw/.env + config.yaml
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: auth-jira.sh <specclaw_dir>
+
+Set up Jira authentication for specclaw. Guides you to:
+  1. Enter Jira domain, email, and project key
+  2. Open the Atlassian API token page
+  3. Paste the generated token
+  4. Validates and saves credentials
+
+Arguments:
+  specclaw_dir   Path to the .specclaw directory
+EOF
+  exit 0
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+if [[ $# -lt 1 ]]; then
+  echo "ERROR: Expected argument: <specclaw_dir>" >&2
+  exit 1
+fi
+
+SPECCLAW_DIR="$1"
+CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
+AUTH_FILE="$SPECCLAW_DIR/.env"
+
+[[ -d "$SPECCLAW_DIR" ]] || { echo "ERROR: specclaw directory not found: $SPECCLAW_DIR" >&2; exit 1; }
+[[ -f "$CONFIG_FILE" ]]  || { echo "ERROR: config.yaml not found — run: specclaw init" >&2; exit 1; }
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+env_set() {
+  local key="$1" val="$2"
+  if [[ -f "$AUTH_FILE" ]] && grep -q "^${key}=" "$AUTH_FILE" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$AUTH_FILE"
+  else
+    echo "${key}=${val}" >> "$AUTH_FILE"
+  fi
+}
+
+yaml_set_jira() {
+  local key="$1" val="$2"
+  if grep -q '^jira:' "$CONFIG_FILE" 2>/dev/null; then
+    if grep -qE "^[[:space:]]+${key}:" "$CONFIG_FILE" 2>/dev/null; then
+      sed -i "s|^\([[:space:]]*\)${key}:.*|\1${key}: \"${val}\"|" "$CONFIG_FILE"
+    else
+      sed -i "/^jira:/a\\  ${key}: \"${val}\"" "$CONFIG_FILE"
+    fi
+  else
+    printf '\n# Jira integration\njira:\n  enabled: true\n  domain: ""\n  email: ""\n  project_key: ""\n  issue_type: "Story"\n' >> "$CONFIG_FILE"
+    yaml_set_jira "$key" "$val"
+  fi
+}
+
+ensure_gitignored() {
+  local gitignore
+  gitignore="$(cd "$SPECCLAW_DIR/.." && git rev-parse --show-toplevel 2>/dev/null)/.gitignore"
+  if [[ -f "$gitignore" ]] && ! grep -q '\.specclaw/\.env' "$gitignore" 2>/dev/null; then
+    echo ".specclaw/.env" >> "$gitignore"
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "SpecClaw — Jira Auth Setup"
+  echo "==========================="
+  echo ""
+
+  echo -n "Jira domain (e.g. 'mycompany.atlassian.net'): "
+  read -r DOMAIN </dev/tty
+  [[ -n "$DOMAIN" ]] || die "Domain required"
+  DOMAIN="${DOMAIN#https://}"; DOMAIN="${DOMAIN#http://}"; DOMAIN="${DOMAIN%/}"
+
+  echo -n "Atlassian account email: "
+  read -r EMAIL </dev/tty
+  [[ -n "$EMAIL" ]] || die "Email required"
+
+  echo -n "Jira project key (e.g. 'PROJ' — shown in issue IDs like PROJ-123): "
+  read -r PROJECT_KEY </dev/tty
+  [[ -n "$PROJECT_KEY" ]] || die "Project key required"
+  PROJECT_KEY="$(echo "$PROJECT_KEY" | tr '[:lower:]' '[:upper:]')"
+
+  echo -n "Default issue type [Story]: "
+  read -r ISSUE_TYPE </dev/tty
+  ISSUE_TYPE="${ISSUE_TYPE:-Story}"
+
+  echo ""
+  echo "─────────────────────────────────────────────────────────────────"
+  echo "Now create an Atlassian API token:"
+  echo ""
+  echo "  Open → https://id.atlassian.com/manage-profile/security/api-tokens"
+  echo ""
+  echo "  Steps:"
+  echo "    1. Click 'Create API token'"
+  echo "    2. Label: 'specclaw' (or any name)"
+  echo "    3. Click 'Create'"
+  echo "    4. Copy the token — it is shown only once"
+  echo "─────────────────────────────────────────────────────────────────"
+  echo ""
+  echo -n "Paste your API token here (hidden): "
+  read -rs TOKEN </dev/tty
+  echo ""
+  [[ -n "$TOKEN" ]] || die "Token required"
+
+  echo "Validating credentials..."
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "${EMAIL}:${TOKEN}" \
+    -H "Accept: application/json" \
+    "https://${DOMAIN}/rest/api/3/myself") || true
+
+  case "$HTTP_CODE" in
+    200) echo "✅ Credentials valid" ;;
+    401) die "Invalid email or token — check and try again" ;;
+    403) die "Token lacks required permissions" ;;
+    *)   die "Validation failed (HTTP ${HTTP_CODE}) — check domain and credentials" ;;
+  esac
+
+  echo "Checking project '${PROJECT_KEY}'..."
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "${EMAIL}:${TOKEN}" \
+    -H "Accept: application/json" \
+    "https://${DOMAIN}/rest/api/3/project/${PROJECT_KEY}") || true
+
+  case "$HTTP_CODE" in
+    200) echo "✅ Project '${PROJECT_KEY}' confirmed" ;;
+    404) die "Project '${PROJECT_KEY}' not found — check the project key" ;;
+    *)   die "Project check failed (HTTP ${HTTP_CODE})" ;;
+  esac
+
+  yaml_set_jira "enabled"     "true"
+  yaml_set_jira "domain"      "$DOMAIN"
+  yaml_set_jira "email"       "$EMAIL"
+  yaml_set_jira "project_key" "$PROJECT_KEY"
+  yaml_set_jira "issue_type"  "$ISSUE_TYPE"
+
+  env_set "JIRA_TOKEN"   "$TOKEN"
+  env_set "JIRA_URL"     "https://${DOMAIN}"
+  env_set "JIRA_EMAIL"   "$EMAIL"
+  env_set "JIRA_PROJECT" "$PROJECT_KEY"
+
+  ensure_gitignored
+
+  echo ""
+  echo "✅ Jira auth saved."
+  echo "   Domain:      $DOMAIN"
+  echo "   Email:       $EMAIL"
+  echo "   Project:     $PROJECT_KEY"
+  echo "   Issue type:  $ISSUE_TYPE"
+  echo "   Token:       stored in ${AUTH_FILE} (gitignored)"
+  echo ""
+  echo "Next: 'specclaw issue <change>' to create a Jira issue from a proposal."
+}
+
+main

--- a/skill/scripts/azdo-pr.sh
+++ b/skill/scripts/azdo-pr.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# azdo-pr.sh — Create an Azure DevOps PR for a specclaw change
+# Mirrors pr.sh but targets ADO Repos via REST API instead of GitHub.
+# Usage: azdo-pr.sh <specclaw_dir> <change_name>
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: azdo-pr.sh <specclaw_dir> <change_name>
+
+Create an Azure DevOps pull request for a specclaw change. Requires:
+  - verify-report.md (build + verify must have completed)
+  - test policy configured (prompts on first run, enforced on all runs)
+  - Azure DevOps auth configured (run: specclaw auth azdo)
+
+Arguments:
+  specclaw_dir   Path to the .specclaw directory
+  change_name    Name of the change
+EOF
+  exit 0
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+if [[ $# -lt 2 ]]; then
+  echo "ERROR: Expected 2 arguments: <specclaw_dir> <change_name>" >&2
+  exit 1
+fi
+
+SPECCLAW_DIR="$1"
+CHANGE_NAME="$2"
+CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
+AUTH_FILE="$SPECCLAW_DIR/.env"
+CHANGE_DIR="$SPECCLAW_DIR/changes/$CHANGE_NAME"
+
+[[ -d "$SPECCLAW_DIR" ]] || { echo "ERROR: specclaw directory not found: $SPECCLAW_DIR" >&2; exit 1; }
+[[ -d "$CHANGE_DIR" ]]   || { echo "ERROR: change directory not found: $CHANGE_DIR" >&2; exit 1; }
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARNING: $*" >&2; }
+
+FAILURES=()
+fail() { FAILURES+=("$1"); }
+
+# ─── Load Auth ────────────────────────────────────────────────────────────────
+
+# shellcheck disable=SC1090
+[[ -f "$AUTH_FILE" ]] && source "$AUTH_FILE"
+
+AZDO_TOKEN="${AZDO_TOKEN:-}"
+AZDO_ORG="${AZDO_ORG:-}"
+AZDO_PROJECT="${AZDO_PROJECT:-}"
+AZDO_REPO="${AZDO_REPO:-}"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+yaml_val() {
+  local file="$1" key="$2"
+  local section field
+  if [[ "$key" == *.* ]]; then
+    section="${key%%.*}"; field="${key#*.}"
+  else
+    section=""; field="$key"
+  fi
+  local in_section=false value=""
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+    if [[ -z "$section" ]]; then
+      if [[ "$line" =~ ^${field}:[[:space:]]*(.*) ]]; then value="${BASH_REMATCH[1]}"; break; fi
+    else
+      if [[ "$line" =~ ^[a-zA-Z_] ]]; then
+        [[ "$line" =~ ^${section}: ]] && in_section=true || in_section=false; continue
+      fi
+      if $in_section && [[ "$line" =~ ^[[:space:]]+${field}:[[:space:]]*(.*) ]]; then
+        value="${BASH_REMATCH[1]}"; break
+      fi
+    fi
+  done < "$file"
+  value="${value#\"}"; value="${value%\"}"; value="${value#\'}"; value="${value%\'}"
+  echo "$value"
+}
+
+# Fall back to config.yaml values if env vars not set
+if [[ -z "$AZDO_ORG" && -f "$CONFIG_FILE" ]]; then
+  AZDO_ORG="$(yaml_val "$CONFIG_FILE" "azdo.org")"
+  AZDO_PROJECT="$(yaml_val "$CONFIG_FILE" "azdo.project")"
+  AZDO_REPO="$(yaml_val "$CONFIG_FILE" "azdo.repo")"
+fi
+
+[[ -n "$AZDO_TOKEN" ]]   || die "AZDO_TOKEN not set — run: specclaw auth azdo"
+[[ -n "$AZDO_ORG" ]]     || die "AZDO_ORG not set — run: specclaw auth azdo"
+[[ -n "$AZDO_PROJECT" ]] || die "AZDO_PROJECT not set — run: specclaw auth azdo"
+[[ -n "$AZDO_REPO" ]]    || die "AZDO_REPO not set — run: specclaw auth azdo"
+
+STRICT="true"
+if [[ -f "$CONFIG_FILE" ]]; then
+  _s="$(yaml_val "$CONFIG_FILE" "workflow.strict")"
+  [[ -n "$_s" ]] && STRICT="$_s"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── Phase Validation ─────────────────────────────────────────────────────────
+
+validate_phase() {
+  bash "$SCRIPT_DIR/validate-change.sh" "$SPECCLAW_DIR" "$CHANGE_NAME" pr
+}
+
+# ─── Test Policy ──────────────────────────────────────────────────────────────
+
+yaml_set_pr_policy() {
+  local policy="$1"
+  if grep -q '^pr:' "$CONFIG_FILE" 2>/dev/null; then
+    if grep -q '^\s*test_policy:' "$CONFIG_FILE" 2>/dev/null; then
+      sed -i "s|^\([[:space:]]*\)test_policy:.*|\1test_policy: \"$policy\"|" "$CONFIG_FILE"
+    else
+      sed -i "/^pr:/a\\  test_policy: \"$policy\"" "$CONFIG_FILE"
+    fi
+  else
+    printf '\npr:\n  test_policy: "%s"\n' "$policy" >> "$CONFIG_FILE"
+  fi
+}
+
+check_test_policy() {
+  local policy=""
+  [[ -f "$CONFIG_FILE" ]] && policy="$(yaml_val "$CONFIG_FILE" "pr.test_policy")"
+  if [[ -z "$policy" ]]; then
+    echo ""
+    echo "SpecClaw: Test Policy Setup"
+    echo "----------------------------"
+    echo "Do you plan to implement automated tests for this project?"
+    echo "This will be enforced on all future PR runs."
+    echo ""
+    while true; do
+      echo -n "Enter policy [none/unit/e2e/both]: "
+      read -r policy </dev/tty
+      policy="$(echo "$policy" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+      case "$policy" in
+        none|unit|e2e|both) break ;;
+        *) echo "Invalid. Enter one of: none, unit, e2e, both" ;;
+      esac
+    done
+    yaml_set_pr_policy "$policy"
+    echo "Saved test policy: $policy"
+    echo ""
+  fi
+  echo "$policy"
+}
+
+enforce_test_policy() {
+  local policy="$1"
+  [[ "$policy" == "none" ]] && return 0
+  local test_cmd=""
+  [[ -f "$CONFIG_FILE" ]] && test_cmd="$(yaml_val "$CONFIG_FILE" "build.test_command")"
+  [[ -z "$test_cmd" ]] && fail "test_policy is '$policy' but build.test_command is not set in config.yaml"
+  local verify_report="$CHANGE_DIR/verify-report.md"
+  if [[ ! -s "$verify_report" ]]; then fail "verify-report.md empty — no test evidence (policy: $policy)"; return; fi
+  local kw="test|passed|failed|coverage|e2e|unit|assert|spec|describe|expect"
+  grep -qiE "$kw" "$verify_report" 2>/dev/null || fail "No test evidence in verify-report.md (policy: $policy)"
+  if [[ "$policy" == "e2e" || "$policy" == "both" ]]; then
+    grep -qiE "e2e|end.to.end|cypress|playwright|selenium|integration" "$verify_report" 2>/dev/null \
+      || fail "No e2e evidence in verify-report.md (policy: $policy)"
+  fi
+}
+
+report_failures() {
+  [[ ${#FAILURES[@]} -eq 0 ]] && return 0
+  for msg in "${FAILURES[@]}"; do
+    [[ "$STRICT" == "true" ]] && echo "ERROR: $msg" >&2 || echo "WARNING: $msg" >&2
+  done
+  [[ "$STRICT" == "true" ]] && exit 1
+}
+
+# ─── PR Content Builder ───────────────────────────────────────────────────────
+
+extract_section() {
+  local file="$1" header="$2" max_lines="${3:-40}"
+  local in_section=false count=0 output=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^##[[:space:]] ]]; then
+      if [[ "$line" =~ $header ]]; then in_section=true; continue
+      elif $in_section; then break; fi
+    fi
+    if $in_section; then
+      output+="$line"$'\n'; ((count++)) || true; [[ $count -ge $max_lines ]] && break
+    fi
+  done < "$file"
+  printf '%s' "$output"
+}
+
+build_pr_title() {
+  local proposal_file="$CHANGE_DIR/proposal.md"
+  local summary=""
+  if [[ -f "$proposal_file" ]]; then
+    while IFS= read -r line; do
+      [[ -z "${line// /}" ]] && continue
+      [[ "$line" =~ ^# ]]    && continue
+      [[ "$line" =~ ^\*\* ]] && continue
+      summary="$line"; break
+    done < "$proposal_file"
+  fi
+  local title
+  if [[ -n "$summary" ]]; then
+    summary="${summary//\*/}"; summary="${summary//\`/}"
+    title="[specclaw] ${CHANGE_NAME}: ${summary}"
+  else
+    title="[specclaw] ${CHANGE_NAME}"
+  fi
+  # ADO PR titles: 128 char limit
+  [[ ${#title} -gt 128 ]] && title="${title:0:125}..."
+  echo "$title"
+}
+
+build_pr_description() {
+  local policy="$1"
+  local proposal_file="$CHANGE_DIR/proposal.md"
+  local spec_file="$CHANGE_DIR/spec.md"
+  local verify_file="$CHANGE_DIR/verify-report.md"
+
+  local summary_text=""
+  if [[ -f "$proposal_file" ]]; then
+    local problem solution
+    problem="$(extract_section "$proposal_file" "Problem" 10)"
+    solution="$(extract_section "$proposal_file" "Proposed Solution" 10)"
+    if [[ -n "$problem" || -n "$solution" ]]; then
+      summary_text="${problem}${solution}"
+    else
+      local count=0
+      while IFS= read -r line; do
+        [[ "$line" =~ ^# ]] && continue
+        summary_text+="$line"$'\n'; ((count++)) || true; [[ $count -ge 15 ]] && break
+      done < "$proposal_file"
+    fi
+  else
+    summary_text="See change: \`${CHANGE_NAME}\`"
+  fi
+
+  local ac_text=""
+  if [[ -f "$spec_file" ]]; then
+    ac_text="$(extract_section "$spec_file" "Acceptance Criteria" 40)"
+    [[ -z "$ac_text" ]] && ac_text="$(head -40 "$spec_file")"
+  else
+    ac_text="_spec.md not found_"
+  fi
+
+  local verdict="unknown" verify_excerpt=""
+  if [[ -f "$verify_file" ]]; then
+    verdict="$(grep -oiE '\b(PASS|FAIL|PARTIAL)\b' "$verify_file" | head -1)"
+    [[ -z "$verdict" ]] && verdict="unknown"
+    verify_excerpt="$(head -20 "$verify_file")"
+  fi
+
+  local test_section=""
+  if [[ "$policy" != "none" && -f "$verify_file" ]]; then
+    local test_lines
+    test_lines="$(grep -iE "test|passed|failed|coverage|e2e|unit|assert" "$verify_file" | head -10)" || true
+    test_section="## Tests
+**Policy:** ${policy}
+
+\`\`\`
+${test_lines}
+\`\`\`
+"
+  fi
+
+  cat <<EOF
+## Summary
+${summary_text}
+## Acceptance Criteria
+${ac_text}
+## Verification
+**Verdict:** ${verdict}
+
+${verify_excerpt}
+${test_section}
+---
+🤖 Generated by SpecClaw
+EOF
+}
+
+# ─── ADO REST API ─────────────────────────────────────────────────────────────
+
+adoapi_post() {
+  local path="$1" data="$2"
+  local url="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_apis/${path}"
+  local auth
+  auth="$(printf ':%s' "$AZDO_TOKEN" | base64 -w0 2>/dev/null || printf ':%s' "$AZDO_TOKEN" | base64)"
+  curl -sf -X POST "$url" \
+    -H "Authorization: Basic ${auth}" \
+    -H "Content-Type: application/json" \
+    -d "$data"
+}
+
+adoapi_get() {
+  local path="$1"
+  local url="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_apis/${path}"
+  local auth
+  auth="$(printf ':%s' "$AZDO_TOKEN" | base64 -w0 2>/dev/null || printf ':%s' "$AZDO_TOKEN" | base64)"
+  curl -sf "$url" -H "Authorization: Basic ${auth}"
+}
+
+get_default_branch() {
+  local result
+  result="$(adoapi_get "git/repositories/${AZDO_REPO}?api-version=7.1" 2>/dev/null)" || true
+  if [[ -n "$result" ]]; then
+    local branch
+    branch="$(echo "$result" | grep -o '"defaultBranch":"[^"]*"' | cut -d'"' -f4)"
+    echo "${branch#refs/heads/}"
+  else
+    echo "main"
+  fi
+}
+
+json_escape() {
+  python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null || \
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n' | sed 's/\\n$//' | sed 's/^/"/; s/$/"/'
+}
+
+save_pr_url() {
+  local url="$1"
+  local status_file="$CHANGE_DIR/status.md"
+  if [[ -f "$status_file" ]]; then
+    echo "**ADO PR:** $url" >> "$status_file"
+  else
+    printf '# Status: %s\n\n**ADO PR:** %s\n' "$CHANGE_NAME" "$url" > "$status_file"
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  validate_phase
+
+  local policy
+  policy="$(check_test_policy)"
+
+  enforce_test_policy "$policy"
+  report_failures
+
+  local source_branch target_branch
+  source_branch="$(git rev-parse --abbrev-ref HEAD)"
+  target_branch="$(get_default_branch)"
+
+  local title description
+  title="$(build_pr_title)"
+  description="$(build_pr_description "$policy")"
+
+  local title_json desc_json
+  title_json="$(echo "$title" | json_escape)"
+  desc_json="$(echo "$description" | json_escape)"
+
+  local payload
+  payload=$(printf '{"title":%s,"description":%s,"sourceRefName":"refs/heads/%s","targetRefName":"refs/heads/%s"}' \
+    "$title_json" "$desc_json" "$source_branch" "$target_branch")
+
+  echo "Creating ADO PR: $title"
+  local response
+  response="$(adoapi_post "git/repositories/${AZDO_REPO}/pullrequests?api-version=7.1" "$payload")"
+
+  local pr_id
+  pr_id="$(echo "$response" | grep -o '"pullRequestId":[0-9]*' | cut -d: -f2)"
+  [[ -n "$pr_id" ]] || die "Failed to parse PR ID from ADO response"
+
+  local pr_url="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_git/${AZDO_REPO}/pullrequest/${pr_id}"
+  save_pr_url "$pr_url"
+  echo "✅ ADO PR created: $pr_url"
+}
+
+main

--- a/skill/scripts/jira-issue.sh
+++ b/skill/scripts/jira-issue.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# jira-issue.sh — Create a Jira issue from a specclaw proposal
+# Usage: jira-issue.sh <specclaw_dir> <change_name>
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: jira-issue.sh <specclaw_dir> <change_name>
+
+Create a Jira issue from a specclaw change proposal. Requires:
+  - proposal.md (specclaw propose must have completed)
+  - Jira auth configured (run: specclaw auth jira)
+
+Arguments:
+  specclaw_dir   Path to the .specclaw directory
+  change_name    Name of the change
+EOF
+  exit 0
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+if [[ $# -lt 2 ]]; then
+  echo "ERROR: Expected 2 arguments: <specclaw_dir> <change_name>" >&2
+  exit 1
+fi
+
+SPECCLAW_DIR="$1"
+CHANGE_NAME="$2"
+CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
+AUTH_FILE="$SPECCLAW_DIR/.env"
+CHANGE_DIR="$SPECCLAW_DIR/changes/$CHANGE_NAME"
+
+[[ -d "$SPECCLAW_DIR" ]] || { echo "ERROR: specclaw directory not found: $SPECCLAW_DIR" >&2; exit 1; }
+[[ -d "$CHANGE_DIR" ]]   || { echo "ERROR: change directory not found: $CHANGE_DIR" >&2; exit 1; }
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ─── Load Auth ────────────────────────────────────────────────────────────────
+
+# shellcheck disable=SC1090
+[[ -f "$AUTH_FILE" ]] && source "$AUTH_FILE"
+
+JIRA_TOKEN="${JIRA_TOKEN:-}"
+JIRA_URL="${JIRA_URL:-}"
+JIRA_EMAIL="${JIRA_EMAIL:-}"
+JIRA_PROJECT="${JIRA_PROJECT:-}"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+yaml_val() {
+  local file="$1" key="$2"
+  local section field
+  if [[ "$key" == *.* ]]; then
+    section="${key%%.*}"; field="${key#*.}"
+  else
+    section=""; field="$key"
+  fi
+  local in_section=false value=""
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+    if [[ -z "$section" ]]; then
+      if [[ "$line" =~ ^${field}:[[:space:]]*(.*) ]]; then value="${BASH_REMATCH[1]}"; break; fi
+    else
+      if [[ "$line" =~ ^[a-zA-Z_] ]]; then
+        [[ "$line" =~ ^${section}: ]] && in_section=true || in_section=false; continue
+      fi
+      if $in_section && [[ "$line" =~ ^[[:space:]]+${field}:[[:space:]]*(.*) ]]; then
+        value="${BASH_REMATCH[1]}"; break
+      fi
+    fi
+  done < "$file"
+  value="${value#\"}"; value="${value%\"}"; value="${value#\'}"; value="${value%\'}"
+  echo "$value"
+}
+
+# Fall back to config.yaml
+if [[ -z "$JIRA_URL" && -f "$CONFIG_FILE" ]]; then
+  local_domain="$(yaml_val "$CONFIG_FILE" "jira.domain")"
+  [[ -n "$local_domain" ]] && JIRA_URL="https://${local_domain}"
+  JIRA_EMAIL="$(yaml_val "$CONFIG_FILE" "jira.email")"
+  JIRA_PROJECT="$(yaml_val "$CONFIG_FILE" "jira.project_key")"
+fi
+
+[[ -n "$JIRA_TOKEN" ]]   || die "JIRA_TOKEN not set — run: specclaw auth jira"
+[[ -n "$JIRA_URL" ]]     || die "JIRA_URL not set — run: specclaw auth jira"
+[[ -n "$JIRA_EMAIL" ]]   || die "JIRA_EMAIL not set — run: specclaw auth jira"
+[[ -n "$JIRA_PROJECT" ]] || die "JIRA_PROJECT not set — run: specclaw auth jira"
+
+# ─── Issue Content Builder ────────────────────────────────────────────────────
+
+build_issue_summary() {
+  local proposal_file="$CHANGE_DIR/proposal.md"
+  local summary=""
+  if [[ -f "$proposal_file" ]]; then
+    while IFS= read -r line; do
+      [[ -z "${line// /}" ]] && continue
+      [[ "$line" =~ ^# ]]    && continue
+      [[ "$line" =~ ^\*\* ]] && continue
+      summary="$line"; break
+    done < "$proposal_file"
+  fi
+  summary="${summary:-$CHANGE_NAME}"
+  summary="${summary//\*/}"; summary="${summary//\`/}"
+  [[ ${#summary} -gt 255 ]] && summary="${summary:0:252}..."
+  echo "$summary"
+}
+
+build_issue_body() {
+  local proposal_file="$CHANGE_DIR/proposal.md"
+  local spec_file="$CHANGE_DIR/spec.md"
+  local content=""
+
+  if [[ -f "$proposal_file" ]]; then
+    content="$(cat "$proposal_file")"
+  else
+    content="Change: ${CHANGE_NAME}"
+  fi
+
+  if [[ -f "$spec_file" ]]; then
+    content+=$'\n\n---\n\n'
+    content+="$(cat "$spec_file")"
+  fi
+
+  echo "$content"
+}
+
+get_issue_type() {
+  local type=""
+  [[ -f "$CONFIG_FILE" ]] && type="$(yaml_val "$CONFIG_FILE" "jira.issue_type")"
+  echo "${type:-Story}"
+}
+
+# ─── Jira REST API ────────────────────────────────────────────────────────────
+
+jiraapi_post() {
+  local path="$1" data="$2"
+  curl -sf -X POST "${JIRA_URL}/rest/api/3/${path}" \
+    -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "$data"
+}
+
+json_escape() {
+  python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null || \
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n' | sed 's/\\n$//' | sed 's/^/"/; s/$/"/'
+}
+
+build_adf_doc() {
+  local text="$1"
+  local text_json
+  text_json="$(echo "$text" | json_escape)"
+  printf '{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":%s}]}]}' \
+    "$text_json"
+}
+
+save_issue_key() {
+  local key="$1" url="$2"
+  local status_file="$CHANGE_DIR/status.md"
+  if [[ -f "$status_file" ]]; then
+    echo "**Jira Issue:** [${key}](${url})" >> "$status_file"
+  else
+    printf '# Status: %s\n\n**Jira Issue:** [%s](%s)\n' "$CHANGE_NAME" "$key" "$url" > "$status_file"
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  [[ -f "$CHANGE_DIR/proposal.md" ]] || die "proposal.md not found — run: specclaw propose first"
+
+  # Skip if issue already exists
+  if [[ -f "$CHANGE_DIR/status.md" ]] && grep -q "Jira Issue" "$CHANGE_DIR/status.md" 2>/dev/null; then
+    local existing
+    existing="$(grep "Jira Issue" "$CHANGE_DIR/status.md" | head -1)"
+    echo "WARNING: Jira issue already exists for this change: $existing" >&2
+    exit 0
+  fi
+
+  local summary body issue_type
+  summary="$(build_issue_summary)"
+  body="$(build_issue_body)"
+  issue_type="$(get_issue_type)"
+
+  local summary_json adf_desc
+  summary_json="$(echo "$summary" | json_escape)"
+  adf_desc="$(build_adf_doc "$body")"
+
+  local payload
+  payload=$(printf '{"fields":{"project":{"key":"%s"},"summary":%s,"description":%s,"issuetype":{"name":"%s"}}}' \
+    "$JIRA_PROJECT" "$summary_json" "$adf_desc" "$issue_type")
+
+  echo "Creating Jira issue: $summary"
+  local response
+  response="$(jiraapi_post "issue" "$payload")"
+
+  local issue_key
+  issue_key="$(echo "$response" | grep -o '"key":"[^"]*"' | head -1 | cut -d'"' -f4)"
+  [[ -n "$issue_key" ]] || die "Failed to parse issue key from Jira response"
+
+  local issue_url="${JIRA_URL}/browse/${issue_key}"
+  save_issue_key "$issue_key" "$issue_url"
+  echo "✅ Jira issue created: ${issue_key} — ${issue_url}"
+}
+
+main

--- a/skill/templates/config.yaml
+++ b/skill/templates/config.yaml
@@ -71,3 +71,20 @@ pr:
                     # unit  — requires unit test evidence in verify-report + build.test_command set
                     # e2e   — requires e2e test evidence in verify-report + build.test_command set
                     # both  — requires unit + e2e evidence
+
+# Azure DevOps integration (optional)
+# Run `specclaw auth azdo` to configure. Token stored in .specclaw/.env (gitignored).
+azdo:
+  enabled: false
+  org: ""           # Organisation name — part after dev.azure.com/
+  project: ""       # ADO project name
+  repo: ""          # Repository name within the project
+
+# Jira integration (optional)
+# Run `specclaw auth jira` to configure. Token stored in .specclaw/.env (gitignored).
+jira:
+  enabled: false
+  domain: ""        # e.g. mycompany.atlassian.net
+  email: ""         # Atlassian account email
+  project_key: ""   # Project key shown in issue IDs, e.g. PROJ
+  issue_type: "Story"  # Default issue type: Story | Task | Bug | Epic


### PR DESCRIPTION
## Summary

- `specclaw auth azdo` — interactive PAT setup for Azure DevOps, validates token via REST API, saves to `.specclaw/.env` + `config.yaml`
- `specclaw pr azdo <change>` — creates ADO pull request via REST API; same test-policy gate as `specclaw pr`
- `specclaw auth jira` — interactive Atlassian API token setup, validates credentials + project key, saves to `.specclaw/.env` + `config.yaml`
- `specclaw issue <change>` — creates Jira issue from `proposal.md` using ADF description format; idempotent (skips if issue already exists)
- `config.yaml` template: `azdo` and `jira` sections with `enabled` flag and connection fields
- `SKILL.md`: new command docs for all 4 commands
- `.gitignore`: ensure `.specclaw/.env` is always excluded
- `CLAUDE.md`: project assistant instructions committed alongside skill

## Test plan

- [ ] Run `specclaw auth azdo` with valid PAT — verify credentials saved to `.env` and `config.yaml`
- [ ] Run `specclaw auth azdo` with bad token — verify error message and exit 1
- [ ] Run `specclaw pr azdo <change>` after verify — confirm ADO PR created and URL saved to `status.md`
- [ ] Run `specclaw auth jira` with valid token — verify credentials saved
- [ ] Run `specclaw issue <change>` — confirm Jira issue created and `[KEY](url)` in `status.md`
- [ ] Run `specclaw issue <change>` twice — confirm idempotent (no duplicate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)