### PR TITLE
chore(config): align github.repo to chan4lk/specclaw

### DIFF
--- a/.specclaw/config.yaml
+++ b/.specclaw/config.yaml
@@ -5,7 +5,7 @@ version: 1
 project:
   name: "specclaw"
   description: "Spec-driven development framework for OpenClaw agents"
-  repo: "chanbistec/specclaw"
+  repo: "chan4lk/specclaw"
 
 # Model routing — use the best model for each phase
 models:
@@ -40,7 +40,7 @@ notifications:
 # GitHub Issues integration
 github:
   sync: true
-  repo: "chanbistec/specclaw"
+  repo: "chan4lk/specclaw"
   token: ""
   label: "specclaw"
 


### PR DESCRIPTION
## Summary

`.specclaw/config.yaml` pointed `project.repo` and `github.repo` at `chanbistec/specclaw`, while
this checkout's git remote `origin` is `chan4lk/specclaw`. That split meant `specclaw-gh-sync`
created/updated issues in a **different repo** than the one the lifecycle pushes PRs to — the source
of the `#15` cross-repo confusion during the B2–B9 work.

This aligns both repo fields to the actual remote, `chan4lk/specclaw`.

## Note

`chan4lk/specclaw` has GitHub **Issues disabled**. With `github.sync: true` (unchanged here),
`gh-sync create` now **skips gracefully** once the B10 fix (#24) is merged — no tracking issue, no
error. If you'd rather disable issue sync entirely, set `github.sync: false` (say the word and I'll
add it to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)