### PR TITLE
plugin: auto-init on first specclaw command (v0.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-05-15
+
+### Added
+- `specclaw-ensure-init` helper script that idempotently creates `.specclaw/`
+  if missing, using the current directory's basename as the project name.
+- Every non-init skill now runs `specclaw-ensure-init` as Step 0, so any
+  specclaw command (e.g. `/specclaw:propose`) works in a fresh project
+  without requiring `/specclaw:init` first.
+
 ## [0.2.0] — 2026-05-15
 
 ### Changed

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-ensure-init
+++ b/plugins/specclaw/bin/specclaw-ensure-init
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# specclaw ensure-init — Idempotently ensure .specclaw/ exists.
+#
+# Called by every non-init lifecycle skill as Step 0. If .specclaw/ already
+# exists, this exits silently. If not, it runs `specclaw-init` with the
+# current directory's basename as the project name, so the user can run
+# `/specclaw:propose ...` immediately without a separate /specclaw:init.
+#
+# Usage:
+#   specclaw-ensure-init [specclaw_dir]
+#
+# specclaw_dir defaults to .specclaw (in CWD).
+
+set -euo pipefail
+
+SPECCLAW_DIR="${1:-.specclaw}"
+PROJECT_DIR="$(dirname "$(cd "$(dirname "$SPECCLAW_DIR")" && pwd)/$(basename "$SPECCLAW_DIR")")"
+
+if [ -d "$SPECCLAW_DIR" ]; then
+  exit 0
+fi
+
+PROJECT_NAME="$(basename "$PROJECT_DIR")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "🦞 No .specclaw/ in $PROJECT_DIR — auto-initializing as '$PROJECT_NAME'..." >&2
+"$SCRIPT_DIR/specclaw-init" "$PROJECT_DIR" "$PROJECT_NAME" "" >&2
+echo "" >&2
+echo "  Tip: run \`/specclaw:init\` later if you want to set a custom project name or description." >&2
+echo "" >&2

--- a/plugins/specclaw/skills/archive/SKILL.md
+++ b/plugins/specclaw/skills/archive/SKILL.md
@@ -4,6 +4,8 @@ description: Move a completed change to .specclaw/changes/archive/ with a date p
 
 # specclaw archive
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Archive a completed change.
 
 1. **Validate:** `specclaw-validate-change .specclaw <change> archive`. If it fails, report and stop.

--- a/plugins/specclaw/skills/auth-azdo/SKILL.md
+++ b/plugins/specclaw/skills/auth-azdo/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 
 # specclaw auth azdo
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Interactive Azure DevOps authentication setup. Guides the user to create a PAT, validates it, and saves credentials.
 
 1. **Run:** `specclaw-auth-azdo .specclaw`

--- a/plugins/specclaw/skills/auth-jira/SKILL.md
+++ b/plugins/specclaw/skills/auth-jira/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 
 # specclaw auth jira
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Interactive Jira authentication setup. Guides the user to create an Atlassian API token, validates it, and saves credentials.
 
 1. **Run:** `specclaw-auth-jira .specclaw`

--- a/plugins/specclaw/skills/auto/SKILL.md
+++ b/plugins/specclaw/skills/auto/SKILL.md
@@ -4,6 +4,8 @@ description: Run the propose → plan → build → verify lifecycle autonomousl
 
 # specclaw auto
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Run the lifecycle autonomously for the active queue.
 
 1. Read `.specclaw/STATUS.md` for the next actionable item across changes.

--- a/plugins/specclaw/skills/build/SKILL.md
+++ b/plugins/specclaw/skills/build/SKILL.md
@@ -4,6 +4,8 @@ description: Implement planned tasks by executing them wave-by-wave, committing 
 
 # specclaw build
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Execute the planned tasks.
 
 ## Step 0 — Validate

--- a/plugins/specclaw/skills/issue/SKILL.md
+++ b/plugins/specclaw/skills/issue/SKILL.md
@@ -4,6 +4,8 @@ description: Create a Jira issue for a proposed change. Mirrors GitHub Issues sy
 
 # specclaw issue
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Create a Jira issue from a specclaw proposal. Requires `proposal.md` (run `/specclaw:propose` first).
 
 1. **Check idempotency:** if `status.md` already records a Jira issue for this change, warn and skip.

--- a/plugins/specclaw/skills/learn/SKILL.md
+++ b/plugins/specclaw/skills/learn/SKILL.md
@@ -4,6 +4,8 @@ description: Record a build learning — a spec gap, design miss, recurring patt
 
 # specclaw learn
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Capture build learnings — spec gaps, design misses, and patterns discovered during implementation.
 
 **Log a learning:**

--- a/plugins/specclaw/skills/patterns/SKILL.md
+++ b/plugins/specclaw/skills/patterns/SKILL.md
@@ -4,6 +4,8 @@ description: Inspect the cross-change pattern registry. Track recurring errors a
 
 # specclaw patterns
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Track recurring patterns across changes — errors and learnings that repeat become prevention rules.
 
 **Scan a change for patterns:**

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -4,6 +4,8 @@ description: Generate spec, design, and ordered task list for an approved propos
 
 # specclaw plan
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Turn an approved proposal into an executable plan.
 
 1. **Validate:** run `specclaw-validate-change .specclaw <change> plan`. If it fails, report missing prerequisites and stop.

--- a/plugins/specclaw/skills/pr-azdo/SKILL.md
+++ b/plugins/specclaw/skills/pr-azdo/SKILL.md
@@ -4,6 +4,8 @@ description: Create an Azure DevOps pull request for a verified change. Mirrors 
 
 # specclaw pr-azdo
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Create an Azure DevOps PR for a verified change.
 
 1. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Fails if `verify-report.md` is missing.

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -4,6 +4,8 @@ description: Create a GitHub pull request for a verified change. Reads verify-re
 
 # specclaw pr
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Create a GitHub PR for a verified change. Requires `verify-report.md` (build + verify must complete first).
 
 1. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Exits with a warning (exit 0) if a PR already exists for this change. Fails if `verify-report.md` is missing.

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -4,6 +4,8 @@ description: Draft a new change proposal. Creates .specclaw/changes/<name>/propo
 
 # specclaw propose
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Create a new proposal for a change.
 
 1. Slugify the user's idea into a `<change-name>` (lowercase, hyphens, no spaces).

--- a/plugins/specclaw/skills/status/SKILL.md
+++ b/plugins/specclaw/skills/status/SKILL.md
@@ -4,6 +4,8 @@ description: Show the project's specclaw dashboard — active changes, completed
 
 # specclaw status
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Show the project dashboard.
 
 1. Refresh: `specclaw-update-status .specclaw`

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -4,6 +4,8 @@ description: Validate that the implementation satisfies the spec's acceptance cr
 
 # specclaw verify
 
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
 Validate that the implementation satisfies the spec.
 
 ## Step 0 — Validate


### PR DESCRIPTION
## Summary
- Adds `plugins/specclaw/bin/specclaw-ensure-init` — idempotent helper that creates `.specclaw/` if missing, using the CWD basename as the project name
- Patches every non-init SKILL.md to run `specclaw-ensure-init .specclaw` as Step 0
- Version bump: 0.2.0 → 0.2.1

## Why
Users currently have to run `/specclaw:init` before any other specclaw command. Saying "i have a proposal" in a fresh project triggers `/specclaw:propose`, which fails. With this change, propose (and every other lifecycle skill) auto-creates `.specclaw/` first.

`/specclaw:init` is still available for users who want to provide a custom project name and description — the auto-init only fires when `.specclaw/` doesn't exist.

## Smoke-tested
- First run in fresh dir: prints `🦞 No .specclaw/ in <dir> — auto-initializing as '<basename>'...` then runs init.
- Subsequent runs: silent (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)