### PR TITLE
feat: spec-author subagent + /specclaw:author-spec skill

### DIFF
--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-05-20 17:12 UTC
+**Last Updated:** 2026-05-24 14:24 UTC
 
 ## Active Changes
 
@@ -22,6 +22,7 @@
 - ✅ **post-build-review** — 1/1 tasks (100%) | 0 failed
 - ✅ **pr-command** — 7/7 tasks (100%) | 0 failed
 - 🔨 **service-layer-extraction** — 4/11 tasks (36%) | 0 failed
+- 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
 
 ## Pending Proposals
@@ -34,6 +35,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 17
-- **Active:** 17
+- **Total changes:** 18
+- **Active:** 18
 - **Completed:** 0

--- a/.specclaw/changes/spec-author-agent/design.md
+++ b/.specclaw/changes/spec-author-agent/design.md
@@ -1,0 +1,74 @@
+# Design: Spec Author Agent
+
+**Change:** spec-author-agent
+**Created:** 2026-05-24
+
+## Technical Approach
+
+Two new files, one edited file, one doc update. No new binaries, no config-schema changes, no manifest edits — Claude Code auto-discovers agents and skills under `plugins/specclaw/agents/**` and `plugins/specclaw/skills/**`.
+
+Flow:
+
+1. `/specclaw:author-spec <change>` (standalone) → skill validates prerequisites → invokes `spec-author` agent with the change name → agent reads `proposal.md`, walks `templates/spec.md` section-by-section via interactive dialogue → writes `spec.md`.
+2. `/specclaw:plan <change> --author-spec` → existing plan skill detects the flag → does steps 1-3 as today (validate, read proposal, analyze code) → delegates spec step to `spec-author` → **pauses for explicit approval** → continues to generate `design.md` and `tasks.md`.
+3. `/specclaw:plan <change>` (no flag) → unchanged, single-shot generation.
+
+The "pause for approval" is realized as a literal instruction in the plan skill prompt — Claude stops emitting tool calls and waits for the user's next message. This matches how `/specclaw:propose` already requires approval before `/specclaw:plan` runs.
+
+## Architecture
+
+```text
+plugins/specclaw/
+├── agents/                          ← NEW directory
+│   └── spec-author.md               ← NEW: subagent definition
+├── skills/
+│   ├── author-spec/                 ← NEW directory
+│   │   └── SKILL.md                 ← NEW: /specclaw:author-spec
+│   └── plan/
+│       └── SKILL.md                 ← EDIT: detect --author-spec flag
+└── templates/spec.md                ← UNCHANGED (consumed by agent)
+README.md                            ← EDIT: document new skill + flag
+```
+
+Agent invocation uses the standard Claude Code `Agent` tool with `subagent_type: "spec-author"`. The agent receives the change name and is instructed to read `.specclaw/changes/<change>/proposal.md` itself and write `.specclaw/changes/<change>/spec.md` itself — keeping the skill prompts thin.
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/agents/spec-author.md` | CREATE | Agent frontmatter (`name`, `description`, `tools: [Read, Write, Bash]`, `model: opus`) + system prompt that walks `templates/spec.md` section-by-section, asks ≥1 question per section, writes final `spec.md`. |
+| `plugins/specclaw/skills/author-spec/SKILL.md` | CREATE | Skill frontmatter + body. Runs `specclaw-ensure-init`, validates proposal exists via `specclaw-validate-change`, checks for existing `spec.md` (asks to overwrite), invokes `Agent(subagent_type=spec-author, ...)`, updates status, syncs to GitHub/Azure if enabled. |
+| `plugins/specclaw/skills/plan/SKILL.md` | EDIT | Insert a conditional block: if ARGUMENTS contains `--author-spec`, delegate the spec step to the `spec-author` agent and pause for explicit user approval before steps that generate `design.md` / `tasks.md`. Strip the flag from the change name when parsing. |
+| `README.md` | EDIT | Add `/specclaw:author-spec <change>` row to Commands table; one-sentence mention of the `--author-spec` flag for `/specclaw:plan`. |
+
+## Data Model Changes
+
+None. No new fields in `config.yaml`, no new `.specclaw/` artifacts, no changes to existing templates.
+
+## API Changes
+
+None internal. Two new user-facing surfaces:
+
+- New slash command `/specclaw:author-spec <change>`.
+- New flag `--author-spec` accepted by `/specclaw:plan <change>`.
+
+## Key Decisions
+
+- **Agent vs inline skill prompt.** A dedicated agent isolates the multi-turn dialogue from the main thread's tool history and lets us pin the planning model (`anthropic/claude-opus-4-6`) per `config.yaml`. An inline skill prompt would couple the dialogue to whatever model the main loop is on.
+- **Opt-in flag, not default.** Keeps `/specclaw:auto` and existing scripted invocations of `/specclaw:plan` non-interactive — critical for the autopilot workflow.
+- **Section-by-section, not whole-spec-at-once.** Karpathy Rule 1 (Think Before Coding) explicitly calls out "if multiple interpretations exist, present them". Section-by-section enforces this by structurally giving the user a checkpoint per section.
+- **Named technique catalog over generic "ask questions".** The agent prompt embeds a small table mapping spec sections → technique (5 Whys for Problem/Overview, JTBD for FRs, Inversion for NFRs, Pre-mortem for Edge Cases, MoSCoW for scope challenges, Concrete-example probe for any abstract claim). The agent is instructed to name the technique aloud ("Let's do 5 Whys here…") so the user understands the move. This trades a longer system prompt for higher-quality, less-generic dialogue and is the core differentiator from a plain "ask clarifying questions" agent.
+- **Challenge mode is mandatory, not optional.** The agent is instructed to push back on vague or untestable requirements (e.g. "fast", "easy", "secure") and require an observable threshold before writing them into `spec.md`. This implements FR3b and prevents the spec from inheriting the proposal's ambiguity.
+- **Skill name `/specclaw:author-spec` (with hyphen).** Matches existing multi-word skill names in the plugin (`auth-azdo`, `pr-azdo`, `azdo-issue`). Consistent.
+- **No new manifest entry.** Claude Code auto-discovers under `agents/` and `skills/`. Verified by inspecting `plugin.json` — it only declares package metadata, not skill/agent lists.
+
+## Risks & Mitigations
+
+- **Risk: plugin auto-discovery doesn't find the new `agents/` directory** (no existing agents in this plugin, so unproven path).
+  - *Mitigation:* AC2 explicitly tests that `/reload-plugins` surfaces the new skill, and the build task verifies the agent is invokable. If discovery fails, fall back to inlining the system prompt directly in the skill (cheap rewrite, no API change for users).
+- **Risk: the `--author-spec` flag detection is brittle** (e.g. user passes a change name that contains the literal string).
+  - *Mitigation:* match the flag as a whitespace-delimited token (`\b--author-spec\b`), not a substring. Change names are slugified, so collision is essentially impossible.
+- **Risk: agent writes a partial `spec.md` if the dialogue is interrupted.**
+  - *Mitigation:* the agent only calls `Write` once, at the end, after the last section is confirmed. Documented in the agent prompt.
+- **Risk: pause-for-approval is just a prompt instruction — Claude might continue anyway.**
+  - *Mitigation:* phrase the instruction with the same explicit STOP wording used in `/specclaw:propose` ("Do not proceed to `/specclaw:plan` until the user has approved"). That wording is observed to hold reliably in the existing flow.

--- a/.specclaw/changes/spec-author-agent/proposal.md
+++ b/.specclaw/changes/spec-author-agent/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Spec Author Agent
+
+**Created:** 2026-05-24
+**Status:** 🟡 Draft
+
+## Problem
+
+Today, `/specclaw:plan` generates `spec.md` in a single shot from `proposal.md`. The result is often thin: requirements are inferred from a short proposal without dialogue, edge cases get missed, and acceptance criteria end up vague. Users end up rewriting the spec by hand before `/specclaw:build` is safe to run.
+
+The plugin has 16 skills but **zero agents** under `plugins/specclaw/agents/` — there is no conversational sub-agent dedicated to specification authoring. The `templates/spec.md` scaffold (Overview, Functional Requirements, Non-Functional Requirements, Acceptance Criteria, Edge Cases, Dependencies, Notes) is well-structured but currently filled out by the main loop in passing.
+
+## Proposed Solution
+
+Add a new subagent `spec-author` shipped under `plugins/specclaw/agents/spec-author.md` that:
+
+1. Loads `proposal.md` for a given change.
+2. Walks the user through the `spec.md` template **section by section** via Socratic dialogue (one section at a time, asking targeted clarifying questions).
+3. Probes for edge cases, ambiguous wording, missing non-functional requirements (performance, security, observability), and dependencies.
+4. Writes the resulting detailed `spec.md` to `.specclaw/changes/<change>/spec.md` using `templates/spec.md` as the scaffold.
+5. Is callable two ways:
+   - **Standalone**: a new `/specclaw:author-spec` skill invokes it for an already-approved proposal.
+   - **From `/specclaw:plan --author-spec`**: with the flag, `plan` delegates the `spec.md` step to `spec-author` and **pauses for user approval of `spec.md` before generating `design.md` / `tasks.md`**. Without the flag, `plan` behaves as it does today (non-interactive one-shot), so `/specclaw:auto` is unaffected.
+
+**Interaction style:** blocking Socratic dialogue in the main thread. The flag is the escape hatch for automation.
+
+The agent uses the planning model (`anthropic/claude-opus-4-6` per `config.yaml`) and follows the same guardrails as `references/agent-guardrails.md` (Rule 1: state assumptions, Rule 2: simplicity first).
+
+## Scope
+
+### In Scope
+- New file: `plugins/specclaw/agents/spec-author.md` (agent frontmatter + system prompt).
+- New skill: `plugins/specclaw/skills/author-spec/SKILL.md` — invokes the agent for a named change.
+- Add `--author-spec` flag handling to `plugins/specclaw/skills/plan/SKILL.md` that delegates the spec step to `spec-author` and **pauses for user approval of `spec.md` before generating `design.md` / `tasks.md`**.
+- Update plugin manifest (`.claude-plugin/plugin.json` or equivalent) so the agent is discovered.
+- Brief docs update in the plugin README about the new agent + `/specclaw:author-spec` skill + `--author-spec` flag.
+
+### Out of Scope
+- Changing the `templates/spec.md` shape itself.
+- Replacing or rewriting `/specclaw:plan` end-to-end.
+- A separate "design author" or "tasks author" agent (could be follow-ups).
+- Multi-spec / spec-versioning workflows.
+
+## Impact
+
+- **Files affected:** ~5 (new agent, new skill, plan skill edit, plugin manifest, README) (estimated)
+- **Complexity:** small
+- **Risk:** low — additive; the existing `/specclaw:plan` flow keeps working even if the agent is bypassed.
+
+## Decisions
+
+1. **Invocation style:** blocking, interactive Socratic dialogue.
+2. **`/specclaw:plan` integration:** opt-in via `--author-spec` flag — default behavior unchanged so `/specclaw:auto` stays non-interactive.
+3. **Skill name:** `/specclaw:author-spec`.
+4. **Approval gate:** when the flag is on, pause after `spec.md` for explicit user approval before generating `design.md` / `tasks.md`.
+
+## Open Questions
+
+_None — all resolved above._
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/spec-author-agent/spec.md
+++ b/.specclaw/changes/spec-author-agent/spec.md
@@ -1,0 +1,74 @@
+# Spec: Spec Author Agent
+
+**Change:** spec-author-agent
+**Created:** 2026-05-24
+**Status:** 🟡 Draft
+
+## Overview
+
+Add a conversational subagent `spec-author` and a standalone skill `/specclaw:author-spec` that walk a user through `templates/spec.md` section by section to produce a detailed, high-quality spec. `/specclaw:plan` gains an opt-in `--author-spec` flag that delegates the spec step to this agent and pauses for approval before generating `design.md` and `tasks.md`. Default `/specclaw:plan` behavior — and therefore `/specclaw:auto` — is unchanged.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR1** — Ship a new subagent definition file at `plugins/specclaw/agents/spec-author.md` with frontmatter (`name`, `description`, `tools`, `model`) and a system prompt that walks `templates/spec.md` section by section.
+- **FR2** — The agent's dialogue covers, in order: Overview → Functional Requirements → Non-Functional Requirements → Acceptance Criteria → Edge Cases → Dependencies → Notes. It moves to the next section only after the user confirms the current one (or explicitly says "skip").
+- **FR3** — For each section, the agent asks ≥1 clarifying question grounded in the change's `proposal.md`; it does **not** invent requirements silently when the proposal is ambiguous (per Karpathy Rule 1).
+- **FR3a** — The agent's system prompt names and uses recognized brainstorming/challenge techniques, applied where each fits best:
+  - **5 Whys** — drill from stated solution to root problem (used in Overview / Problem framing).
+  - **Jobs-to-be-Done** — frame functional requirements as "When [situation], I want to [motivation], so I can [outcome]" (used in FRs).
+  - **Inversion** — "what would make this spec fail / be useless?" (used to surface NFRs).
+  - **Pre-mortem** — "imagine we shipped this and it broke — what broke?" (used to surface Edge Cases).
+  - **MoSCoW** — Must / Should / Could / Won't, used to challenge scope creep when the user proposes additions.
+  - **Concrete-example probe** — ask for a worked example whenever the user gives an abstract requirement.
+  The agent picks the technique appropriate to the section, does not robotically apply all of them, and explicitly names the technique to the user (e.g. "Let's do 5 Whys on this — why do you need…").
+- **FR3b** — The agent challenges (does not just accept) requirements that look speculative, vague, or untestable. Acceptance criteria must be observable; if the user proposes "system should be fast", the agent pushes for a measurable threshold.
+- **FR4** — On completion, the agent writes the final spec to `.specclaw/changes/<change>/spec.md` using `$CLAUDE_PLUGIN_ROOT/templates/spec.md` as the scaffold.
+- **FR5** — Ship a new skill `plugins/specclaw/skills/author-spec/SKILL.md` invokable as `/specclaw:author-spec <change>`. It validates that `proposal.md` exists, then invokes the `spec-author` agent for `<change>`. If `spec.md` already exists it asks for confirmation before overwriting.
+- **FR6** — Modify `plugins/specclaw/skills/plan/SKILL.md` to detect the `--author-spec` flag in ARGUMENTS. When present, delegate the spec step to `spec-author`, then **pause** and require explicit user approval before generating `design.md` and `tasks.md`.
+- **FR7** — Without `--author-spec`, `/specclaw:plan` behaves exactly as it does today (single-shot generation of all three files).
+- **FR8** — Update `README.md` (repo root) `Commands` table and brief workflow description to document `/specclaw:author-spec` and the `--author-spec` flag.
+
+### Non-Functional Requirements
+
+- **NFR1** — The agent's system prompt follows the existing plugin convention used by other skills (Markdown with a brief description and numbered steps). No new dependencies.
+- **NFR2** — The agent must obey the existing guardrails in `references/agent-guardrails.md` (Rules 1 & 2 in particular: surface assumptions, no speculative additions).
+- **NFR3** — `/specclaw:auto` and any non-interactive invocation of `/specclaw:plan` must remain non-interactive — verified by running `/specclaw:plan` without the flag and observing no agent dialogue.
+- **NFR4** — Agent and skill files must be plain Markdown with valid YAML frontmatter so they're picked up by Claude Code's plugin auto-discovery (no manifest changes required).
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- **AC1** — `plugins/specclaw/agents/spec-author.md` exists with valid frontmatter and a system prompt that names each section of `templates/spec.md`.
+- **AC2** — `plugins/specclaw/skills/author-spec/SKILL.md` exists, is discovered by `/reload-plugins`, and appears as `/specclaw:author-spec` in the skills list.
+- **AC3** — Invoking `/specclaw:author-spec spec-author-agent` (the in-flight change itself, as a self-test) opens an interactive dialogue and produces a `spec.md` reflecting the user's answers, written to `.specclaw/changes/spec-author-agent/spec.md`.
+- **AC3a** — During the dialogue, the agent explicitly references at least three of the named techniques (5 Whys, JTBD, Inversion, Pre-mortem, MoSCoW, Concrete-example probe) by name and applies them — verified by inspecting the transcript of the self-test run in `verify-report.md`.
+- **AC3b** — The agent pushes back on at least one vague/untestable requirement during the self-test (e.g. asks for a measurable threshold when the user says "should be fast" or similar) — recorded in `verify-report.md`.
+- **AC4** — Invoking `/specclaw:plan <change> --author-spec` runs the agent for the spec step, **pauses** after writing `spec.md`, and only proceeds to write `design.md` / `tasks.md` after the user types an approval (e.g. "approved", "yes", "go"). On rejection, no `design.md` / `tasks.md` is created.
+- **AC5** — Invoking `/specclaw:plan <change>` **without** the flag produces all three files in one pass with no dialogue, matching the pre-change behavior.
+- **AC6** — `/specclaw:author-spec` aborts cleanly if `proposal.md` is missing, with a message naming the missing file.
+- **AC7** — If `spec.md` already exists when `/specclaw:author-spec` runs, the user is asked to confirm overwrite; declining leaves the existing file untouched.
+- **AC8** — `README.md` Commands table lists `/specclaw:author-spec` with a one-line description, and a sentence somewhere in the README mentions the `--author-spec` flag for `/specclaw:plan`.
+
+## Edge Cases
+
+- **EC1** — `proposal.md` missing → `/specclaw:author-spec` fails fast with a clear message; the new skill's first step calls `specclaw-validate-change .specclaw <change> plan` (the existing validator already enforces this).
+- **EC2** — Existing `spec.md` → prompt-to-overwrite, default to "no". Same behavior whether the agent is invoked standalone or via `plan --author-spec`.
+- **EC3** — User abandons mid-dialogue → no partial `spec.md` is written; the agent only writes on successful completion of the final section.
+- **EC4** — Flag passed in an unexpected position (e.g. `/specclaw:plan --author-spec my-change` vs `/specclaw:plan my-change --author-spec`) → detection is positional-agnostic (substring match on `--author-spec` in ARGUMENTS).
+- **EC5** — `/specclaw:auto` happens to advance a change whose proposal is ambiguous → because `auto` calls `plan` without the flag, the existing non-interactive behavior is preserved (no regression).
+- **EC6** — User approves `spec.md` but the subsequent `design.md` / `tasks.md` generation fails → the partial state (spec only) is acceptable; the user can rerun `/specclaw:plan <change>` (without the flag) to regenerate the rest.
+
+## Dependencies
+
+- Existing plugin scaffolding: `plugins/specclaw/skills/plan/SKILL.md`, `templates/spec.md`, `references/agent-guardrails.md`, `bin/specclaw-validate-change`.
+- Claude Code plugin agent/skill discovery (no SDK changes assumed).
+- No new external libraries, binaries, or config keys.
+
+## Notes
+
+- The agent is intentionally additive — the default `/specclaw:plan` flow is untouched so existing automation (`/specclaw:auto`, scheduled runs) is not affected.
+- A natural follow-up (out of scope) would be peer agents `design-author` and `tasks-author` that the user can mix-and-match into `/specclaw:plan`.
+- Self-test: running `/specclaw:author-spec spec-author-agent` after merging will produce a richer `spec.md` for this very change — a useful smoke test.

--- a/.specclaw/changes/spec-author-agent/status.md
+++ b/.specclaw/changes/spec-author-agent/status.md
@@ -1,0 +1,4 @@
+# Status: spec-author-agent
+
+**Status:** planning
+**GitHub Issue:** #14

--- a/.specclaw/changes/spec-author-agent/tasks.md
+++ b/.specclaw/changes/spec-author-agent/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Spec Author Agent
+
+**Change:** spec-author-agent
+**Created:** 2026-05-24
+**Total Tasks:** 4
+
+## Summary
+
+Four tasks across two waves. Wave 1 ships the agent + standalone skill (independent files). Wave 2 wires the flag into `/specclaw:plan` and updates the README. Self-test of the new flow happens in `/specclaw:verify`, not as a separate task.
+
+## Tasks
+
+### Wave 1 — Create agent and standalone skill
+
+- [x] `T1` — Create `spec-author` subagent
+  - Files: `plugins/specclaw/agents/spec-author.md` (new)
+  - Estimate: medium
+  - Depends: —
+  - Notes: Frontmatter with `name: spec-author`, `description`, `tools: [Read, Write, Bash]`, `model: opus`. System prompt instructs the agent to:
+    (a) read `.specclaw/changes/<change>/proposal.md`;
+    (b) walk `templates/spec.md` section-by-section (Overview → FRs → NFRs → ACs → Edge Cases → Dependencies → Notes);
+    (c) ask ≥1 grounded clarifying question per section, applying a named brainstorming/challenge technique appropriate to the section — embed a small mapping table in the prompt: **5 Whys** (Overview/Problem framing), **Jobs-to-be-Done** (Functional Requirements), **Inversion** (Non-Functional Requirements: "what would make this useless?"), **Pre-mortem** (Edge Cases: "imagine it shipped and broke — what broke?"), **MoSCoW** (scope-creep challenges), **Concrete-example probe** (any abstract claim);
+    (d) name the technique to the user before using it (e.g. "Let's do 5 Whys here — why…");
+    (e) push back on vague/untestable requirements ("fast", "easy", "secure") and require an observable threshold before writing them into the spec — implements FR3b;
+    (f) write the final spec to `.specclaw/changes/<change>/spec.md` in a single `Write` call only after the user confirms the last section.
+    Reference `references/agent-guardrails.md` Rules 1 & 2.
+
+- [x] `T2` — Create `/specclaw:author-spec` skill
+  - Files: `plugins/specclaw/skills/author-spec/SKILL.md` (new)
+  - Estimate: small
+  - Depends: —
+  - Notes: Frontmatter `description` follows the pattern of `skills/plan/SKILL.md`. Steps: (1) `specclaw-ensure-init .specclaw`, (2) `specclaw-validate-change .specclaw <change> plan` — abort on failure, (3) if `.specclaw/changes/<change>/spec.md` exists, ask the user to confirm overwrite (default no), (4) invoke `Agent(subagent_type=spec-author, prompt="Author the spec for change '<change>'.")`, (5) `specclaw-update-status .specclaw`, (6) GitHub/Azure sync if enabled (mirror what `plan/SKILL.md` does).
+
+### Wave 2 — Integrate flag and document
+
+- [x] `T3` — Wire `--author-spec` flag into `/specclaw:plan`
+  - Files: `plugins/specclaw/skills/plan/SKILL.md` (edit)
+  - Estimate: small
+  - Depends: T1
+  - Notes: Add a "Flags" section explaining `--author-spec`. In step 4, branch: if the flag is present in ARGUMENTS (matched as a whitespace-delimited token), invoke the `spec-author` agent for the spec step instead of generating `spec.md` inline, then explicitly STOP and require the user to type an approval before continuing to `design.md` / `tasks.md`. Strip the flag token before using the rest of ARGUMENTS as the change name. Use the same explicit "Do not proceed until approved" wording as `skills/propose/SKILL.md`.
+
+- [x] `T4` — Document new skill and flag in README
+  - Files: `README.md` (edit)
+  - Estimate: small
+  - Depends: T2, T3
+  - Notes: Add a row `| /specclaw:author-spec <change> | Author spec.md interactively via the spec-author subagent |` to the Commands table. Add one sentence under the `/specclaw:plan` example noting that `--author-spec` can be appended for interactive spec authoring with an approval gate.
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T<n>` — <title>
+  - Files: <files to create/modify>
+  - Estimate: small | medium | large
+  - Depends: <task ids> (if any)
+  - Notes: <additional context>
+```

--- a/.specclaw/learnings.md
+++ b/.specclaw/learnings.md
@@ -65,3 +65,18 @@ specclaw-verify-context fails on macOS with 'sed: 1: invalid command code f' —
 Audit specclaw-verify-context for sed -i / sed -E flag portability, similar to the v0.2.5 cross-platform sed fix. Follow-up change.
 
 ---
+
+## [L5] design_gap — Spec did not specify behavior when spec.md already exists...
+
+**When:** 2026-05-24 14:24 UTC
+**Category:** design_gap
+**Priority:** medium
+**Status:** pending
+
+### Detail
+Spec did not specify behavior when spec.md already exists and /specclaw:plan is run without the flag (EC6 implied 'don't overwrite' but FR7 said 'behaves exactly as today')
+
+### Action
+Resolved in T3 by adding explicit 'if spec.md exists, skip spec step' branch in plan/SKILL.md; should be backported into spec.md FR7 wording on a future iteration
+
+---

--- a/.specclaw/patterns.md
+++ b/.specclaw/patterns.md
@@ -1,0 +1,6 @@
+# Pattern Registry
+
+Cross-change patterns detected from build errors and learnings.
+Patterns with recurrence >= 3 are eligible for promotion to agent prompts.
+
+---

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Future plugins by the same owner ship in the same `chan4lk` marketplace — you 
 
 > /specclaw:plan add-dark-mode
   Generates spec.md, design.md, tasks.md once the proposal is approved.
+  Append --author-spec to author spec.md interactively via the spec-author subagent, with an approval gate before design.md / tasks.md.
 
 > /specclaw:build add-dark-mode
   Executes tasks wave-by-wave, committing each.
@@ -79,7 +80,8 @@ All commands are namespaced under `/specclaw:`. Most are model-invokable — Cla
 |---------|---------|
 | `/specclaw:init` | Initialize `.specclaw/` in the current project |
 | `/specclaw:propose "<idea>"` | Draft a new change proposal |
-| `/specclaw:plan <change>` | Generate spec + design + tasks |
+| `/specclaw:plan <change>` | Generate spec + design + tasks (append `--author-spec` for interactive spec authoring with an approval gate) |
+| `/specclaw:author-spec <change>` | Author `spec.md` interactively via the `spec-author` subagent (5 Whys, JTBD, Inversion, Pre-mortem, MoSCoW) |
 | `/specclaw:build <change>` | Execute tasks wave-by-wave |
 | `/specclaw:learn <change> "..."` | Record a spec gap, design miss, or pattern |
 | `/specclaw:patterns` | Inspect the cross-change pattern registry |

--- a/plugins/specclaw/agents/spec-author.md
+++ b/plugins/specclaw/agents/spec-author.md
@@ -1,0 +1,75 @@
+---
+name: spec-author
+description: Interactively co-authors a high-quality spec.md for a specclaw change. Walks the user through the spec template section by section, applying named brainstorming techniques (5 Whys, Jobs-to-be-Done, Inversion, Pre-mortem, MoSCoW, Concrete-example probe) and challenging vague or untestable requirements before writing the final file.
+tools: [Read, Write, Bash]
+model: opus
+---
+
+You are **spec-author**, a specclaw subagent that co-authors `spec.md` interactively with the user.
+
+You will be invoked with a change name (e.g. `spec-author-agent`). Your job is to produce a detailed, observable, testable `spec.md` for that change — not to write it in one shot, but to **co-design it section by section with the user**, applying recognized brainstorming and challenge techniques.
+
+## Inputs
+
+1. Read `.specclaw/changes/<change>/proposal.md`. If it does not exist, stop and tell the user that `proposal.md` is required.
+2. Read the spec scaffold at `$CLAUDE_PLUGIN_ROOT/templates/spec.md`. Use this as the structural template; do **not** invent new sections.
+
+## Output
+
+A single `Write` call to `.specclaw/changes/<change>/spec.md`. Only write the file **once**, at the very end, after the user confirms the last section. If the dialogue is abandoned, no file is written.
+
+## Dialogue Protocol
+
+Walk these sections in this exact order. Move to the next section only after the user explicitly confirms the current one (or says "skip"):
+
+1. **Overview**
+2. **Functional Requirements**
+3. **Non-Functional Requirements**
+4. **Acceptance Criteria**
+5. **Edge Cases**
+6. **Dependencies**
+7. **Notes**
+
+For each section: present your draft of that section grounded in `proposal.md`, ask at least one clarifying question, apply the technique mapped to that section, and wait for the user before moving on.
+
+## Technique Catalog
+
+You **must** name the technique aloud before applying it (e.g. *"Let's do 5 Whys here — why do you need..."*). Pick the technique that fits the section; do **not** robotically apply all of them.
+
+| Section | Technique | How to apply |
+|---------|-----------|--------------|
+| Overview | **5 Whys** | Drill from the stated solution down to the root problem. Ask "why?" up to five times until you bottom out on a real user/business need. |
+| Functional Requirements | **Jobs-to-be-Done** | Frame each FR as: *"When [situation], I want to [motivation], so I can [outcome]."* Reject FRs that can't be expressed this way — they're usually solutions, not requirements. |
+| Non-Functional Requirements | **Inversion** | Ask the user: *"What would make this spec useless or actively bad? What's the worst non-functional outcome?"* Invert each answer into an NFR. |
+| Acceptance Criteria | **Concrete-example probe** | For every AC the user offers, ask for a worked example. If the user can't give a concrete example, the AC is too vague — push for an observable, testable form. |
+| Edge Cases | **Pre-mortem** | Ask: *"Imagine we shipped this and a week later it broke or embarrassed us. What broke? What did we miss?"* Each answer becomes an edge case. |
+| Scope challenges (any section) | **MoSCoW** | When the user proposes additions, categorize as Must / Should / Could / Won't. "Could" and "Won't" go in Notes or out of scope, not as FRs. |
+
+## Challenge Mode (mandatory)
+
+You are **not** a transcriptionist. Push back on:
+
+- **Vague terms** — "fast", "easy", "secure", "intuitive", "scalable". Require a measurable threshold ("p95 < 200ms", "first-time user completes onboarding in < 3 steps", "passes OWASP top-10 review"). Do not write a vague term into `spec.md`.
+- **Untestable acceptance criteria** — every AC must be observable from outside the system (a command, a file existing, a UI state, a log line). Reject "the system works correctly" / "code is clean".
+- **Solution-disguised-as-requirement** — if an FR prescribes implementation ("use Redis", "store as JSON"), ask whether that's a true requirement or a leak from the design phase. If it's a design choice, move it to a Note.
+- **Silent assumptions** — when the proposal is ambiguous, **ask** rather than guessing. Per Karpathy Rule 1, surface the ambiguity to the user; do not pick silently.
+
+If after one round of pushback the user insists on the vague phrasing, accept it but record the conversation in the section's Notes so the gap is visible.
+
+## Guardrails
+
+You inherit the project's standing guardrails (`references/agent-guardrails.md`):
+
+- **Rule 1 (Think Before Coding)** — surface assumptions, ask when uncertain, present multiple interpretations.
+- **Rule 2 (Simplicity First)** — no speculative requirements, no "configurability for the future". If a section could be 3 FRs instead of 8, make it 3.
+
+## Style
+
+- Keep your turns short — present the section draft, ask the question, stop.
+- Use the user's wording where it's already clear. Don't rewrite for the sake of rewriting.
+- Number requirements (FR1, NFR1, AC1, EC1) consistent with the existing specclaw spec convention.
+- The final `spec.md` must follow the structure of `$CLAUDE_PLUGIN_ROOT/templates/spec.md` exactly — same headers, same order.
+
+## Completion
+
+After the **Notes** section is confirmed, summarize all sections back to the user one final time and ask for a single explicit approval (e.g. *"Ready to write spec.md?"*). Only on approval, do a single `Write` to `.specclaw/changes/<change>/spec.md`, then report the file path.

--- a/plugins/specclaw/skills/author-spec/SKILL.md
+++ b/plugins/specclaw/skills/author-spec/SKILL.md
@@ -1,0 +1,18 @@
+---
+description: Interactively co-author spec.md for an approved proposal via the spec-author subagent. The agent walks the user through the spec template section by section, applying named brainstorming techniques (5 Whys, Jobs-to-be-Done, Inversion, Pre-mortem, MoSCoW) and challenging vague requirements. Use when you want a high-quality, dialogue-driven spec instead of the single-shot one /specclaw:plan produces by default. Standalone alternative to /specclaw:plan --author-spec.
+---
+
+# specclaw author-spec
+
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
+Interactively author `spec.md` for an approved proposal.
+
+1. **Validate:** run `specclaw-validate-change .specclaw <change> plan`. If it fails (typically: `proposal.md` missing), report the missing prerequisite and stop.
+2. **Check for existing spec:** if `.specclaw/changes/<change>/spec.md` already exists, show the user the first few lines and ask whether to overwrite. Default is **no** — abort if the user does not explicitly confirm overwrite.
+3. **Invoke the agent:** call the `spec-author` subagent via the `Agent` tool with `subagent_type: "spec-author"` and a prompt instructing it to author the spec for `<change>`. The agent reads `proposal.md` and writes `spec.md` itself; do not wrap the dialogue in this skill.
+4. **Update status:** `specclaw-update-status .specclaw`.
+5. **GitHub sync** (if `github.sync: true` in `config.yaml`): `specclaw-gh-sync update .specclaw <change>` to refresh the issue with the new spec.
+6. **Azure Boards sync** (if `azdo.boards.sync: true`): `specclaw-azdo-issue update .specclaw <change>`.
+
+Do not proceed to `/specclaw:plan` automatically. After `spec.md` is written, the user can run `/specclaw:plan <change>` (which will use the freshly-authored `spec.md` and generate `design.md` + `tasks.md`) when ready.

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -8,11 +8,20 @@ description: Generate spec, design, and ordered task list for an approved propos
 
 Turn an approved proposal into an executable plan.
 
+## Flags
+
+- `--author-spec` — delegate spec authoring to the `spec-author` subagent for an interactive, technique-driven dialogue (5 Whys, Jobs-to-be-Done, Inversion, Pre-mortem, MoSCoW). When this flag is present, **pause for explicit user approval of `spec.md`** before generating `design.md` and `tasks.md`. Without the flag, behavior is unchanged (single-shot generation, no dialogue) so `/specclaw:auto` remains non-interactive.
+
+  Detect the flag as a whitespace-delimited token anywhere in ARGUMENTS (positional-agnostic), and strip it before using the rest of ARGUMENTS as `<change>`.
+
 1. **Validate:** run `specclaw-validate-change .specclaw <change> plan`. If it fails, report missing prerequisites and stop.
 2. Read `.specclaw/changes/<change>/proposal.md`.
 3. Analyze the existing codebase (file structure, patterns, dependencies relevant to the change).
 4. Generate three files in `.specclaw/changes/<change>/`:
-   - `spec.md` — functional requirements, non-functional requirements, acceptance criteria, edge cases. Use `$CLAUDE_PLUGIN_ROOT/templates/spec.md` as a starting template.
+   - `spec.md` — functional requirements, non-functional requirements, acceptance criteria, edge cases.
+     - **If `--author-spec` is set:** invoke the `spec-author` subagent via the `Agent` tool with `subagent_type: "spec-author"` to author the spec interactively. After the agent writes the file, **STOP and require explicit user approval** (e.g. "approved", "yes", "go") before proceeding to `design.md` and `tasks.md`. Do not generate the remaining files until the user approves.
+     - **Otherwise:** generate `spec.md` directly using `$CLAUDE_PLUGIN_ROOT/templates/spec.md` as a starting template (single-shot, no dialogue).
+     - **If `spec.md` already exists** (e.g. authored previously via `/specclaw:author-spec`): do not overwrite it; skip the spec step and proceed to `design.md` / `tasks.md`.
    - `design.md` — technical approach, architecture, file changes map, key decisions, risks. Template: `$CLAUDE_PLUGIN_ROOT/templates/design.md`.
    - `tasks.md` — ordered tasks grouped into waves with dependencies. Template: `$CLAUDE_PLUGIN_ROOT/templates/tasks.md`.
 5. Present a plan summary to the user (counts of FRs, ACs, tasks, waves).


### PR DESCRIPTION
## Summary

Adds a new specclaw subagent `spec-author` that interactively co-authors `spec.md` for a change, applying named brainstorming techniques (5 Whys, Jobs-to-be-Done, Inversion, Pre-mortem, MoSCoW, Concrete-example probe) and pushing back on vague or untestable requirements. Exposed two ways:

- `/specclaw:author-spec <change>` — standalone interactive spec authoring
- `/specclaw:plan <change> --author-spec` — opt-in flag; delegates the spec step to the agent and pauses for approval before generating `design.md` / `tasks.md`

Without the flag, `/specclaw:plan` and `/specclaw:auto` behavior is unchanged.

## Why

`/specclaw:plan` today generates `spec.md` in a single shot from `proposal.md`. The result is often thin: requirements inferred without dialogue, edge cases missed, ACs vague. Users end up rewriting the spec by hand before `/specclaw:build` is safe to run. This change gives the planning phase a real co-author, not a transcriptionist.

The plugin had 16 skills and 0 agents prior to this change — `plugins/specclaw/agents/spec-author.md` is the first.

## Files

- `plugins/specclaw/agents/spec-author.md` — agent system prompt with named-technique catalog and mandatory challenge mode
- `plugins/specclaw/skills/author-spec/SKILL.md` — standalone `/specclaw:author-spec` skill
- `plugins/specclaw/skills/plan/SKILL.md` — `--author-spec` flag handling + "skip spec if already exists" branch
- `README.md` — Commands table + quickstart mention of the flag
- `.specclaw/changes/spec-author-agent/` — full proposal/spec/design/tasks trail per v0.3.2 convention

## Process trail

- Proposal: `.specclaw/changes/spec-author-agent/proposal.md`
- Spec (8 FRs, 4 NFRs, 8 ACs, 6 edge cases): `spec.md`
- Design (5 key decisions incl. the agent-vs-inline tradeoff): `design.md`
- Tasks (4 across 2 waves): `tasks.md`
- Issue: #14

## Design-gap noted

Logged as L5 (medium): spec FR7 says `/specclaw:plan` "behaves exactly as today" without the flag, but EC6 implies don't-overwrite-existing-spec. Resolved during T3 with an explicit "if `spec.md` exists, skip the spec step" branch in `plan/SKILL.md`. Worth back-porting the wording fix into the spec on a future iteration.

## Test plan

- [ ] `/reload-plugins` surfaces `/specclaw:author-spec` and the `spec-author` agent
- [ ] `/specclaw:author-spec <some-change>` opens an interactive dialogue, names ≥3 techniques aloud, pushes back on at least one vague requirement, and writes `spec.md` only after final approval
- [ ] `/specclaw:plan <change> --author-spec` pauses for approval before generating design.md/tasks.md
- [ ] `/specclaw:plan <change>` (no flag) — single-shot behavior unchanged
- [ ] `/specclaw:author-spec` aborts cleanly when `proposal.md` is missing
- [ ] Existing `spec.md` triggers an overwrite confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)