### PR TITLE
fix: 8 lifecycle bugs (B2–B9) in propose→plan→build→verify→pr

### DIFF
--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-05-24 14:24 UTC
+**Last Updated:** 2026-06-14 10:20 UTC
 
 ## Active Changes
 
@@ -10,18 +10,15 @@
 - ✅ **build-engine** — 6/6 tasks (100%) | 0 failed
 - ✅ **build-error-journal** — 3/3 tasks (100%) | 0 failed
 - ✅ **claude-plugin-packaging** — 11/11 tasks (100%) | 0 failed
-- 🔨 **feedback-ux-improvements** — 6/8 tasks (75%) | 0 failed
 - ✅ **git-worktrees** — 3/3 tasks (100%) | 0 failed
 - ✅ **github-issues-sync** — 3/3 tasks (100%) | 0 failed
-- ✅ **hr360-structured-feedback-okr** — 10/10 tasks (100%) | 0 failed
 - ✅ **karpathy-build-guardrails** — 6/6 tasks (100%) | 0 failed
 - ✅ **learn-command** — 2/2 tasks (100%) | 0 failed
-- ✅ **mcp-feedback-endpoint** — 2/2 tasks (100%) | 0 failed
+- ✅ **lifecycle-bug-fixes** — 8/8 tasks (100%) | 0 failed
 - ✅ **pattern-detection** — 3/3 tasks (100%) | 0 failed
 - ✅ **phase-validation** — 2/2 tasks (100%) | 0 failed
 - ✅ **post-build-review** — 1/1 tasks (100%) | 0 failed
 - ✅ **pr-command** — 7/7 tasks (100%) | 0 failed
-- 🔨 **service-layer-extraction** — 4/11 tasks (36%) | 0 failed
 - 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
 
@@ -35,6 +32,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 18
-- **Active:** 18
+- **Total changes:** 15
+- **Active:** 15
 - **Completed:** 0

--- a/.specclaw/changes/lifecycle-bug-fixes/design.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/design.md
@@ -1,0 +1,76 @@
+# Design: lifecycle-bug-fixes
+
+**Change:** lifecycle-bug-fixes
+**Created:** 2026-06-14
+
+## Technical Approach
+
+Each bug is a localized defect in one `bin/` script (plus the propose skill/template for B6). Fix
+each at its root, reusing patterns already present in the repo (the portable `sedi()` wrapper in
+`specclaw-pr`, the awk task-id extraction in `specclaw-parse-tasks`). Add one plain-bash regression
+script with fixtures so the template→parser contract is checkable going forward — no test framework
+is introduced (none exists today; Rule 2 simplicity).
+
+## Architecture
+
+All scripts live in `plugins/specclaw/bin/`. The three "parsers" that must agree on the same
+template output:
+- `specclaw-parse-tasks` — **reference impl** (awk; requires `` `T[0-9]+` ``, tracks fences). Not
+  modified — it is the contract the others are aligned to.
+- `specclaw-validate-change` — fixed to match it (FR1).
+- `specclaw-verify collect` — fixed for AC/Files tolerance (FR2, FR3).
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/bin/specclaw-validate-change` | modify | B2: `count_incomplete`/`count_total`/`count_tasks` require `` `T[0-9]+` `` and skip fenced blocks |
+| `plugins/specclaw/bin/specclaw-verify` | modify | B3: AC grep accepts `AC1`/`AC-1`, optional checkbox/bold. B4: `Files:` grep allows leading `- `/`* `. B6: `update-status` creates `status.md` if absent |
+| `plugins/specclaw/bin/specclaw-verify-context` | modify | B5: replace bare `sed -i` calls with portable `sedi()` (or awk); no path in script position |
+| `plugins/specclaw/bin/specclaw-azdo-pr` | modify | B7: `build_pr_title` from `# Proposal:` H1. B8: `adoapi_post` captures `%{http_code}`+body, prints ADO error on non-2xx |
+| `plugins/specclaw/bin/specclaw-pr` | modify | B7: `build_pr_title` from `# Proposal:` H1 (same fix as azdo) |
+| `plugins/specclaw/bin/specclaw-build` | modify | B9: `finalize` captures `git checkout` stderr into the error message |
+| `plugins/specclaw/skills/propose/SKILL.md` | modify | B6: instruct propose to scaffold `status.md` from template |
+| `plugins/specclaw/bin/specclaw-ensure-init` *or* propose flow | verify | Ensure a per-change `status.md` is created (whichever owns scaffolding) |
+| `plugins/specclaw/tests/run-parser-tests.sh` | create | Regression suite + fixtures (AC-9) |
+| `plugins/specclaw/tests/fixtures/*` | create | Sample `tasks.md`/`spec.md` matching template output |
+
+## Data Model Changes
+
+None. Output JSON shapes (`acceptance_criteria`, `changed_files`) are unchanged — only populated
+correctly.
+
+## API Changes
+
+- `adoapi_post` (B8): on non-2xx, prints `ADO HTTP <code>: <body>` to stderr and returns non-zero.
+  Callers already `die` on empty parse, so behavior on success is unchanged; failure is now loud.
+- `build_pr_title` (B7): same signature, different source line. Falls back to `[specclaw] <change>`
+  when no `# Proposal:` H1 exists (unchanged fallback path).
+
+## Key Decisions
+
+1. **Align to `parse-tasks`, don't rewrite it.** `parse-tasks` already does the right thing
+   (backtick `T\d+`, fence tracking). `validate-change` is brought to the same rule rather than
+   inventing a third behavior. (B2)
+2. **Make collectors tolerant, not the templates rigid.** Rather than forcing one AC/Files format,
+   the collector accepts the variants the planner naturally emits. This fixes the *systemic* silent
+   degradation (B3/B4) regardless of which format a given plan used.
+3. **B6 — fix both sides.** Scaffold `status.md` in `propose` (fixes all future changes) *and*
+   self-heal in `update-status` (fixes existing changes / direct invocations). Per the resolved
+   open question.
+4. **B7 in-place in both scripts.** Two call sites only → no shared library; surgical edits.
+5. **Reuse `sedi()` for B5.** The portable wrapper already exists in `specclaw-pr`; copy it (or
+   rewrite the two strip steps in awk) rather than add a dependency.
+6. **Plain-bash tests.** A single executable script with fixture files; no bats/npm. Asserts the
+   three parsers agree on template-shaped input and that the existing in-repo specs still parse.
+
+## Risks & Mitigations
+
+- **R1: Parser change breaks existing valid docs.** Mitigation: NFR2 + AC-9 run the in-repo
+  `build-engine` spec/tasks through the fixed parsers; both formats must pass.
+- **R2: B5 awk/sed rewrite changes the extracted template subtly.** Mitigation: diff the produced
+  payload before/after on the same `agent-prompts.md`; AC-4 asserts non-empty + no sed error.
+- **R3: B8 change alters success path.** Mitigation: only the non-2xx branch is new; 2xx returns
+  the body exactly as before.
+- **R4: B6 status.md format drift.** Mitigation: scaffold from `templates/status.md` (single
+  source) in both the propose and self-heal paths.

