### PR TITLE
plugin: enable model invocation on lifecycle skills (v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2026-05-15
+
+### Changed
+- Enabled model-invocation on 13 of 15 skills (everything except `auth-azdo`
+  and `auth-jira`). Claude now routes conversationally — saying "i have a
+  proposal" auto-fires `/specclaw:propose`. The two auth skills remain
+  explicit-only because they handle credentials.
+
 ## [0.1.0] — 2026-05-15
 
 First release as a Claude Code plugin.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When initialized in a project, SpecClaw creates:
 
 ## Commands
 
-All commands are namespaced under `/specclaw:` and must be invoked explicitly (skills have `disable-model-invocation: true` — Claude does not trigger them spontaneously).
+All commands are namespaced under `/specclaw:`. Most are model-invokable — Claude will route conversationally (e.g. "i have a proposal" fires `/specclaw:propose`). Auth setup commands (`/specclaw:auth-azdo`, `/specclaw:auth-jira`) are explicit-only because they handle credentials.
 
 | Command | Purpose |
 |---------|---------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ State lives in `.specclaw/` in your project. The plugin operates on your CWD; no
 
 ## Commands
 
-All commands are namespaced under `/specclaw:` and require explicit invocation (`disable-model-invocation: true` — Claude never triggers them spontaneously).
+All commands are namespaced under `/specclaw:`. Most are model-invokable — Claude will route conversationally (e.g. "i have a proposal" fires `/specclaw:propose`). Auth setup commands (`/specclaw:auth-azdo`, `/specclaw:auth-jira`) stay explicit-only because they handle credentials.
 
 | Command | Purpose |
 |---------|---------|

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/skills/archive/SKILL.md
+++ b/plugins/specclaw/skills/archive/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Move a completed change to .specclaw/changes/archive/ with a date prefix. Closes the GitHub Issue (if sync is enabled) and optionally creates a git tag. Use after a change is merged — the PR is complete and the change should leave the active list.
-disable-model-invocation: true
 ---
 
 # specclaw archive

--- a/plugins/specclaw/skills/auto/SKILL.md
+++ b/plugins/specclaw/skills/auto/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Run the propose → plan → build → verify lifecycle autonomously across the queue of active changes. Advanced — requires automation config in config.yaml. Use when you want specclaw to advance every change to its next phase without prompting; do not use for a single targeted change (use the specific verb instead).
-disable-model-invocation: true
 ---
 
 # specclaw auto

--- a/plugins/specclaw/skills/build/SKILL.md
+++ b/plugins/specclaw/skills/build/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Implement planned tasks by executing them wave-by-wave, committing each, and logging errors and learnings. Reads tasks.md and drives the build loop. The longest-running phase of the specclaw lifecycle. Run after /specclaw:plan has produced spec.md, design.md, and tasks.md.
-disable-model-invocation: true
 ---
 
 # specclaw build

--- a/plugins/specclaw/skills/init/SKILL.md
+++ b/plugins/specclaw/skills/init/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Initialize specclaw in this project. Creates the .specclaw/ directory, generates config.yaml from the template, and sets up the project dashboard. Run once per project before any other specclaw command.
-disable-model-invocation: true
 ---
 
 # specclaw init

--- a/plugins/specclaw/skills/issue/SKILL.md
+++ b/plugins/specclaw/skills/issue/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Create a Jira issue for a proposed change. Mirrors GitHub Issues sync but for Jira-based teams. Builds the issue summary and description from proposal.md and spec.md. Requires credentials from /specclaw:auth-jira. Idempotent — warns if a Jira issue already exists for this change.
-disable-model-invocation: true
 ---
 
 # specclaw issue

--- a/plugins/specclaw/skills/learn/SKILL.md
+++ b/plugins/specclaw/skills/learn/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Record a build learning — a spec gap, design miss, recurring pattern, or insight discovered during implementation. Appends to .specclaw/changes/<change>/learnings.md. Use mid-build to capture knowledge before it's lost; do not use for routine progress updates.
-disable-model-invocation: true
 ---
 
 # specclaw learn

--- a/plugins/specclaw/skills/patterns/SKILL.md
+++ b/plugins/specclaw/skills/patterns/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Inspect the cross-change pattern registry. Track recurring errors and learnings across changes; promote patterns with 3+ occurrences to prevention rules. Use to see what keeps happening before planning a new change.
-disable-model-invocation: true
 ---
 
 # specclaw patterns

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Generate spec, design, and ordered task list for an approved proposal. Reads proposal.md, analyzes the codebase, then writes spec.md, design.md, and tasks.md. Run after /specclaw:propose has been approved, before /specclaw:build.
-disable-model-invocation: true
 ---
 
 # specclaw plan

--- a/plugins/specclaw/skills/pr-azdo/SKILL.md
+++ b/plugins/specclaw/skills/pr-azdo/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Create an Azure DevOps pull request for a verified change. Mirrors /specclaw:pr but targets ADO Repos via REST API instead of GitHub. Requires credentials from /specclaw:auth-azdo. Use when the project uses Azure DevOps instead of GitHub.
-disable-model-invocation: true
 ---
 
 # specclaw pr-azdo

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Create a GitHub pull request for a verified change. Reads verify-report.md, opens a PR with title from proposal and body from spec, enforces the configured test policy. Requires the gh CLI authenticated. Run after /specclaw:verify produces a verify-report.md. For Azure DevOps PRs, use /specclaw:pr-azdo instead.
-disable-model-invocation: true
 ---
 
 # specclaw pr

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Draft a new change proposal. Creates .specclaw/changes/<name>/proposal.md with problem statement, solution, scope, impact, and open questions. The first step in the propose → plan → build → verify → pr lifecycle. Use when the user wants to record a feature idea or initiative before writing any spec.
-disable-model-invocation: true
 ---
 
 # specclaw propose

--- a/plugins/specclaw/skills/status/SKILL.md
+++ b/plugins/specclaw/skills/status/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Show the project's specclaw dashboard — active changes, completed changes, pending proposals, blocked work. Reads .specclaw/STATUS.md. Read-only; does not modify state.
-disable-model-invocation: true
 ---
 
 # specclaw status

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Validate that the implementation satisfies the spec's acceptance criteria. Runs the configured test/lint/build commands, evaluates against spec.md, and produces verify-report.md. Required before /specclaw:pr. Run after all tasks in /specclaw:build are complete.
-disable-model-invocation: true
 ---
 
 # specclaw verify


### PR DESCRIPTION
## Summary
- Removes `disable-model-invocation: true` from 13 of 15 skills so Claude can route conversationally (e.g. "i have a proposal" → `/specclaw:propose`)
- Keeps `auth-azdo` and `auth-jira` explicit-only — credential setup shouldn't fire by accident
- Version bump: 0.1.0 → 0.2.0
- README + docs landing page + CHANGELOG updated

## Why
Original design defaulted everything to explicit-invocation-only out of caution. User feedback in practice: the friction wasn't worth it for read-only and lifecycle verbs. Auth commands are the only ones where accidental invocation has real cost.

## Changed
| Skill | Model invocation |
|-------|------------------|
| init, propose, plan, build, learn, patterns, verify, pr, pr-azdo, issue, status, archive, auto | enabled |
| auth-azdo, auth-jira | disabled |

## Test plan
After install, "i have a proposal …" should auto-trigger `/specclaw:propose`.
"set up azure devops" should NOT auto-trigger `/specclaw:auth-azdo` — user must type it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)