### PR TITLE
feat(learn): knowledge base per repo, not plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.specclaw/config.yaml
+++ b/.specclaw/config.yaml
@@ -55,3 +55,9 @@ automation:
 # PR creation settings
 pr:
   test_policy: "none"   # set non-interactively for plugin packaging change (no app tests apply)
+
+# Plugin version files — specclaw-pr will auto-bump patch if version unchanged vs base branch
+plugin:
+  version_files:
+    - "plugins/specclaw/.claude-plugin/plugin.json"
+    - ".claude-plugin/marketplace.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-05-21
+
+### Added
+- **Per-repo knowledge base.** Promoting a learning or pattern now
+  writes to `.specclaw/knowledge/` in the target repo — never to the
+  plugin. `spec_gap`/`design_gap` learnings go to `spec-guidelines.md`;
+  `pattern`/`best_practice`/`agent_issue` learnings and pattern
+  prevention rules go to `agent-hints.md`. Plugin stays versioned and
+  generic; repos accumulate their own knowledge over time.
+- **Build agent auto-receives repo knowledge.** `specclaw-build-context`
+  injects `.specclaw/knowledge/agent-hints.md` into every coding-agent
+  prompt as a "Repo Knowledge Base" section when the file exists.
+- **Knowledge templates.** `templates/knowledge/agent-hints.md` and
+  `templates/knowledge/spec-guidelines.md` seed new knowledge bases.
+
 ## [0.4.0] — 2026-05-20
 
 ### Added

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-build-context
+++ b/plugins/specclaw/bin/specclaw-build-context
@@ -218,6 +218,16 @@ else
   echo "WARNING: agent-guardrails.md not found at $GUARDRAILS_FILE — proceeding without guardrails" >&2
 fi
 
