### PR TITLE
fix(gh-sync): skip issue creation when repo has Issues disabled (B10)

### DIFF
--- a/plugins/specclaw/bin/specclaw-gh-sync
+++ b/plugins/specclaw/bin/specclaw-gh-sync
@@ -194,6 +194,32 @@ detect_repo() {
   REPO="${REPO%.git}"
 }
 
+# ─── Issues-enabled Detection ──────────────────────────────────────────────────
+# Echoes "true" if the repo has GitHub Issues enabled, "false" if disabled,
+# "" if the state could not be determined. Requires REPO + auth already set.
+repo_has_issues() {
+  if [[ "$AUTH_METHOD" == "gh" ]]; then
+    gh repo view "$REPO" --json hasIssuesEnabled -q '.hasIssuesEnabled' 2>/dev/null || true
+  else
+    local tmp http_code
+    tmp="$(mktemp)"
+    http_code="$(curl -s -w '%{http_code}' -o "$tmp" \
+      "https://api.github.com/repos/$REPO" \
+      -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github.v3+json")"
+    if [[ "$http_code" -ge 400 ]]; then
+      rm -f "$tmp"; echo ""; return
+    fi
+    if grep -q '"has_issues"[[:space:]]*:[[:space:]]*true' "$tmp"; then
+      rm -f "$tmp"; echo "true"
+    elif grep -q '"has_issues"[[:space:]]*:[[:space:]]*false' "$tmp"; then
+      rm -f "$tmp"; echo "false"
+    else
+      rm -f "$tmp"; echo ""
+    fi
+  fi
+}
+
 # ─── Config ───────────────────────────────────────────────────────────────────
 
 find_config() {
@@ -275,7 +301,16 @@ api_create_issue() {
   esc_label="$(json_escape "$label")"
 
   if [[ "$AUTH_METHOD" == "gh" ]]; then
-    gh issue create --repo "$REPO" --title "$title" --body "$body" --label "$label" 2>&1
+    # Capture output AND exit code: on failure gh writes an error to stderr that
+    # must NOT be returned as a "response" (the caller scrapes /issues/<n> from
+    # it and would fabricate a bogus issue number — e.g. when Issues are
+    # disabled). Fail loudly instead.
+    local out rc=0
+    out="$(gh issue create --repo "$REPO" --title "$title" --body "$body" --label "$label" 2>&1)" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+      die "gh issue create failed: $out"
+    fi
+    echo "$out"
   else
     api_curl POST "https://api.github.com/repos/$REPO/issues" \
       "{\"title\":\"$esc_title\",\"body\":\"$esc_body\",\"labels\":[\"$esc_label\"]}"
@@ -603,6 +638,16 @@ cmd_create() {
 
   detect_auth "$config_file"
   detect_repo "$config_file"
+
+  # Don't attempt creation if the repo has Issues disabled — gh/curl would fail
+  # and we'd otherwise risk recording a fabricated issue number. Skip gracefully
+  # (sync is best-effort; the lifecycle continues without a tracking issue).
+  local has_issues
+  has_issues="$(repo_has_issues)"
+  if [[ "$has_issues" == "false" ]]; then
+    warn "GitHub Issues are disabled for $REPO — skipping issue creation (no tracking issue recorded)."
+    exit 0
+  fi
 
   local label
   label="$(get_label "$config_file")"


### PR DESCRIPTION
## Summary

Fixes **B10**: `specclaw-gh-sync create` could record a **fabricated issue number** in `status.md`
when the configured `github.repo` has GitHub Issues disabled.

**Root cause:** `api_create_issue` runs `gh issue create … 2>&1`, folding gh's *error* output into
the returned "response". The caller (`cmd_create`) then greps `/issues/<n>` out of that text — so a
failed creation could yield a bogus number that downstream steps trust.

## Fix

- **Precheck** — new `repo_has_issues()` (gh: `hasIssuesEnabled`; curl: `has_issues`). `cmd_create`
  now `warn`s and skips gracefully when Issues are disabled — no bogus number, no `status.md` write,
  exit 0 (sync is best-effort).
- **Harden** `api_create_issue` (gh mode) — capture the exit code and `die` with gh's message on
  failure, instead of returning error text for the caller to scrape.

## Verification

```
$ specclaw-gh-sync create <dir-with-issues-disabled-repo> demo
WARN: GitHub Issues are disabled for chan4lk/specclaw — skipping issue creation (no tracking issue recorded).
exit=0    # → GOOD: no status.md, no fabricated number
```
The Issues-enabled happy path is unchanged (still creates the issue and records its real number).

## Note

The `#15` confusion observed while resolving B2–B9 (PR #23) turned out to be **operator error**, not
this bug: `gh-sync` correctly created a real issue in the *configured* repo (`chanbistec/specclaw`,
Issues enabled), but a manual `gh issue close 15` defaulted to the git remote (`chan4lk/specclaw`,
Issues disabled). The latent scrape-on-failure bug fixed here is nonetheless real for any config
pointing at an Issues-disabled repo. See `SPECCLAW-BUGS.md` B10 for the full writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)