### PR TITLE
plugin: eager /specclaw:propose trigger (v0.2.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-05-15
+
+### Changed
+- Tightened `/specclaw:propose` skill description to `INVOKE IMMEDIATELY` —
+  Claude now fires the skill on the first turn when the user mentions a
+  proposal/feature idea/change request, instead of gathering details
+  conversationally first. The skill itself asks once for missing details.
+
 ## [0.2.1] — 2026-05-15
 
 ### Added

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Draft a new change proposal. Creates .specclaw/changes/<name>/proposal.md with problem statement, solution, scope, impact, and open questions. The first step in the propose → plan → build → verify → pr lifecycle. Use when the user wants to record a feature idea or initiative before writing any spec.
+description: Draft a new change proposal. INVOKE IMMEDIATELY whenever the user mentions a proposal, feature idea, change request, new initiative, or anything they want to add/build/implement — do NOT gather details conversationally first. The skill itself will ask for any missing information after invocation. Creates .specclaw/changes/<name>/proposal.md with problem statement, solution, scope, impact, and open questions. The first step in the propose → plan → build → verify → pr lifecycle.
 ---
 
 # specclaw propose
@@ -7,6 +7,8 @@ description: Draft a new change proposal. Creates .specclaw/changes/<name>/propo
 **First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
 
 Create a new proposal for a change.
+
+**If the user hasn't yet provided enough detail to draft the proposal (e.g. they just said "i have a proposal" with no specifics), ask once for the essentials inside this skill — what's the idea, what problem does it solve — then proceed to the steps below. Do not wait for a separate turn to invoke this skill.**
 
 1. Slugify the user's idea into a `<change-name>` (lowercase, hyphens, no spaces).
 2. Create `.specclaw/changes/<change-name>/`.


### PR DESCRIPTION
## Summary
- Tightens the propose skill description to **INVOKE IMMEDIATELY** when the user mentions a proposal, feature idea, change request, or initiative
- Adds an explicit guard in the SKILL.md body: if the user hasn't supplied details, ask once inside the skill rather than gathering them in conversation first
- Version bump: 0.2.1 → 0.2.2

## Before / After

**Before (v0.2.1):**
```
> i have a feature proposal
Claude: "Great — share it. What's the feature, and what problem does it solve?"
> i want to add multi-tenancy support
Claude: [now invokes /specclaw:propose]
```

**After (v0.2.2):**
```
> i have a feature proposal
Claude: [invokes /specclaw:propose, then asks for details inside the skill flow]
```

## Why
v0.2.0 enabled model invocation; v0.2.1 added auto-init. But the description was still soft ("Use when the user wants to..."), so Claude reasonably gathered context conversationally before invoking. This tightens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)