### PR TITLE
fix: auth scripts gracefully refuse no-tty invocation (v0.2.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] — 2026-05-15
+
+### Fixed
+- `specclaw-auth-azdo` and `specclaw-auth-jira` no longer crash with
+  `/dev/tty: Device not configured` when an agent (like Claude Code)
+  invokes them. They now detect missing `/dev/tty` upfront and exit with
+  clear instructions telling the user to run the command directly from
+  their own terminal (so they can paste their PAT / API token securely
+  without going through an agent).
+- The `auth-azdo` and `auth-jira` skill bodies now explicitly tell Claude
+  to delegate the run to the user rather than invoking it.
+
 ## [0.2.2] — 2026-05-15
 
 ### Changed

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-auth-azdo
+++ b/plugins/specclaw/bin/specclaw-auth-azdo
@@ -26,6 +26,24 @@ if [[ $# -lt 1 ]]; then
   exit 1
 fi
 
+# Auth setup needs an interactive terminal — refuses to run if invoked
+# from a non-tty context (e.g. when Claude Code runs the script for you).
+# You shouldn't paste a PAT through an agent anyway.
+if ! { : </dev/tty; } 2>/dev/null; then
+  cat >&2 <<'EOF'
+ERROR: specclaw-auth-azdo needs an interactive terminal — /dev/tty is not available here.
+
+This usually means an agent (like Claude Code) tried to run the script for you.
+Open your own terminal and run it directly so you can paste your PAT securely:
+
+  cd <your-project>
+  specclaw-auth-azdo .specclaw
+
+After it completes, return to your agent session and continue.
+EOF
+  exit 1
+fi
+
 SPECCLAW_DIR="$1"
 CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
 AUTH_FILE="$SPECCLAW_DIR/.env"

--- a/plugins/specclaw/bin/specclaw-auth-jira
+++ b/plugins/specclaw/bin/specclaw-auth-jira
@@ -26,6 +26,24 @@ if [[ $# -lt 1 ]]; then
   exit 1
 fi
 
+# Auth setup needs an interactive terminal — refuses to run if invoked
+# from a non-tty context (e.g. when Claude Code runs the script for you).
+# You shouldn't paste an API token through an agent anyway.
+if ! { : </dev/tty; } 2>/dev/null; then
+  cat >&2 <<'EOF'
+ERROR: specclaw-auth-jira needs an interactive terminal — /dev/tty is not available here.
+
+This usually means an agent (like Claude Code) tried to run the script for you.
+Open your own terminal and run it directly so you can paste your API token securely:
+
+  cd <your-project>
+  specclaw-auth-jira .specclaw
+
+After it completes, return to your agent session and continue.
+EOF
+  exit 1
+fi
+
 SPECCLAW_DIR="$1"
 CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
 AUTH_FILE="$SPECCLAW_DIR/.env"

--- a/plugins/specclaw/skills/auth-azdo/SKILL.md
+++ b/plugins/specclaw/skills/auth-azdo/SKILL.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Interactive Azure DevOps authentication setup. Guides the user to create a PAT, validates it, and saves credentials.
 
+**The user must run this command themselves in a real terminal — `specclaw-auth-azdo` refuses to run without `/dev/tty` because it prompts for a Personal Access Token. If you (the agent) try to invoke it, the script exits with instructions for the user. Just tell the user to open their shell and run `specclaw-auth-azdo .specclaw` directly.**
+
 1. **Run:** `specclaw-auth-azdo .specclaw`
    - Prompts for org name, project name, repo name.
    - Guides the user to `https://dev.azure.com/<org>/_usersSettings/tokens` to create a PAT.

--- a/plugins/specclaw/skills/auth-jira/SKILL.md
+++ b/plugins/specclaw/skills/auth-jira/SKILL.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Interactive Jira authentication setup. Guides the user to create an Atlassian API token, validates it, and saves credentials.
 
+**The user must run this command themselves in a real terminal — `specclaw-auth-jira` refuses to run without `/dev/tty` because it prompts for an API token. If you (the agent) try to invoke it, the script exits with instructions for the user. Just tell the user to open their shell and run `specclaw-auth-jira .specclaw` directly.**
+
 1. **Run:** `specclaw-auth-jira .specclaw`
    - Prompts for domain (e.g. `mycompany.atlassian.net`), email, project key, issue type.
    - Guides the user to `https://id.atlassian.com/manage-profile/security/api-tokens`.


### PR DESCRIPTION
## Bug
\`specclaw-auth-azdo\` and \`specclaw-auth-jira\` use \`read -r VAR </dev/tty\` for every prompt. When invoked by Claude Code (no tty), the script crashes mid-prompt:
\`\`\`
Azure DevOps org name (...): /Users/.../bin/specclaw-auth-azdo: line 80: /dev/tty: Device not configured
\`\`\`

## Fix
Both scripts now detect missing \`/dev/tty\` **before any prompt** and exit with a friendly error explaining that the user must run them directly in their own terminal. (You don't want to paste a PAT through an agent anyway.)

Updated skill bodies also tell Claude explicitly to delegate the run to the user rather than invoking the script.

## Smoke test
\`\`\`
$ specclaw-auth-azdo .specclaw </dev/null
ERROR: specclaw-auth-azdo needs an interactive terminal — /dev/tty is not available here.

This usually means an agent (like Claude Code) tried to run the script for you.
Open your own terminal and run it directly so you can paste your PAT securely:

  cd <your-project>
  specclaw-auth-azdo .specclaw

After it completes, return to your agent session and continue.
\`\`\`

## Version bump
0.2.2 → 0.2.3 (patch — bug fix, no API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)