--- a/.specclaw/changes/lifecycle-bug-fixes/proposal.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/proposal.md
@@ -1,0 +1,89 @@
+# Proposal: lifecycle-bug-fixes — fix 9 bugs in the propose→plan→build→verify→pr lifecycle
+
+**Created:** 2026-06-14
+**Status:** 🟡 Draft
+
+## Problem
+
+Running the full `propose → plan → build → verify → pr-azdo` lifecycle for a real change on
+macOS surfaced **9 bugs** (documented in `SPECCLAW-BUGS.md`), four of them 🔴 blocking. The
+lifecycle currently fails or degrades silently on a clean, template-generated change:
+
+- **Parser disagreement** — `parse-tasks`, `validate-change`, and `verify collect` interpret the
+  *same* `tasks.md`/`spec.md` that our own templates emit in incompatible ways. The template and
+  the parsers are not a single source of truth.
+- **BSD/macOS portability** — `specclaw-verify-context` embeds a temp-file path into a `sed`
+  script position; GNU sed tolerates it, BSD sed (macOS default) crashes (`invalid command code`).
+- **Tools assume files exist or swallow errors** — `verify update-status` hard-fails when a
+  per-change `status.md` is absent; `azdo-pr` builds the PR title from the wrong field and hides
+  the ADO HTTP error body (`curl --fail`, exit 22); `build finalize` reports a non-actionable
+  merge failure.
+- **Version skew** — command→skill→bin resolution can load skill bodies from an older cached
+  version (0.2.2) than the bin scripts (0.4.2), so docs describe a different contract than the code.
+
+Net effect: the happy path through our own lifecycle does not work end-to-end on macOS without
+manual workarounds (hand-edited templates, hand-built verify payloads, direct REST PR creation).
+
+## Proposed Solution
+
+Fix each bug at its root, prioritizing the 🔴 blockers, and add regression coverage so the
+template→parser contract stays a single source of truth.
+
+- **B2** — `specclaw-validate-change` verify: ignore fenced code blocks and require a real task id
+  (`T\d+`) when counting incomplete tasks, matching `specclaw-parse-tasks`.
+- **B3** — `specclaw-verify collect`: accept `AC1`/`AC-1`, with or without a checkbox, when
+  parsing acceptance criteria.
+- **B4** — `specclaw-verify collect`: allow an optional leading `- `/`* ` bullet on `Files:` lines.
+- **B5** — `specclaw-verify-context`: remove the embedded-path `sed` call; replace with a portable
+  approach (awk/python or in-host read-replace) that works on BSD and GNU sed.
+- **B6** — scaffold a per-change `status.md` in `propose` (and/or have `verify update-status`
+  create it if absent) so update-status never hard-fails.
+- **B7** — build the PR title from the proposal H1 / `# Proposal:` line, sanitize newlines,
+  enforce the char cap with an ellipsis. **Confirmed to affect BOTH paths:** `specclaw-pr`
+  (GitHub) and `specclaw-azdo-pr` share an identical `build_pr_title` that takes the first
+  non-header line (the Problem prose) — GitHub caps at 72, ADO at 128. Fix both.
+- **B8** — `specclaw-azdo-pr`: drop `curl --fail` (or capture `%{http_code}` + body) and print the
+  ADO error payload on any non-2xx. (ADO-specific — the GitHub path uses `gh pr create`, which
+  already surfaces errors.)
+- **B9** — `specclaw-build finalize`: surface the underlying `git checkout` stderr and skip
+  auto-merge gracefully when the base branch can't be checked out, explaining why.
+
+### Parked
+- **B1** (version/cache resolution) — **parked** by request. Not addressed in this change;
+  remains documented in `SPECCLAW-BUGS.md` for later (likely an install/packaging artifact rather
+  than a code fix in this repo).
+
+## Scope
+
+### In Scope
+- Fixes to the affected `bin/` scripts: `specclaw-validate-change`, `specclaw-verify`,
+  `specclaw-verify-context`, `specclaw-azdo-pr`, `specclaw-pr` (GitHub — shares the B7 title bug),
+  `specclaw-build`.
+- `propose` skill / template change to scaffold per-change `status.md` (B6).
+- Regression tests covering the template→parser contract (the exact `tasks.md`/`spec.md` our
+  templates generate must round-trip through all three parsers).
+
+### Out of Scope
+- **B1** (version/cache resolution) — parked, see below.
+- Redesigning the spec/tasks template format beyond what the parser fixes require.
+- New lifecycle features or commands.
+
+## Impact
+
+- **Files affected:** ~6–8 (estimated) — 5 bin scripts, 1 template, propose skill, plus tests.
+- **Complexity:** medium
+- **Risk:** medium — parser changes touch the core lifecycle; regression tests required to avoid
+  breaking existing valid `tasks.md`/`spec.md` documents in-repo.
+
+## Open Questions
+
+1. **B6 placement** — scaffold `status.md` in `propose` (preferred, fixes it for all future
+   changes) *and* make `update-status` self-heal for existing changes, or only one?
+2. **Test harness** — is there an existing test runner for the `bin/` scripts, or do we add one?
+
+_Resolved during review: B1 parked (out of scope); GitHub `specclaw-pr` B7 fix included in scope
+(confirmed it shares the same `build_pr_title` bug as `specclaw-azdo-pr`)._
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/lifecycle-bug-fixes/spec.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/spec.md
@@ -1,0 +1,94 @@
+# Spec: lifecycle-bug-fixes
+
+**Change:** lifecycle-bug-fixes
+**Created:** 2026-06-14
+**Status:** 🟡 Draft
+
+## Overview
+
+Fix 8 bugs (B2–B9 from `SPECCLAW-BUGS.md`) that break or silently degrade the
+`propose → plan → build → verify → pr` lifecycle on macOS/BSD. The unifying theme is that the
+`bin/` parsers (`validate-change`, `verify collect`) disagree with `parse-tasks` and with the
+formats our own templates emit, plus three robustness defects (BSD `sed`, missing-file hard-fail,
+swallowed errors). B1 (version-cache resolution) is parked and out of scope.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR1 (B2)** — `specclaw-validate-change … verify` MUST count only real tasks (backtick-wrapped
+  `` `T<digits>` `` ids) and MUST ignore lines inside fenced code blocks, matching the behavior of
+  `specclaw-parse-tasks`.
+- **FR2 (B3)** — `specclaw-verify collect` MUST parse acceptance criteria written as `AC1` or
+  `AC-1`, with or without a leading `- [ ]` checkbox and with or without `**bold**`.
+- **FR3 (B4)** — `specclaw-verify collect` MUST parse `Files:` fields whether or not the line
+  begins with a `- ` / `* ` list bullet (the format the tasks template emits: `  - Files: …`).
+- **FR4 (B5)** — `specclaw-verify-context` MUST build the verify-agent template without crashing on
+  BSD/macOS `sed` (no temp-file path interpolated into a `sed` script position).
+- **FR5 (B6)** — A per-change `status.md` MUST exist after `propose`, and
+  `specclaw-verify update-status` MUST NOT hard-fail when `status.md` is absent — it creates it.
+- **FR6 (B7)** — Both `specclaw-azdo-pr` and `specclaw-pr` MUST build the PR title from the
+  proposal's `# Proposal:` H1 line (not the Problem prose), strip markdown/newlines, and enforce
+  the per-platform char cap with an ellipsis (128 ADO / 72 GitHub, unchanged).
+- **FR7 (B8)** — `specclaw-azdo-pr` MUST surface the ADO HTTP status code and response body on any
+  non-2xx instead of exiting 22 with no diagnostic.
+- **FR8 (B9)** — `specclaw-build finalize` MUST include the underlying `git checkout` stderr in its
+  error message when it cannot check out the base branch for the auto-merge.
+
+### Non-Functional Requirements
+
+- **NFR1** — Fixes are surgical: touch only the affected functions; match existing bash style
+  (the portable `sedi`/`json_escape` patterns already in the repo).
+- **NFR2** — Parser fixes MUST NOT regress the existing in-repo specs/tasks (e.g. `build-engine`,
+  which uses `- [ ] **AC-1:**`). Verified by the regression suite.
+- **NFR3** — Portable across BSD (macOS) and GNU (Linux) `sed`; no GNU-only flags.
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- [ ] **AC-1 (B2):** GIVEN a `tasks.md` whose every real task is `[x]` and whose Legend fence
+  contains `` - [ ] `T<n>` — <title> `` WHEN `specclaw-validate-change .specclaw <c> verify` runs
+  THEN it reports ready (0 incomplete), agreeing with `specclaw-parse-tasks`.
+- [ ] **AC-2 (B3):** GIVEN a spec with ACs written as `- **AC1** — …` (no checkbox, no hyphen)
+  WHEN `specclaw-verify collect` runs THEN `acceptance_criteria` is non-empty and contains the AC
+  text; AND the existing `- [ ] **AC-1:** …` format still parses.
+- [ ] **AC-3 (B4):** GIVEN a `tasks.md` with `  - Files: \`path/a\`, \`path/b\`` WHEN
+  `specclaw-verify collect` runs THEN `changed_files` contains `path/a` and `path/b`.
+- [ ] **AC-4 (B5):** GIVEN macOS BSD `sed` WHEN `specclaw-verify-context` runs THEN it emits the
+  verify-agent template payload with no `sed: … invalid command code` error and a non-empty body.
+- [ ] **AC-5 (B6):** GIVEN a change with no `status.md` WHEN `specclaw-verify update-status
+  .specclaw <c> PASS` runs THEN it creates `status.md` and writes the Verify verdict (exit 0);
+  AND a fresh `propose` scaffolds `status.md`.
+- [ ] **AC-6 (B7):** GIVEN a proposal with H1 `# Proposal: research-to-agents: …` WHEN
+  `build_pr_title` runs in both `specclaw-azdo-pr` and `specclaw-pr` THEN the title derives from
+  the H1 (not the Problem sentence), has no embedded newline, and is within the cap.
+- [ ] **AC-7 (B8):** GIVEN an ADO POST that returns a non-2xx (e.g. 409 duplicate PR) WHEN
+  `specclaw-azdo-pr` runs THEN it prints the HTTP status code and the ADO error body and exits
+  non-zero with that diagnostic visible.
+- [ ] **AC-8 (B9):** GIVEN `finalize` cannot check out the base branch WHEN it records the error
+  THEN the error string contains the `git checkout` stderr (not just "Failed to checkout … for
+  merge").
+- [ ] **AC-9 (tests):** A regression script runs all parser fixtures (the exact `tasks.md`/`spec.md`
+  shapes the templates emit) through `parse-tasks`, `validate-change`, and `verify collect` and
+  passes; it is runnable from the repo with a single command.
+
+## Edge Cases
+
+- Legend fence with multiple checkbox-looking lines — none counted.
+- A spec mixing both AC formats — all parsed, none duplicated.
+- `Files:` line with no backticks (plain comma-separated) — still parsed (existing fallback kept).
+- Proposal with no `# Proposal:` H1 — title falls back to `[specclaw] <change-name>`.
+- ADO 2xx with empty body — treated as success (no false error).
+- `finalize` when base branch checkout fails due to dirty tree — error names the reason.
+
+## Dependencies
+
+- `git`, `curl`, `awk`, `sed` (BSD + GNU), `python3` (already used), `gh`/ADO PAT for PR paths.
+- No new runtime dependencies; no new test framework (plain bash regression script).
+
+## Notes
+
+- B1 (version/cache resolution) parked — out of scope, remains in `SPECCLAW-BUGS.md`.
+- The PR title fix is applied in-place in each of the two scripts (no shared lib extraction — only
+  two call sites; matches Rule 3 surgical-changes).

--- a/.specclaw/changes/lifecycle-bug-fixes/status.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/status.md
@@ -1,0 +1,5 @@
+# Status: lifecycle-bug-fixes
+
+**Status:** planning
+**GitHub Issue:** #15
+| Verify | ✅ Passed |  |

--- a/.specclaw/changes/lifecycle-bug-fixes/tasks.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: lifecycle-bug-fixes
+
+**Change:** lifecycle-bug-fixes
+**Created:** 2026-06-14
+**Total Tasks:** 8
+
+## Summary
+
+Fix 8 lifecycle bugs (B2–B9). Wave 1 fixes each script independently (no shared files). Wave 2
+adds the regression suite that locks the template→parser contract. B1 is parked (out of scope).
+
+## Tasks
+
+### Wave 1 — Root-cause fixes (independent files, parallel)
+
+- [x] `T1` — B2: validate-change counts only real tasks, ignores fenced blocks
+  - Files: `plugins/specclaw/bin/specclaw-validate-change`
+  - Estimate: small
+  - Notes: In `count_incomplete`/`count_total`/`count_tasks`, require a backtick-wrapped
+    `` `T[0-9]+` `` id and skip lines inside ``` fences, matching `specclaw-parse-tasks`
+    (awk fence-tracking + `match($0,/\`T[0-9]+\`/)`). AC-1.
+
+- [x] `T2` — B3+B4+B6: verify collect AC/Files tolerance + update-status self-heal
+  - Files: `plugins/specclaw/bin/specclaw-verify`
+  - Estimate: medium
+  - Notes: B3 — AC grep accepts `AC1`/`AC-1`, optional `- [ ]` checkbox and optional `**`; fix the
+    clean-up sed for the no-checkbox case. B4 — `Files:` grep allows an optional leading `- `/`* `
+    bullet. B6 — in `update-status`, if `status.md` is absent, create it from
+    `templates/status.md` instead of `die`. AC-2, AC-3, AC-5 (self-heal half).
+
+- [x] `T3` — B5: verify-context portable sed (no path in script position)
+  - Files: `plugins/specclaw/bin/specclaw-verify-context`
+  - Estimate: small
+  - Notes: Replace bare `sed -i '…' "$TEMPLATE_FILE"` calls (lines ~225–232) with the portable
+    `sedi()` wrapper from `specclaw-pr` (or rewrite the blank-line/fence strips in awk). AC-4.
+
+- [x] `T4` — B6: scaffold per-change status.md in propose
+  - Files: `plugins/specclaw/skills/propose/SKILL.md`
+  - Estimate: small
+  - Notes: Add a step that writes `status.md` from `$CLAUDE_PLUGIN_ROOT/templates/status.md` when
+    creating the change dir, so every future change has one. AC-5 (scaffold half).
+
+- [x] `T5` — B7+B8: azdo-pr title from H1 + surface ADO errors
+  - Files: `plugins/specclaw/bin/specclaw-azdo-pr`
+  - Estimate: medium
+  - Notes: B7 — `build_pr_title` reads the `# Proposal:` H1 line, strips the `# Proposal: ` prefix,
+    removes markdown/newlines, keeps the 128-char ellipsis cap; fall back to `[specclaw] <change>`.
+    B8 — `adoapi_post` captures `%{http_code}` + body, prints `ADO HTTP <code>: <body>` to stderr
+    and returns non-zero on non-2xx. AC-6 (azdo), AC-7.
+
+- [x] `T6` — B7: gh specclaw-pr title from H1
+  - Files: `plugins/specclaw/bin/specclaw-pr`
+  - Estimate: small
+  - Notes: Same `build_pr_title` fix as T5, 72-char cap unchanged. AC-6 (gh).
+
+- [x] `T7` — B9: build finalize surfaces git checkout stderr
+  - Files: `plugins/specclaw/bin/specclaw-build`
+  - Estimate: small
+  - Notes: In `cmd_finalize`, capture stderr of `git checkout "$main_branch"` and append it to the
+    `errors+=("Failed to checkout … for merge")` message. AC-8.
+
+### Wave 2 — Regression suite
+
+- [x] `T8` — Parser-contract regression tests + fixtures
+  - Files: `plugins/specclaw/tests/run-parser-tests.sh`, `plugins/specclaw/tests/fixtures/`
+  - Estimate: medium
+  - Depends: T1, T2
+  - Notes: Plain-bash script (no framework). Fixtures = template-shaped `tasks.md` (with Legend
+    fence) and `spec.md` (both AC formats). Assert: `parse-tasks` and `validate-change` agree on
+    task counts; `verify collect` returns the expected ACs + files; the in-repo `build-engine`
+    spec/tasks still parse (NFR2). Single command runs all. AC-9.
+
+---
+
+## Legend
+
+Status markers: pending, in-progress (`~`), complete (`x`), failed (`!`).
+
+Each task line is `` `T<id>` — <title> `` followed by indented `Files:` / `Estimate:` /
+`Depends:` / `Notes:` detail lines.

--- a/.specclaw/changes/lifecycle-bug-fixes/verify-report.md
+++ b/.specclaw/changes/lifecycle-bug-fixes/verify-report.md
@@ -1,0 +1,30 @@
+# Verify Report: lifecycle-bug-fixes
+
+**Verdict:** PASS
+**Date:** 2026-06-14
+
+## Acceptance Criteria Results
+
+| AC | Description (short) | Result | Evidence (command + key output) |
+|----|---------------------|--------|---------------------------------|
+| AC-1 (B2) | `validate-change verify` counts only real `` `T<n>` `` tasks; ignores fenced Legend lines | ✅ PASS | `validate-change .specclaw lifecycle-bug-fixes verify` → `✅ Ready for verify` (EXIT 0); status line `tasks.md (8/8 complete)`. /tmp fixture with a Legend fence containing two `` - [ ] `T<n>` `` lines + 2 real `[x]` tasks → `tasks.md (2/2 complete)` and `✅ Ready` — fence lines correctly NOT counted. |
+| AC-2 (B3) | `verify collect` parses `AC1`/`AC-1`, with/without checkbox & bold | ✅ PASS | Real change: `collect … | jq '.acceptance_criteria | length'` → `9` (non-empty). /tmp spec mixing `- **AC1** —`, `- [ ] **AC-1:**`, `- [ ] AC-2` → all 3 parsed, each non-empty. |
+| AC-3 (B4) | `changed_files` from `  - Files: \`...\`` bullet lines | ✅ PASS | Real change: `collect … | jq '.changed_files | length'` → `9`, paths include all touched bin/ scripts. /tmp tasks with `  - Files: \`src/x.ts\`, \`src/y.ts\`` → both extracted. |
+| AC-4 (B5) | `verify-context` runs on BSD sed, non-empty payload, no sed errors | ✅ PASS | On `uname=Darwin`: `verify-context .specclaw lifecycle-bug-fixes` → EXIT 0, stdout 60999 bytes, stderr empty, `grep -c 'invalid command code'` = 0. Script uses `sed_i()` helper (`sed -i ''` on Darwin). |
+| AC-5 (B6) | self-heal creates status.md; propose scaffolds it | ✅ PASS | (a) `verify update-status /tmp/ac5 heal PASS` with no status.md → `WARN: status.md not found; created from template`, `Updated status.md: Verify → ✅ Passed`, EXIT 0, file created with `\| Verify \| ✅ Passed \|`. (b) `skills/propose/SKILL.md:16` instructs generating `status.md` from `$CLAUDE_PLUGIN_ROOT/templates/status.md`. |
+| AC-6 (B7) | `build_pr_title` from `# Proposal:` H1, no newline, within cap | ✅ PASS | Both scripts read `^#[[:space:]]*Proposal:`, strip `*`/backtick/CR/LF, cap (specclaw-pr:72 lines 307-309; specclaw-azdo-pr:128 line 235). Replicated against real proposal.md → GH `[specclaw] lifecycle-bug-fixes: lifecycle-bug-fixes — fix 9 bugs in t...` (len 72, 0 embedded newlines); ADO len 110 ≤ 128. Derived from H1, not Problem prose. |
+| AC-7 (B8) | `adoapi_post` no `curl -f`; prints `ADO HTTP <code>: <body>`, non-zero on non-2xx | ✅ PASS | Code (lines 308-329): `curl -s` (no `-f`), `-w $'\n%{http_code}'`, splits code/body, on non-2xx `echo "ADO HTTP ${code}: ${body}" >&2; return 1`; 2xx returns body (empty-body-safe). Stubbed-curl simulation of 409 → stderr `ADO HTTP 409: {"message":"TF401179: dup PR",...}`, RC=1. |
+| AC-8 (B9) | `finalize` checkout error includes `git checkout` stderr | ✅ PASS | specclaw-build lines 345/358: `checkout_err="$(git checkout "$main_branch" 2>&1 >/dev/null)"` then `errors+=("Failed to checkout $main_branch for merge: $checkout_err")` — captured stderr appended. |
+| AC-9 (tests) | regression script runs & passes | ✅ PASS | `bash plugins/specclaw/tests/run-parser-tests.sh` → `13 passed, 0 failed`, EXIT 0. |
+
+## Tests
+`run-parser-tests.sh`: **13 passed / 0 failed** (EXIT 0). Covers parse-tasks T-id extraction & statuses, B2 fence/legend exclusion (1/2 and 1/3 lines), B3 three AC formats (AC-1/AC2/AC-3, no empty entries), B4 bulleted `Files:` paths, and NFR2 regression on the real in-repo `build-engine` change (6 tasks, 10 ACs found — no regression).
+
+## Notes / Concerns
+- **Legend-fence nuance (AC-1):** `parse-tasks` emits a benign `WARNING: Skipping malformed task … (no task ID): - [ ] \`T<n>\`` for the literal placeholder — correct (placeholder not counted); `validate-change`'s awk counters likewise exclude it via the `` `T[0-9]+` `` requirement and fence tracking.
+- **No live ADO/GitHub calls possible** (no creds): AC-6 verified by replicating `build_pr_title` against the real proposal.md; AC-7 verified by code inspection plus a stubbed-`curl` simulation of a 409. AC-8 verified by code inspection.
+- **JSON escaping is correct:** the real change's AC text contains literal backtick sequences; `json_escape` escapes backslashes first, so `collect` output is valid JSON (`jq .` succeeds).
+- **Repo state untouched:** verifier's `update-status` test wrote only to /tmp; /tmp artifacts cleaned up.
+
+## Verdict Rationale
+All 9 acceptance criteria pass with direct evidence — three exercised live against the actual change (AC-1, AC-2/3 via collect, AC-4 on macOS BSD sed, AC-9 suite 13/0), and the PR/ADO/finalize criteria (AC-6/7/8) confirmed by code inspection plus behavioral replication/stub since no live credentials exist. No regressions and no blocking issues.

--- a/plugins/specclaw/bin/specclaw-azdo-pr
+++ b/plugins/specclaw/bin/specclaw-azdo-pr
@@ -212,16 +212,21 @@ build_pr_title() {
   local proposal_file="$CHANGE_DIR/proposal.md"
   local summary=""
   if [[ -f "$proposal_file" ]]; then
+    # Derive the title from the proposal H1: "# Proposal: <real title>"
     while IFS= read -r line; do
-      [[ -z "${line// /}" ]] && continue
-      [[ "$line" =~ ^# ]]    && continue
-      [[ "$line" =~ ^\*\* ]] && continue
-      summary="$line"; break
+      if [[ "$line" =~ ^#[[:space:]]*Proposal: ]]; then
+        summary="${line#*Proposal:}"
+        # trim leading/trailing whitespace
+        summary="${summary#"${summary%%[![:space:]]*}"}"
+        summary="${summary%"${summary##*[![:space:]]}"}"
+        break
+      fi
     done < "$proposal_file"
   fi
   local title
   if [[ -n "$summary" ]]; then
     summary="${summary//\*/}"; summary="${summary//\`/}"
+    summary="${summary//$'\r'/}"; summary="${summary//$'\n'/ }"
     title="[specclaw] ${CHANGE_NAME}: ${summary}"
   else
     title="[specclaw] ${CHANGE_NAME}"
@@ -305,10 +310,22 @@ adoapi_post() {
   local url="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_apis/${path}"
   local auth
   auth="$(printf ':%s' "$AZDO_TOKEN" | base64 -w0 2>/dev/null || printf ':%s' "$AZDO_TOKEN" | base64)"
-  curl -sf -X POST "$url" \
+  # No -f: with --fail curl exits 22 and discards the body, losing ADO error
+  # diagnostics (e.g. TF401179, HTTP 409). Capture body + status via -w and split.
+  local raw code body
+  raw="$(curl -s -X POST "$url" \
     -H "Authorization: Basic ${auth}" \
     -H "Content-Type: application/json" \
-    -d "$data"
+    -d "$data" \
+    -w $'\n%{http_code}')"
+  code="${raw##*$'\n'}"
+  body="${raw%$'\n'*}"
+  if [[ "$code" =~ ^2[0-9][0-9]$ ]]; then
+    printf '%s' "$body"
+  else
+    echo "ADO HTTP ${code}: ${body}" >&2
+    return 1
+  fi
 }
 
 adoapi_get() {

--- a/plugins/specclaw/bin/specclaw-build
+++ b/plugins/specclaw/bin/specclaw-build
@@ -341,7 +341,9 @@ cmd_finalize() {
 
     if [[ "$current_branch" == "$branch_name" ]]; then
       # Switch to main and merge
-      if git checkout "$main_branch" 2>/dev/null; then
+      local checkout_err checkout_rc=0
+      checkout_err="$(git checkout "$main_branch" 2>&1 >/dev/null)" || checkout_rc=$?
+      if [[ $checkout_rc -eq 0 ]]; then
         if git merge --no-ff "$branch_name" -m "Merge $branch_name" 2>&1; then
           merged=true
           # Clean up feature branch
@@ -353,7 +355,7 @@ cmd_finalize() {
           errors+=("Merge conflict merging $branch_name into $main_branch — manual resolution required")
         fi
       else
-        errors+=("Failed to checkout $main_branch for merge")
+        errors+=("Failed to checkout $main_branch for merge: $checkout_err")
       fi
     else
       warn "Not on feature branch ($current_branch != $branch_name) — skipping merge"

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -277,21 +277,27 @@ build_pr_title() {
   local summary=""
 
   if [[ -f "$proposal_file" ]]; then
-    # First non-blank, non-header, non-bold, non-status line
+    # Derive summary from the proposal title: "# Proposal: <title>"
     while IFS= read -r line; do
-      [[ -z "${line// /}" ]] && continue
-      [[ "$line" =~ ^# ]] && continue
-      [[ "$line" =~ ^\*\* ]] && continue
-      summary="$line"
-      break
+      if [[ "$line" =~ ^#[[:space:]]*Proposal: ]]; then
+        # Strip leading "#" and "Proposal:" prefix, then trim whitespace
+        summary="${line#\#}"
+        summary="${summary#"${summary%%[![:space:]]*}"}"   # ltrim
+        summary="${summary#Proposal:}"
+        summary="${summary#"${summary%%[![:space:]]*}"}"   # ltrim
+        summary="${summary%"${summary##*[![:space:]]}"}"   # rtrim
+        break
+      fi
     done < "$proposal_file"
   fi
 
   local title
   if [[ -n "$summary" ]]; then
-    # Strip markdown
+    # Strip markdown and guard against stray CR/newline
     summary="${summary//\*/}"
     summary="${summary//\`/}"
+    summary="${summary//$'\r'/}"
+    summary="${summary//$'\n'/}"
     title="[specclaw] ${CHANGE_NAME}: ${summary}"
   else
     title="[specclaw] ${CHANGE_NAME}"

--- a/plugins/specclaw/bin/specclaw-validate-change
+++ b/plugins/specclaw/bin/specclaw-validate-change
@@ -132,25 +132,42 @@ fail() {
   FAILURES+=("$1")
 }
 
-# Count tasks by marker in tasks.md
+# Count tasks in tasks.md, mirroring specclaw-parse-tasks:
+#   - tracks ``` code fences and ignores lines inside them
+#   - only counts top-level checkbox lines with a backtick-wrapped `T[0-9]+` id
 count_tasks() {
   local file="$1" marker="$2"
   local n
-  n=$(grep -c "^- \[${marker}\]" "$file" 2>/dev/null) || true
+  n=$(awk -v m="$marker" '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    $0 ~ ("^- \\[" m "\\].*`T[0-9]+`") { c++ }
+    END { print c+0 }
+  ' "$file" 2>/dev/null) || true
   echo "${n:-0}"
 }
 
 count_incomplete() {
   local file="$1"
   local n
-  n=$(grep -cE '^\- \[( |~|!)\]' "$file" 2>/dev/null) || true
+  n=$(awk '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    /^- \[( |~|!)\].*`T[0-9]+`/ { c++ }
+    END { print c+0 }
+  ' "$file" 2>/dev/null) || true
   echo "${n:-0}"
 }
 
 count_total() {
   local file="$1"
   local n
-  n=$(grep -cE '^\- \[.\]' "$file" 2>/dev/null) || true
+  n=$(awk '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    /^- \[.\].*`T[0-9]+`/ { c++ }
+    END { print c+0 }
+  ' "$file" 2>/dev/null) || true
   echo "${n:-0}"
 }
 

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -96,13 +96,18 @@ cmd_collect() {
   [ -f "$tasks_file" ] || die "tasks.md not found at ${tasks_file}"
 
   # 1. Extract acceptance criteria
+  # Tolerant match: optional "- [ ] " or "- "/"* " bullet, optional "**bold**",
+  # then "AC" + optional "-" + a digit. Accepts e.g.
+  #   - [ ] **AC-1:** text      - **AC1** — text      - [ ] AC-2 text
   local ac_lines=()
   while IFS= read -r line; do
-    # Strip the checkbox prefix and bold markers to get clean AC text
+    # Strip optional bullet/checkbox prefix and bold markers to get clean AC text
     local clean
-    clean=$(printf '%s' "$line" | sed 's/^[[:space:]]*- \[ \] \*\*//' | sed 's/^[[:space:]]*- \[ \] //' | sed 's/\*\*$//' | sed 's/\*\*//')
+    clean=$(printf '%s' "$line" \
+      | sed -E 's/^[[:space:]]*([-*][[:space:]]+)?(\[ \][[:space:]]+)?//' \
+      | sed 's/\*\*//g')
     ac_lines+=("$clean")
-  done < <(grep -E '^\s*- \[ \] (\*\*)?AC-' "$spec_file" || true)
+  done < <(grep -E '^[[:space:]]*([-*][[:space:]]+)?(\[ \][[:space:]]+)?(\*\*)?AC-?[0-9]' "$spec_file" || true)
 
   # 2. Collect file paths from tasks.md Files: fields
   local file_paths=()
@@ -123,7 +128,7 @@ cmd_collect() {
         [ -n "$p" ] && file_paths+=("$p")
       done
     fi
-  done < <(grep -iE '^\s*\*?\*?Files\*?\*?\s*:' "$tasks_file" || true)
+  done < <(grep -iE '^[[:space:]]*([-*][[:space:]]+)?\*?\*?Files\*?\*?[[:space:]]*:' "$tasks_file" || true)
 
   # Deduplicate file paths
   local unique_paths=()
@@ -293,7 +298,25 @@ cmd_update_status() {
   local change_dir="${specclaw_dir}/changes/${change_name}"
   local status_file="${change_dir}/status.md"
 
-  [ -f "$status_file" ] || die "status.md not found at ${status_file}"
+  # Self-heal: if status.md is absent, create it from the template so the
+  # Verify-row update below can proceed.
+  if [ ! -f "$status_file" ]; then
+    local template_file="$(cd "$(dirname "$0")/.." && pwd)/templates/status.md"
+    if [ -f "$template_file" ]; then
+      mkdir -p "$change_dir"
+      local today
+      today=$(date +%Y-%m-%d)
+      sed -e "s/{{title}}/${change_name}/g" \
+          -e "s/{{change_name}}/${change_name}/g" \
+          -e "s/{{date}}/${today}/g" \
+          -e "s/{{updated}}/${today}/g" \
+          -e "s/{{[a-zA-Z_]*}}/-/g" \
+          "$template_file" > "$status_file"
+      warn "status.md not found; created from template at ${status_file}"
+    else
+      die "status.md not found at ${status_file} and template missing at ${template_file}"
+    fi
+  fi
 
   # Determine status emoji
   local status_text

--- a/plugins/specclaw/bin/specclaw-verify-context
+++ b/plugins/specclaw/bin/specclaw-verify-context
@@ -3,6 +3,17 @@
 # Part of the specclaw skill. Bash + coreutils only (jq optional).
 set -euo pipefail
 
+# Portable sed -i for both GNU (Linux) and BSD (macOS) sed.
+# BSD sed requires an explicit empty string after -i; GNU sed does not.
+sed_i() {
+  local expr="$1"; shift
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$expr" "$@"
+  else
+    sed -i "$expr" "$@"
+  fi
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -221,15 +232,35 @@ awk '
   found { print }
 ' "$PROMPTS_FILE" > "$TEMPLATE_FILE"
 
-# Strip leading/trailing blank lines
-sed -i '/./,$!d' "$TEMPLATE_FILE"
-# Remove trailing blank lines
-sed -i -e :a -e '/^\s*$/{ $d; N; ba; }' "$TEMPLATE_FILE"
+# Strip leading and trailing blank lines (portable; avoids GNU-only sed addressing).
+# Buffer all lines, then emit from the first non-blank line through the last
+# non-blank line.
+TRIM_FILE=$(mktemp)
+awk '
+  { lines[NR] = $0 }
+  /[^[:space:]]/ { if (!first) first = NR; last = NR }
+  END {
+    if (first) for (i = first; i <= last; i++) print lines[i]
+  }
+' "$TEMPLATE_FILE" > "$TRIM_FILE"
+mv "$TRIM_FILE" "$TEMPLATE_FILE"
 
-# If the template is wrapped in a code fence, strip first and last fence lines
+# If the template is wrapped in a code fence, strip first and last fence lines.
 if head -1 "$TEMPLATE_FILE" | grep -qE '^\s*```'; then
-  sed -i '1d' "$TEMPLATE_FILE"
-  sed -i '${ /^```/d }' "$TEMPLATE_FILE"
+  # Drop the opening fence (line 1) via the portable sed wrapper.
+  sed_i '1d' "$TEMPLATE_FILE"
+  # Drop the closing fence (last line, only if it is a fence) via awk: the
+  # GNU "${ /^```/d }" block form is not portable to BSD sed.
+  FENCE_FILE=$(mktemp)
+  awk '
+    { lines[NR] = $0 }
+    END {
+      end = NR
+      if (lines[NR] ~ /^```/) end = NR - 1
+      for (i = 1; i <= end; i++) print lines[i]
+    }
+  ' "$TEMPLATE_FILE" > "$FENCE_FILE"
+  mv "$FENCE_FILE" "$TEMPLATE_FILE"
 fi
 
 [ -s "$TEMPLATE_FILE" ] || die "Could not extract Verify Agent template from agent-prompts.md"

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -13,6 +13,7 @@ Create a new proposal for a change.
 1. Slugify the user's idea into a `<change-name>` (lowercase, hyphens, no spaces).
 2. Create `.specclaw/changes/<change-name>/`.
 3. Generate `proposal.md` from `$CLAUDE_PLUGIN_ROOT/templates/proposal.md`. Fill in: problem statement, proposed solution, scope (in / out), impact (files, complexity, risk), open questions.
+   - Also generate `.specclaw/changes/<change-name>/status.md` from `$CLAUDE_PLUGIN_ROOT/templates/status.md`. Fill in: `{{title}}` and `{{change_name}}`, `{{date}}` / `{{updated}}` with today's date, and the phase rows — set Proposal status to `🟡 Draft` and the remaining phases (Spec, Design, Tasks, Build, Verify) to pending. Leave task/agent/issue sections empty for now.
 4. Present the proposal to the user for review.
 5. Update `.specclaw/STATUS.md` via `specclaw-update-status .specclaw`.
 6. **GitHub sync** (if `github.sync: true` in `config.yaml`): run `specclaw-gh-sync create .specclaw <change-name>` to create a GitHub Issue for the proposal. Validation (proposal.md must exist) is enforced by `specclaw-validate-change`.

--- a/plugins/specclaw/tests/fixtures/spec.md
+++ b/plugins/specclaw/tests/fixtures/spec.md
@@ -1,0 +1,18 @@
+# Spec: Fixture Change — AC Format Coverage
+
+## Overview
+
+Template-shaped spec.md used to lock in B3: acceptance criteria written in several
+real-world shapes must all be collected by `specclaw-verify collect`.
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- [ ] **AC-1:** Checkbox + bold + hyphenated id form
+- **AC2** — Bullet + bold, no checkbox, non-hyphenated id form
+- [ ] AC-3 Checkbox, no bold, hyphenated id form
+
+## Notes
+
+These three lines are the only acceptance criteria in this fixture.

--- a/plugins/specclaw/tests/fixtures/tasks-fenced-id.md
+++ b/plugins/specclaw/tests/fixtures/tasks-fenced-id.md
@@ -1,0 +1,31 @@
+# Tasks: B2 Fence/Legend Exclusion
+
+**Change:** b2-fence
+
+## Tasks
+
+### Wave 1 — Real work
+
+- [x] `T1` — Real complete task
+  - Files: `src/a.ts`
+  - Estimate: small
+
+- [ ] `T2` — Real pending task
+  - Files: `src/b.ts`
+  - Estimate: small
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T9` — Numeric task id inside a fenced block (must NOT be counted)
+  - Files: `should/not/count.ts`
+- [x] `T8` — Another fenced complete example (must NOT be counted)
+```

--- a/plugins/specclaw/tests/fixtures/tasks.md
+++ b/plugins/specclaw/tests/fixtures/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Fixture Change — Parser Regression
+
+**Change:** fixture-change
+**Created:** 2026-06-14
+**Total Tasks:** 3
+
+## Summary
+
+Template-shaped tasks.md used to lock in B2 (fence/legend exclusion) and B4 (bulleted Files: lines).
+
+## Tasks
+
+### Wave 1 — Foundation
+
+- [x] `T1` — Real complete task
+  - Files: `src/a.ts`, `src/b.ts`
+  - Estimate: small
+  - Notes: Done.
+
+- [ ] `T2` — Real pending task
+  - Files: `src/c.ts`
+  - Estimate: medium
+
+### Wave 2 — Integration
+
+- [~] `T3` — Real in-progress task
+  - Files: `src/d.ts`
+  - Depends: T1, T2
+  - Estimate: large
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T<n>` — <title>
+  - Files: <files to create/modify>
+  - Estimate: small | medium | large
+  - Depends: <task ids> (if any)
+  - Notes: <additional context>
+```

--- a/plugins/specclaw/tests/run-parser-tests.sh
+++ b/plugins/specclaw/tests/run-parser-tests.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# run-parser-tests.sh — regression suite for specclaw's bin parsers.
+#
+# Locks in the recently fixed behaviors:
+#   B2: validate-change task counting ignores ``` fenced blocks and only
+#       counts backtick-wrapped `T<n>` ids.
+#   B3: verify collect parses ACs as AC1 / AC-1, with/without `- [ ]`,
+#       with/without **bold**.
+#   B4: verify collect parses `Files:` lines that begin with a `  - ` bullet.
+# Plus NFR2: existing in-repo change docs still parse (no regression).
+#
+# Plain bash only — no bats/npm. Run from anywhere:
+#   bash plugins/specclaw/tests/run-parser-tests.sh
+# Exits non-zero if any case fails.
+
+set -uo pipefail
+
+# --- Resolve own dir and locate ../bin ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+BIN_DIR="$(cd "$SCRIPT_DIR/../bin" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PARSE_TASKS="$BIN_DIR/specclaw-parse-tasks"
+VALIDATE_CHANGE="$BIN_DIR/specclaw-validate-change"
+VERIFY="$BIN_DIR/specclaw-verify"
+
+for b in "$PARSE_TASKS" "$VALIDATE_CHANGE" "$VERIFY"; do
+  if [[ ! -x "$b" && ! -f "$b" ]]; then
+    echo "FATAL: missing bin script: $b" >&2
+    exit 2
+  fi
+done
+
+# --- mktemp workspace with a real .specclaw-like layout (changes/<name>/) ---
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label (= '$actual')"
+  else
+    fail "$label (expected '$expected', got '$actual')"
+  fi
+}
+
+# Build a change dir under the temp workspace and echo its specclaw_dir.
+# Usage: make_change <change_name> [spec_fixture] [tasks_fixture]
+make_change() {
+  local name="$1" spec="${2:-}" tasks="${3:-}"
+  local cdir="$WORK/changes/$name"
+  mkdir -p "$cdir"
+  [[ -n "$spec" ]] && cp "$FIXTURES_DIR/$spec" "$cdir/spec.md"
+  [[ -n "$tasks" ]] && cp "$FIXTURES_DIR/$tasks" "$cdir/tasks.md"
+  echo "$cdir"
+}
+
+echo "=== specclaw bin parser regression suite ==="
+echo "bin:      $BIN_DIR"
+echo "fixtures: $FIXTURES_DIR"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 1 — parse-tasks finds exactly the real T-tasks (template Legend +
+# fenced `T<n>` placeholder are not numeric ids, so they are not picked up).
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 1: parse-tasks finds exactly the real T-tasks ---"
+c1="$(make_change c1-tasks "" tasks.md)"
+ids="$("$PARSE_TASKS" "$c1/tasks.md" | jq -r '[.[].id] | sort | join(",")')"
+assert_eq "parse-tasks task ids" "T1,T2,T3" "$ids"
+# Statuses round-trip correctly for the three markers.
+st="$("$PARSE_TASKS" "$c1/tasks.md" | jq -r '[.[] | .status] | join(",")')"
+assert_eq "parse-tasks statuses (x,space,~)" "complete,pending,in_progress" "$st"
+# --validate exits 0 on well-formed output.
+if "$PARSE_TASKS" --validate "$c1/tasks.md" >/dev/null 2>&1; then
+  pass "parse-tasks --validate exits 0"
+else
+  fail "parse-tasks --validate exits 0"
+fi
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 2 — B2: validate-change `status` counts only real backtick T-ids,
+# excluding the fenced block (numeric `T9`/`T8` examples) and bare legend lines.
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 2 (B2): validate-change status excludes fence + legend ---"
+c2="$(make_change b2-fence "" tasks-fenced-id.md)"
+line="$("$VALIDATE_CHANGE" "$WORK" b2-fence status | grep -o 'tasks.md ([0-9]*/[0-9]* complete)')"
+# Real tasks: T1 [x], T2 [ ] -> 1 complete of 2 total. Fenced T9/T8 ignored.
+assert_eq "B2 status line" "tasks.md (1/2 complete)" "$line"
+
+# Same fixture against the c1 tasks (which has 3 real tasks, 1 complete) to
+# confirm counting tracks the real markers and not the fenced placeholder.
+line1="$("$VALIDATE_CHANGE" "$WORK" c1-tasks status | grep -o 'tasks.md ([0-9]*/[0-9]* complete)')"
+assert_eq "B2 status line (case-1 tasks)" "tasks.md (1/3 complete)" "$line1"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 3 — B3: verify collect parses all three AC formats.
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 3 (B3): verify collect parses mixed AC formats ---"
+c3="$(make_change b3-ac spec.md tasks.md)"
+ac_count="$("$VERIFY" collect "$WORK" b3-ac 2>/dev/null | jq '.acceptance_criteria | length')"
+assert_eq "AC count" "3" "$ac_count"
+# Each AC line is non-empty and the AC ids are all represented.
+ac_join="$("$VERIFY" collect "$WORK" b3-ac 2>/dev/null | jq -r '.acceptance_criteria | join("\n")')"
+for needle in "AC-1" "AC2" "AC-3"; do
+  if grep -q "$needle" <<<"$ac_join"; then
+    pass "AC contains $needle"
+  else
+    fail "AC contains $needle"
+  fi
+done
+empty_acs="$("$VERIFY" collect "$WORK" b3-ac 2>/dev/null | jq '[.acceptance_criteria[] | select(. == "")] | length')"
+assert_eq "no empty AC entries" "0" "$empty_acs"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 4 — B4: verify collect parses `  - Files:` bullet lines.
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 4 (B4): verify collect parses bulleted Files: lines ---"
+# Reuse the b3-ac change (its tasks.md has `  - Files:` bullets with backticks).
+paths="$("$VERIFY" collect "$WORK" b3-ac 2>/dev/null | jq -r '[.changed_files[].path] | sort | join(",")')"
+assert_eq "changed_files paths" "src/a.ts,src/b.ts,src/c.ts,src/d.ts" "$paths"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 5 — NFR2: existing in-repo change still parses (no regression).
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 5 (NFR2): real in-repo change still parses ---"
+REAL_SPECCLAW="$REPO_ROOT/.specclaw"
+REAL_CHANGE="build-engine"
+if [[ ! -f "$REAL_SPECCLAW/changes/$REAL_CHANGE/spec.md" ]]; then
+  # Fallback: pick any change that has both spec.md and tasks.md.
+  for d in "$REAL_SPECCLAW"/changes/*/; do
+    if [[ -f "$d/spec.md" && -f "$d/tasks.md" ]]; then
+      REAL_CHANGE="$(basename "$d")"
+      break
+    fi
+  done
+fi
+
+if [[ -f "$REAL_SPECCLAW/changes/$REAL_CHANGE/spec.md" && -f "$REAL_SPECCLAW/changes/$REAL_CHANGE/tasks.md" ]]; then
+  echo "    using real change: $REAL_CHANGE"
+  real_ids="$("$PARSE_TASKS" "$REAL_SPECCLAW/changes/$REAL_CHANGE/tasks.md" | jq 'length')"
+  if [[ "$real_ids" -gt 0 ]]; then
+    pass "NFR2 parse-tasks found $real_ids tasks in $REAL_CHANGE"
+  else
+    fail "NFR2 parse-tasks found 0 tasks in $REAL_CHANGE"
+  fi
+  real_acs="$("$VERIFY" collect "$REAL_SPECCLAW" "$REAL_CHANGE" 2>/dev/null | jq '.acceptance_criteria | length')"
+  if [[ "$real_acs" -gt 0 ]]; then
+    pass "NFR2 verify collect found $real_acs ACs in $REAL_CHANGE"
+  else
+    fail "NFR2 verify collect found 0 ACs in $REAL_CHANGE"
+  fi
+else
+  fail "NFR2 could not locate a real change with spec.md + tasks.md under $REAL_SPECCLAW"
+fi
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo "=================================================="
+echo "$PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes **8 bugs** (B2–B9 from `SPECCLAW-BUGS.md`) that broke or silently degraded the
`propose → plan → build → verify → pr` lifecycle on macOS/BSD. Built and verified through the
specclaw lifecycle itself — **dogfooded against this very change** (the fixed `validate-change`,
`verify collect`, and `verify-context` all ran clean on this change's own artifacts).

B1 (multi-version cache resolution) is **parked** by request — remains documented in `SPECCLAW-BUGS.md`.

## Fixes

| Bug | Fix | File |
|-----|-----|------|
| B2 🔴 | Task counting ignores ``` fences, requires `` `T<digits>` `` ids (matches `parse-tasks`) | `bin/specclaw-validate-change` |
| B3 🟠 | `collect` parses `AC1`/`AC-1`, with/without checkbox & bold | `bin/specclaw-verify` |
| B4 🟠 | `collect` parses `  - Files:` bullet lines | `bin/specclaw-verify` |
| B5 🔴 | Portable `sed` — no temp path in script position; runs on BSD/macOS sed | `bin/specclaw-verify-context` |
| B6 🔴 | `update-status` self-heals missing `status.md`; `propose` scaffolds it | `bin/specclaw-verify`, `skills/propose/SKILL.md` |
| B7 🔴 | PR title from `# Proposal:` H1 (not Problem prose) — **both** PR paths | `bin/specclaw-azdo-pr`, `bin/specclaw-pr` |
| B8 🟠 | Surface ADO HTTP status + body on non-2xx (drop `curl -f`) | `bin/specclaw-azdo-pr` |
| B9 🟡 | `finalize` includes `git checkout` stderr in merge error | `bin/specclaw-build` |

## Tests

New plain-bash regression suite (`plugins/specclaw/tests/run-parser-tests.sh`, **13/13 pass**)
locks the template→parser contract and guards against regressing existing in-repo specs (NFR2,
validated against the real `build-engine` change).

## Verification

Verdict **PASS** — all 9 acceptance criteria pass with direct evidence. Full report:
`.specclaw/changes/lifecycle-bug-fixes/verify-report.md`. Tracked in #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)