### PR TITLE
hotfix: specclaw-detect-patterns path doubling (v0.4.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] — 2026-05-24
+
+### Fixed
+- **`specclaw-detect-patterns` path doubling.** Script formed `patterns.md`
+  and `changes/` paths as `$specclaw_dir/.specclaw/...` while every sibling
+  bin script (and `/specclaw:build`) treats `$specclaw_dir` as already being
+  `.specclaw`. Result: `scan` looked for `.specclaw/.specclaw/changes/<name>`
+  (not found) and `ensure_patterns_file` created a stray
+  `.specclaw/.specclaw/patterns.md` stub on every build. Fixed the four
+  affected lines to use `$specclaw_dir/...` directly.
+
 ## [0.4.1] — 2026-05-21
 
 ### Added

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-detect-patterns
+++ b/plugins/specclaw/bin/specclaw-detect-patterns
@@ -86,7 +86,7 @@ get_next_pat_id() {
 
 ensure_patterns_file() {
   local specclaw_dir="$1"
-  local patterns_file="$specclaw_dir/.specclaw/patterns.md"
+  local patterns_file="$specclaw_dir/patterns.md"
   if [[ ! -f "$patterns_file" ]]; then
     mkdir -p "$(dirname "$patterns_file")"
     cp "$TEMPLATE_DIR/patterns.md" "$patterns_file"
@@ -334,7 +334,7 @@ EOF
 do_scan() {
   local specclaw_dir="$1"
   local change_name="$2"
-  local changes_dir="$specclaw_dir/.specclaw/changes/$change_name"
+  local changes_dir="$specclaw_dir/changes/$change_name"
   local patterns_file
   patterns_file=$(ensure_patterns_file "$specclaw_dir")
   local today
@@ -444,7 +444,7 @@ do_list() {
     esac
   done
 
-  local patterns_file="$specclaw_dir/.specclaw/patterns.md"
+  local patterns_file="$specclaw_dir/patterns.md"
   if [[ ! -f "$patterns_file" ]]; then
     echo "No patterns recorded."
     return
@@ -535,7 +535,7 @@ EOF
 do_promote() {
   local specclaw_dir="$1"
   local pat_id="$2"
-  local patterns_file="$specclaw_dir/.specclaw/patterns.md"
+  local patterns_file="$specclaw_dir/patterns.md"
 
   pat_id=$(echo "$pat_id" | tr '[:lower:]' '[:upper:]')
 


### PR DESCRIPTION
## Summary

- `specclaw-detect-patterns` was forming paths as `$specclaw_dir/.specclaw/...` while every sibling bin script (and `/specclaw:build`) passes `$specclaw_dir` already set to `.specclaw`. Net effect: `scan` could never find the change directory, and `ensure_patterns_file` silently created a stray `.specclaw/.specclaw/patterns.md` stub on every build.
- Fixed four lines (89, 337, 447, 538) to use `$specclaw_dir/...` directly, matching the convention used by `specclaw-gh-sync` and the rest of `bin/`.
- Bumped version 0.4.1 → 0.4.2 in `plugins/specclaw/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`; added entry to `CHANGELOG.md`.

## How it was caught

Surfaced during `/specclaw:build spec-author-agent` (the run that introduced the `spec-author` subagent). The build itself succeeded — pattern detection runs as post-build review step `d`, where the stray directory and "change directory not found" error became visible.

## Test plan

- [x] Removed the stray `.specclaw/.specclaw/` directory and re-ran `specclaw-detect-patterns .specclaw scan spec-author-agent` — no nested dir created, `patterns.md` lives at the correct `.specclaw/patterns.md`.
- [x] Ran `specclaw-detect-patterns .specclaw list` — works (prints "No patterns recorded.").
- [x] `grep '\$specclaw_dir/\.specclaw' plugins/specclaw/bin/specclaw-detect-patterns` returns no matches.
- [ ] Reviewer: confirm sibling bin scripts (`gh-sync`, `azdo-issue`, `update-status`, `log-learning`) all use the single-`.specclaw` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)