### PR TITLE
fix: /specclaw:pr commits .specclaw/ planning artifacts (v0.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] — 2026-05-15
+
+### Fixed
+- `/specclaw:pr` and `/specclaw:pr-azdo` now auto-stage and commit the
+  `.specclaw/changes/<change>/` directory (proposal, spec, design, tasks,
+  status, verify-report, errors, learnings) before opening the PR.
+  Previously these planning artifacts were never committed by
+  `specclaw-build commit` (which only commits each task's declared files),
+  so PRs landed without the spec/design/verify trail. Reviewers had to
+  read the linked GitHub Issue to see the plan. Now the artifacts ship
+  in the PR diff alongside the code. `.specclaw/.env` is already
+  gitignored and is not touched.
+
 ## [0.3.1] — 2026-05-15
 
 ### Fixed

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-azdo-pr
+++ b/plugins/specclaw/bin/specclaw-azdo-pr
@@ -373,6 +373,25 @@ main() {
   payload=$(printf '{"title":%s,"description":%s,"sourceRefName":"refs/heads/%s","targetRefName":"refs/heads/%s"}' \
     "$title_json" "$desc_json" "$source_branch" "$target_branch")
 
+  # Stage and commit planning artifacts (proposal.md, spec.md, design.md,
+  # tasks.md, status.md, verify-report.md, errors.md, learnings.md) so reviewers
+  # see them in the PR. specclaw-build commit only stages each task's declared
+  # files; the planning trail under .specclaw/changes/<change>/ would otherwise
+  # never land in the PR. Skip .specclaw/.env (already gitignored).
+  local change_path="${SPECCLAW_DIR}/changes/${CHANGE_NAME}"
+  if [[ -d "$change_path" ]]; then
+    if ! git diff --quiet HEAD -- "$change_path" 2>/dev/null; then
+      echo "Staging .specclaw/changes/${CHANGE_NAME}/ artifacts for the PR…"
+      git add "$change_path" 2>/dev/null || true
+      if ! git diff --cached --quiet -- "$change_path" 2>/dev/null; then
+        git commit -m "specclaw(${CHANGE_NAME}): include .specclaw/ planning + verify artifacts in PR" \
+          --only -- "$change_path" >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+  # Push so the ADO branch has them before the PR is opened
+  git push 2>/dev/null || true
+
   echo "Creating ADO PR: $title"
   local response
   response="$(adoapi_post "git/repositories/${AZDO_REPO}/pullrequests?api-version=7.1" "$payload")"

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -441,7 +441,26 @@ main() {
   title="$(build_pr_title)"
   body="$(build_pr_body "$policy")"
 
-  # Step 6: Create PR
+  # Step 6a: Stage and commit planning artifacts (proposal.md, spec.md, design.md,
+  # tasks.md, status.md, verify-report.md, errors.md, learnings.md) so reviewers
+  # see them in the PR. specclaw-build commit only stages each task's declared
+  # files; the planning trail under .specclaw/changes/<change>/ would otherwise
+  # never land in the PR. Skip .specclaw/.env (already gitignored).
+  local change_path="${SPECCLAW_DIR}/changes/${CHANGE_NAME}"
+  if [[ -d "$change_path" ]] && git diff --quiet HEAD -- "$change_path" 2>/dev/null; then
+    : # nothing to add (working tree clean for this dir)
+  elif [[ -d "$change_path" ]]; then
+    echo "Staging .specclaw/changes/${CHANGE_NAME}/ artifacts for the PR…"
+    git add "$change_path" 2>/dev/null || true
+    if ! git diff --cached --quiet -- "$change_path" 2>/dev/null; then
+      git commit -m "specclaw(${CHANGE_NAME}): include .specclaw/ planning + verify artifacts in PR" \
+        --only -- "$change_path" >/dev/null 2>&1 || true
+    fi
+  fi
+  # Push any new commits to the remote branch so the PR sees them
+  git push 2>/dev/null || true
+
+  # Step 6b: Create PR
   echo "Creating PR: $title"
   local pr_url
   pr_url="$(gh pr create --base main --title "$title" --body "$body")"


### PR DESCRIPTION
## Problem
\`specclaw-build commit\` only stages each task's declared \`Files:\` field — the planning trail under \`.specclaw/changes/<change>/\` (proposal, spec, design, tasks, status, verify-report, errors, learnings) was never committed. PRs landed without it, and reviewers had to click through to the linked GitHub Issue to read the plan.

Caught by another Claude session that opened a PR and noticed the \`.specclaw/\` artifacts were missing.

## Fix
Right before the \`gh pr create\` / ADO REST call, both \`specclaw-pr\` and \`specclaw-azdo-pr\` now:
1. Check if \`.specclaw/changes/<change>/\` has uncommitted changes.
2. If yes, stage them and commit with message \`specclaw(<change>): include .specclaw/ planning + verify artifacts in PR\`.
3. Push so the remote branch has them before the PR is opened.

\`.specclaw/.env\` stays gitignored — credentials never get included.

## Version
0.3.1 → 0.3.2 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)