### PR TITLE
fix: auth no-tty error gives copy-pasteable absolute path (v0.2.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] — 2026-05-15
+
+### Fixed
+- `specclaw-auth-azdo` / `specclaw-auth-jira` no-tty error now prints a
+  copy-paste-ready command with the script's **absolute path** and the
+  resolved absolute path to `.specclaw/`. Previously the message said
+  `cd <your-project>; specclaw-auth-azdo .specclaw`, which didn't work
+  because the plugin lives in Claude Code's cache (not on the user's PATH)
+  and the angle brackets were getting HTML-escaped by Claude Code's UI.
+
 ## [0.2.3] — 2026-05-15
 
 ### Fixed

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-auth-azdo
+++ b/plugins/specclaw/bin/specclaw-auth-azdo
@@ -30,14 +30,23 @@ fi
 # from a non-tty context (e.g. when Claude Code runs the script for you).
 # You shouldn't paste a PAT through an agent anyway.
 if ! { : </dev/tty; } 2>/dev/null; then
-  cat >&2 <<'EOF'
+  SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  # Resolve the user-supplied specclaw_dir to an absolute path so the copy-paste
+  # command works from anywhere.
+  if [[ -d "${1:-}" ]]; then
+    SPECCLAW_ABS="$(cd "${1}" && pwd)"
+  else
+    SPECCLAW_ABS="$(pwd)/${1:-.specclaw}"
+  fi
+  cat >&2 <<EOF
 ERROR: specclaw-auth-azdo needs an interactive terminal — /dev/tty is not available here.
 
-This usually means an agent (like Claude Code) tried to run the script for you.
-Open your own terminal and run it directly so you can paste your PAT securely:
+The setup prompts for a Personal Access Token; pasting that through an agent
+is unsafe. Open your own terminal and run this exact command (it includes
+the absolute path because the plugin is in Claude Code's cache, not on your
+normal PATH):
 
-  cd <your-project>
-  specclaw-auth-azdo .specclaw
+  "${SCRIPT_PATH}" "${SPECCLAW_ABS}"
 
 After it completes, return to your agent session and continue.
 EOF

--- a/plugins/specclaw/bin/specclaw-auth-jira
+++ b/plugins/specclaw/bin/specclaw-auth-jira
@@ -30,14 +30,21 @@ fi
 # from a non-tty context (e.g. when Claude Code runs the script for you).
 # You shouldn't paste an API token through an agent anyway.
 if ! { : </dev/tty; } 2>/dev/null; then
-  cat >&2 <<'EOF'
+  SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  if [[ -d "${1:-}" ]]; then
+    SPECCLAW_ABS="$(cd "${1}" && pwd)"
+  else
+    SPECCLAW_ABS="$(pwd)/${1:-.specclaw}"
+  fi
+  cat >&2 <<EOF
 ERROR: specclaw-auth-jira needs an interactive terminal — /dev/tty is not available here.
 
-This usually means an agent (like Claude Code) tried to run the script for you.
-Open your own terminal and run it directly so you can paste your API token securely:
+The setup prompts for an Atlassian API token; pasting that through an agent
+is unsafe. Open your own terminal and run this exact command (it includes
+the absolute path because the plugin is in Claude Code's cache, not on your
+normal PATH):
 
-  cd <your-project>
-  specclaw-auth-jira .specclaw
+  "${SCRIPT_PATH}" "${SPECCLAW_ABS}"
 
 After it completes, return to your agent session and continue.
 EOF


### PR DESCRIPTION
## Bug
v0.2.3 added a no-tty guard to the auth scripts, but the error message instructed the user to \`cd <your-project>; specclaw-auth-azdo .specclaw\` — which doesn't work because the plugin lives in Claude Code's cache (\`~/.claude/plugins/cache/...\`) and isn't on the user's PATH. The angle brackets also got HTML-escaped by Claude Code's UI, displaying as \`&lt;your-project&gt;\`.

## Fix
Print the script's actual absolute path **and** the resolved absolute path to \`.specclaw/\`, so the message contains one copy-paste-ready line:

\`\`\`
"/Users/chandima/.claude/plugins/cache/chan4lk/specclaw/0.2.4/bin/specclaw-auth-azdo" "/Users/chandima/repos/agent-nexus/.specclaw"
\`\`\`

Version bump: 0.2.3 → 0.2.4 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)