+# --- Repo knowledge base ---
+# Accumulated hints from promoted learnings and patterns — repo-local, never plugin.
+KNOWLEDGE_HINTS_FILE="$SPECCLAW_DIR/knowledge/agent-hints.md"
+KNOWLEDGE_SECTION=""
+if [[ -f "$KNOWLEDGE_HINTS_FILE" ]]; then
+  KNOWLEDGE_SECTION="## Repo Knowledge Base
+$(cat "$KNOWLEDGE_HINTS_FILE")
+"
+fi
+
 # --- Existing file contents ---
 build_file_contents() {
   local file_list="$1"
@@ -338,7 +348,7 @@ fi
 cat <<PROMPT
 You are a coding agent implementing a specific task in the project "${PROJECT_NAME}".
 
-${GUARDRAILS_SECTION}
+${GUARDRAILS_SECTION}${KNOWLEDGE_SECTION}
 ## Your Task
 ${TASK_TITLE}
 ${TASK_NOTES}

--- a/plugins/specclaw/bin/specclaw-detect-patterns
+++ b/plugins/specclaw/bin/specclaw-detect-patterns
@@ -499,6 +499,38 @@ do_list() {
   fi
 }
 
+# Write a promoted pattern's prevention rule to the repo-local knowledge base
+write_pattern_to_knowledge() {
+  local specclaw_dir="$1" pat_id="$2" category="$3" prevention_rule="$4" keywords="$5"
+  local knowledge_dir="$specclaw_dir/knowledge"
+  local hints_file="$knowledge_dir/agent-hints.md"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%d %H:%M UTC")
+
+  mkdir -p "$knowledge_dir"
+  if [[ ! -f "$hints_file" ]]; then
+    if [[ -f "$TEMPLATE_DIR/knowledge/agent-hints.md" ]]; then
+      cp "$TEMPLATE_DIR/knowledge/agent-hints.md" "$hints_file"
+    else
+      printf "# Agent Hints\n\nAccumulated patterns and prevention rules for this repo.\n\n---\n" > "$hints_file"
+    fi
+  fi
+
+  cat >> "$hints_file" <<EOF
+
+## [$pat_id] $category
+
+**Promoted:** $timestamp
+**Keywords:** $keywords
+
+### Prevention Rule
+$prevention_rule
+---
+EOF
+
+  echo "Written to $hints_file"
+}
+
 # ---- PROMOTE MODE ----
 do_promote() {
   local specclaw_dir="$1"
@@ -517,7 +549,7 @@ do_promote() {
     exit 1
   fi
 
-  # Check if already promoted
+  # Locate the pattern block
   local start_line end_line
   start_line=$(grep -n "^## \[$pat_id\]" "$patterns_file" | head -1 | cut -d: -f1)
   end_line=$(awk "NR>$start_line && /^---$/{print NR; exit}" "$patterns_file")
@@ -527,17 +559,28 @@ do_promote() {
 
   if sed -n "${start_line},${end_line}p" "$patterns_file" | grep -q '^\*\*Status:\*\* *promoted'; then
     echo "Pattern $pat_id is already promoted."
-  else
-    sed_i "${start_line},${end_line}s/\*\*Status:\*\* *active/\*\*Status:\*\* promoted/" "$patterns_file"
-    echo "✅ Pattern $pat_id promoted."
+    return
   fi
 
-  # Output the Prevention Rule
-  echo ""
-  echo "Prevention Rule for $pat_id:"
+  sed_i "${start_line},${end_line}s/\*\*Status:\*\* *active/\*\*Status:\*\* promoted/" "$patterns_file"
+  echo "✅ Pattern $pat_id promoted."
+
+  # Extract prevention rule, keywords, category from the block
   local in_rule=0
+  local prevention_rule=""
+  local pat_category=""
+  local pat_keywords=""
+  local kw_next=false
+
   while IFS= read -r line; do
-    if [[ "$line" == "### Prevention Rule" ]]; then
+    if [[ "$line" =~ ^##\ \[$pat_id\]\ ([a-z_]+)\ — ]]; then
+      pat_category="${BASH_REMATCH[1]}"
+    elif [[ "$line" == "### Keywords" ]]; then
+      kw_next=true
+    elif $kw_next && [[ -n "$line" && ! "$line" =~ ^### ]]; then
+      pat_keywords="$line"
+      kw_next=false
+    elif [[ "$line" == "### Prevention Rule" ]]; then
       in_rule=1
       continue
     fi
@@ -545,9 +588,19 @@ do_promote() {
       if [[ "$line" =~ ^### || "$line" == "---" || "$line" =~ ^##\  ]]; then
         break
       fi
-      [[ -n "$line" ]] && echo "$line"
+      if [[ -n "$line" ]]; then
+        prevention_rule+="$line"$'\n'
+      fi
     fi
   done < <(sed -n "${start_line},${end_line}p" "$patterns_file")
+
+  prevention_rule="${prevention_rule:-"(No prevention rule defined yet — add one with: specclaw-detect-patterns $specclaw_dir promote $pat_id)"}"
+
+  echo ""
+  echo "Prevention Rule for $pat_id:"
+  echo "$prevention_rule"
+
+  write_pattern_to_knowledge "$specclaw_dir" "$pat_id" "$pat_category" "$prevention_rule" "$pat_keywords"
 }
 
 # ---- MAIN ----

--- a/plugins/specclaw/bin/specclaw-log-learning
+++ b/plugins/specclaw/bin/specclaw-log-learning
@@ -14,10 +14,15 @@ Usage:
 Modes:
   log (default)   Append a new learning entry
   --list          Show summary table of all learnings
-  --promote <id>  Promote a learning (e.g. L1) from pending to promoted
+  --promote <id>  Promote a learning to the repo knowledge base
 
 Categories: spec_gap, design_gap, pattern, best_practice, agent_issue
 Priorities: low, medium, high
+
+Promote writes to the repo-local knowledge base (never the plugin):
+  spec_gap, design_gap    -> .specclaw/knowledge/spec-guidelines.md
+  pattern, best_practice,
+  agent_issue             -> .specclaw/knowledge/agent-hints.md
 EOF
   exit 0
 }
@@ -38,6 +43,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 TEMPLATE_DIR="$PLUGIN_ROOT/templates"
 LEARNINGS_FILE="$SPECCLAW_DIR/learnings.md"
+KNOWLEDGE_DIR="$SPECCLAW_DIR/knowledge"
 
 # Ensure learnings.md exists, create from template if missing
 ensure_learnings() {
@@ -55,6 +61,62 @@ next_id() {
   local count
   count=$(grep -c '^## \[L' "$LEARNINGS_FILE" 2>/dev/null || true)
   echo "L$(( count + 1 ))"
+}
+
+# Route a learning category to the appropriate knowledge file
+knowledge_file_for() {
+  local category="$1"
+  case "$category" in
+    spec_gap|design_gap)
+      echo "$KNOWLEDGE_DIR/spec-guidelines.md"
+      ;;
+    *)
+      echo "$KNOWLEDGE_DIR/agent-hints.md"
+      ;;
+  esac
+}
+
+# Write a promoted learning to the repo-local knowledge base
+write_to_knowledge() {
+  local learning_id="$1" category="$2" priority="$3" detail="$4" action="$5"
+  local kfile
+  kfile=$(knowledge_file_for "$category")
+  local tpl_name
+  tpl_name="$(basename "$kfile")"
+
+  mkdir -p "$KNOWLEDGE_DIR"
+  if [[ ! -f "$kfile" ]]; then
+    if [[ -f "$TEMPLATE_DIR/knowledge/$tpl_name" ]]; then
+      cp "$TEMPLATE_DIR/knowledge/$tpl_name" "$kfile"
+    else
+      printf "# %s\n\n---\n" "$(basename "$kfile" .md | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}')" > "$kfile"
+    fi
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%d %H:%M UTC")
+  local short_detail
+  short_detail="$(echo "$detail" | cut -c1-70)"
+
+  cat >> "$kfile" <<EOF
+
+## [$learning_id from $CHANGE_NAME] $category — $short_detail
+
+**Promoted:** $timestamp
+**Category:** $category
+**Priority:** $priority
+**Source change:** $CHANGE_NAME
+
+### Insight
+$detail
+
+### Recommended Action
+${action:-No action specified}
+
+---
+EOF
+
+  echo "Written to $kfile"
 }
 
 # --- List mode ---
@@ -100,29 +162,55 @@ if [[ "$3" == "--promote" ]]; then
     exit 1
   fi
 
-  # Replace status for the target entry
-  # We need to find the entry and change its status
+  # Extract entry fields before rewriting
+  entry_category=""
+  entry_priority=""
+  entry_detail=""
+  entry_action=""
+  in_target=false
+  in_detail=false
+  in_action=false
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^##\ \[${TARGET_ID}\]\ ([a-z_]+)\ — ]]; then
+      in_target=true
+      entry_category="${BASH_REMATCH[1]}"
+    elif $in_target && [[ "$line" =~ ^##\ \[L ]]; then
+      break
+    elif $in_target; then
+      if [[ "$line" =~ ^\*\*Priority:\*\*\ (.+)$ ]]; then
+        entry_priority="${BASH_REMATCH[1]}"
+      elif [[ "$line" == "### Detail" ]]; then
+        in_detail=true; in_action=false
+      elif [[ "$line" == "### Action" ]]; then
+        in_detail=false; in_action=true
+      elif [[ "$line" =~ ^###|^--- ]]; then
+        in_detail=false; in_action=false
+      elif $in_detail && [[ -n "$line" ]]; then
+        entry_detail="$line"; in_detail=false
+      elif $in_action && [[ -n "$line" ]]; then
+        entry_action="$line"; in_action=false
+      fi
+    fi
+  done < "$LEARNINGS_FILE"
+
+  # Rewrite learnings.md with status → promoted
   in_target=false
   promoted=false
   tmp_file="${LEARNINGS_FILE}.tmp"
-  entry_lines=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^##\ \[${TARGET_ID}\] ]]; then
       in_target=true
-      entry_lines="$line"$'\n'
       echo "$line" >> "$tmp_file"
     elif $in_target && [[ "$line" =~ ^##\ \[L ]]; then
-      # Next entry starts, stop capturing
       in_target=false
       echo "$line" >> "$tmp_file"
     elif $in_target && [[ "$line" == "**Status:** pending" ]]; then
       echo "**Status:** promoted" >> "$tmp_file"
-      entry_lines+="**Status:** promoted"$'\n'
       promoted=true
     elif $in_target; then
       echo "$line" >> "$tmp_file"
-      entry_lines+="$line"$'\n'
     else
       echo "$line" >> "$tmp_file"
     fi
@@ -131,18 +219,8 @@ if [[ "$3" == "--promote" ]]; then
   mv "$tmp_file" "$LEARNINGS_FILE"
 
   if $promoted; then
-    # Print the full entry
-    in_target=false
-    while IFS= read -r line; do
-      if [[ "$line" =~ ^##\ \[${TARGET_ID}\] ]]; then
-        in_target=true
-        echo "$line"
-      elif $in_target && [[ "$line" =~ ^##\ \[L ]]; then
-        break
-      elif $in_target; then
-        echo "$line"
-      fi
-    done < "$LEARNINGS_FILE"
+    echo "Promoted $TARGET_ID in learnings.md"
+    write_to_knowledge "$TARGET_ID" "$entry_category" "$entry_priority" "$entry_detail" "$entry_action"
   else
     echo "Warning: $TARGET_ID status was not 'pending', no change made." >&2
   fi

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -418,6 +418,120 @@ EOF
   fi
 }
 
+# ─── Version Bump ─────────────────────────────────────────────────────────────
+
+# Read plugin.version_files from config.yaml as newline-separated list.
+# Supports a single path or a YAML list under plugin.version_files.
+read_version_files() {
+  [[ -f "$CONFIG_FILE" ]] || return 0
+  local in_section=false in_list=false
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" =~ ^plugin: ]]; then
+      in_section=true; continue
+    fi
+    if $in_section; then
+      if [[ "$line" =~ ^[a-zA-Z_] && ! "$line" =~ ^plugin: ]]; then
+        break
+      fi
+      # version_file: "path" (single)
+      if [[ "$line" =~ ^[[:space:]]+version_file:[[:space:]]*(.+) ]]; then
+        local v="${BASH_REMATCH[1]}"
+        v="${v#\"}"; v="${v%\"}"
+        echo "$v"
+        return
+      fi
+      # version_files: (list start)
+      if [[ "$line" =~ ^[[:space:]]+version_files:[[:space:]]*$ ]]; then
+        in_list=true; continue
+      fi
+      # list items: "  - path"
+      if $in_list; then
+        if [[ "$line" =~ ^[[:space:]]+-[[:space:]]*(.+) ]]; then
+          local v="${BASH_REMATCH[1]}"
+          v="${v#\"}"; v="${v%\"}"
+          echo "$v"
+        elif [[ "$line" =~ ^[[:space:]]+[a-zA-Z_] ]]; then
+          break
+        fi
+      fi
+    fi
+  done < "$CONFIG_FILE"
+}
+
+# Bump patch version in a JSON file that has "version": "X.Y.Z"
+bump_patch_json() {
+  local file="$1"
+  local cur
+  cur="$(grep -oE '"version":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$file" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+  if [[ -z "$cur" ]]; then
+    warn "Could not find version in $file — skipping bump"
+    return 1
+  fi
+  local major minor patch
+  IFS='.' read -r major minor patch <<< "$cur"
+  patch=$((patch + 1))
+  local new_ver="${major}.${minor}.${patch}"
+  sed_i "s/\"version\":[[:space:]]*\"${cur}\"/\"version\": \"${new_ver}\"/" "$file"
+  echo "$new_ver"
+}
+
+ensure_version_bumped() {
+  local project_root
+  project_root="$(cd "$SPECCLAW_DIR/.." && pwd)"
+
+  # Collect configured version files
+  local version_files=()
+  while IFS= read -r f; do
+    [[ -n "$f" ]] && version_files+=("$f")
+  done < <(read_version_files)
+
+  [[ ${#version_files[@]} -eq 0 ]] && return 0
+
+  local base_branch
+  base_branch="$(git -C "$project_root" rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||')"
+  base_branch="${base_branch:-main}"
+
+  local bumped=false
+  local files_changed=()
+
+  for rel_path in "${version_files[@]}"; do
+    local abs_path="$project_root/$rel_path"
+    [[ -f "$abs_path" ]] || { warn "version file not found: $abs_path — skipping"; continue; }
+
+    # Get version on base branch
+    local base_ver
+    base_ver="$(git -C "$project_root" show "origin/${base_branch}:${rel_path}" 2>/dev/null \
+      | grep -oE '"version":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' \
+      | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" || true
+
+    # Get current version
+    local cur_ver
+    cur_ver="$(grep -oE '"version":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$abs_path" \
+      | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" || true
+
+    if [[ -n "$base_ver" && "$cur_ver" == "$base_ver" ]]; then
+      echo "Version unchanged in $rel_path (${cur_ver}) — bumping patch..."
+      local new_ver
+      new_ver="$(bump_patch_json "$abs_path")"
+      echo "  bumped: ${cur_ver} → ${new_ver}"
+      files_changed+=("$abs_path")
+      bumped=true
+    elif [[ -z "$base_ver" ]]; then
+      echo "Version in $rel_path: ${cur_ver} (no base branch reference — assuming OK)"
+    else
+      echo "Version already bumped in $rel_path: ${base_ver} → ${cur_ver}"
+    fi
+  done
+
+  if [[ ${#files_changed[@]} -gt 0 ]]; then
+    git -C "$project_root" add "${files_changed[@]}"
+    git -C "$project_root" commit -m "chore: bump plugin version before PR (${CHANGE_NAME})" \
+      -- "${files_changed[@]}" >/dev/null 2>&1 || true
+    echo "Version bump committed."
+  fi
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 main() {
@@ -432,16 +546,19 @@ main() {
   enforce_test_policy "$policy"
   report_failures
 
-  # Step 4: Check gh CLI
+  # Step 4: Version bump (if plugin.version_files configured)
+  ensure_version_bumped
+
+  # Step 5: Check gh CLI
   command -v gh &>/dev/null || die "gh CLI is required for PR creation (https://cli.github.com)"
   gh auth status &>/dev/null || die "gh CLI is not authenticated — run: gh auth login"
 
-  # Step 5: Build title and body
+  # Step 6: Build title and body
   local title body
   title="$(build_pr_title)"
   body="$(build_pr_body "$policy")"
 
-  # Step 6a: Stage and commit planning artifacts (proposal.md, spec.md, design.md,
+  # Step 7a: Stage and commit planning artifacts (proposal.md, spec.md, design.md,
   # tasks.md, status.md, verify-report.md, errors.md, learnings.md) so reviewers
   # see them in the PR. specclaw-build commit only stages each task's declared
   # files; the planning trail under .specclaw/changes/<change>/ would otherwise
@@ -460,7 +577,7 @@ main() {
   # Push any new commits to the remote branch so the PR sees them
   git push 2>/dev/null || true
 
-  # Step 6b: Create PR
+  # Step 7b: Create PR
   echo "Creating PR: $title"
   local pr_url
   pr_url="$(gh pr create --base main --title "$title" --body "$body")"

--- a/plugins/specclaw/skills/learn/SKILL.md
+++ b/plugins/specclaw/skills/learn/SKILL.md
@@ -21,10 +21,16 @@ Priorities: `low` | `medium` | `high`
 specclaw-log-learning .specclaw <change> --list
 ```
 
-**Promote a learning** (mark for elevation to agent prompts or this SKILL):
+**Promote a learning** to the repo-local knowledge base:
 ```bash
 specclaw-log-learning .specclaw <change> --promote <id>
 ```
+
+Promote writes to `.specclaw/knowledge/` — **never to the plugin itself**:
+- `spec_gap`, `design_gap` → `.specclaw/knowledge/spec-guidelines.md`
+- `pattern`, `best_practice`, `agent_issue` → `.specclaw/knowledge/agent-hints.md`
+
+The build agent receives `agent-hints.md` as context automatically on every task.
 
 **When to log:**
 - A build revealed a spec gap (requirements unclear or missing)

--- a/plugins/specclaw/skills/patterns/SKILL.md
+++ b/plugins/specclaw/skills/patterns/SKILL.md
@@ -19,11 +19,14 @@ Reads `errors.md` and `learnings.md`, matches against existing patterns, creates
 specclaw-detect-patterns .specclaw list [--min-recurrence N]
 ```
 
-**Promote a pattern** (mark for elevation to agent prompts):
+**Promote a pattern** to the repo-local knowledge base:
 ```bash
 specclaw-detect-patterns .specclaw promote <pat-id>
 ```
 
-**Auto-promotion:** patterns with 3+ occurrences are flagged ⚠️ — their prevention rules should be added to agent context templates or to the relevant SKILL.md build instructions.
+Promote writes the prevention rule to `.specclaw/knowledge/agent-hints.md` — **never to the plugin itself**. The plugin stays versioned and generic; each repo builds its own knowledge over time.
+
+**Auto-promotion:** patterns with 3+ occurrences are flagged ⚠️ — run `promote` to write their prevention rules into the local knowledge base so future build agents see them automatically.
 
 Pattern registry lives at `.specclaw/patterns.md` (global, not per-change).
+Knowledge base lives at `.specclaw/knowledge/` (repo-local, not plugin).

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -12,6 +12,13 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
 2. **Run:** `specclaw-pr .specclaw <change>`
    - **First run:** prompts for test policy (`none|unit|e2e|both`), saves it to `config.yaml` under `pr.test_policy`. Never prompts again.
    - **Test enforcement:** if policy is not `none`, verifies `build.test_command` is set and that `verify-report.md` contains test evidence. Fails (strict) or warns (non-strict) if evidence is missing.
+   - **Version bump:** if `plugin.version_files` is set in `config.yaml`, compares each file's `"version"` against the base branch. If unchanged, auto-bumps the patch version and commits before PR creation. Configure in `.specclaw/config.yaml`:
+     ```yaml
+     plugin:
+       version_files:
+         - "plugins/specclaw/.claude-plugin/plugin.json"
+         - ".claude-plugin/marketplace.json"
+     ```
    - **PR creation:** builds title from `proposal.md`, body from `spec.md` + `verify-report.md`, runs `gh pr create --base main`.
    - **GitHub sync:** if `github.sync: true`, includes `Closes #N` in the PR body.
    - **Saves URL:** appends `**PR:** <url>` to `status.md`.

--- a/plugins/specclaw/templates/knowledge/agent-hints.md
+++ b/plugins/specclaw/templates/knowledge/agent-hints.md
@@ -1,0 +1,6 @@
+# Agent Hints
+
+Accumulated patterns, best practices, and prevention rules for this repo.
+Promoted from learnings and patterns — never from the plugin.
+
+---

--- a/plugins/specclaw/templates/knowledge/spec-guidelines.md
+++ b/plugins/specclaw/templates/knowledge/spec-guidelines.md
@@ -1,0 +1,6 @@
+# Spec Guidelines
+
+Accumulated spec and design guidance for this repo.
+Promoted from spec_gap and design_gap learnings — never from the plugin.
+
+---


### PR DESCRIPTION
## Summary

- `--promote` in `specclaw-log-learning` now writes to `.specclaw/knowledge/` (repo-local) instead of just marking status in learnings.md
- `promote` in `specclaw-detect-patterns` now writes prevention rules to `.specclaw/knowledge/agent-hints.md`
- `specclaw-build-context` injects `agent-hints.md` into every coding-agent payload automatically
- Added `templates/knowledge/` seed files for both knowledge files

## Knowledge routing

| Category | Target file |
|----------|-------------|
| `spec_gap`, `design_gap` | `.specclaw/knowledge/spec-guidelines.md` |
| `pattern`, `best_practice`, `agent_issue` | `.specclaw/knowledge/agent-hints.md` |
| Pattern prevention rules | `.specclaw/knowledge/agent-hints.md` |

## Why

Plugin has versions — learnings should not bleed into the plugin and affect other repos. Each repo accumulates its own knowledge in `.specclaw/knowledge/` over time.

## Test plan
- [ ] `specclaw-log-learning .specclaw <change> spec_gap medium "detail"` logs to learnings.md
- [ ] `specclaw-log-learning .specclaw <change> --promote L1` writes to `.specclaw/knowledge/spec-guidelines.md`
- [ ] `specclaw-log-learning .specclaw <change> --promote L2` (pattern category) writes to `.specclaw/knowledge/agent-hints.md`
- [ ] `specclaw-detect-patterns .specclaw promote PAT-001` writes to `.specclaw/knowledge/agent-hints.md`
- [ ] `specclaw-build-context .specclaw <change> T1` includes "Repo Knowledge Base" section when `agent-hints.md` exists
- [ ] No changes to `plugins/specclaw/` references or templates from promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)