### PR TITLE
feat(propose): code-reviewer-agent — automated code review on verify

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.specclaw/changes/code-reviewer-agent/design.md
+++ b/.specclaw/changes/code-reviewer-agent/design.md
@@ -1,0 +1,171 @@
+# Design: Code Reviewer Agent
+
+**Change:** code-reviewer-agent
+**Created:** 2026-06-21
+
+## Architecture
+
+### Component Map
+
+```
+plugins/specclaw/
+├── agents/
+│   ├── spec-author.md          (existing)
+│   └── code-reviewer.md        ← NEW
+├── skills/
+│   ├── verify/SKILL.md         ← EDIT (add Step 3.5)
+│   └── pr/SKILL.md             ← EDIT (add code_review_block check)
+├── references/
+│   └── agent-prompts.md        ← EDIT (add Code Reviewer prompt template)
+└── templates/
+    └── config.yaml             ← EDIT (add workflow.code_review flags)
+
+README.md                       ← EDIT (document flags)
+```
+
+### Data Flow
+
+```
+/specclaw:verify
+  │
+  ├─ [existing] Step 1-3: collect evidence → verify agent → save verify-report.md
+  │
+  ├─ [NEW] Step 3.5: if workflow.code_review == true
+  │   ├─ read .specclaw/config.yaml → models.review
+  │   ├─ read .specclaw/changes/<change>/design.md  (may be absent → EC1)
+  │   ├─ read .specclaw/changes/<change>/tasks.md   (may have no files: → EC2)
+  │   ├─ spawn code-reviewer agent with:
+  │   │   • changed_files_content  (from Step 1 collect)
+  │   │   • design_content         (or "" if absent)
+  │   │   • tasks_content          (or "" if absent)
+  │   │   • spec_content           (existing)
+  │   ├─ write output → .specclaw/changes/<change>/review-report.md
+  │   └─ extract verdict → append one-line summary to verify-report.md
+  │
+  └─ [existing] Steps 4-7: save report, update status, sync, notify
+
+/specclaw:pr
+  │
+  ├─ [NEW] if workflow.code_review_block == true:
+  │   └─ read review-report.md → if verdict == CHANGES_REQUESTED → abort
+  │
+  └─ [existing] PR creation flow
+```
+
+## Agent File: `code-reviewer.md`
+
+### Frontmatter
+
+```yaml
+---
+name: code-reviewer
+description: Reviews changed files for a specclaw change across 10 quality dimensions. Produces review-report.md with BLOCK/WARN/NOTE findings and a APPROVED/CHANGES_REQUESTED/APPROVED_WITH_NOTES verdict. Runs inside /specclaw:verify when workflow.code_review is true.
+tools: [Read, Write, Bash]
+model: sonnet
+---
+```
+
+### System Prompt Structure
+
+1. **Identity** — "You are code-reviewer, a specclaw subagent..."
+2. **Inputs** — describe what will be provided in the invocation prompt
+3. **Review Dimensions** — table of 10 dimensions with description + "Follow YAGNI principles, and one-liner solutions." rule called out explicitly under D3 and D4
+4. **Severity Rules** — BLOCK / WARN / NOTE definitions
+5. **Verdict Rules** — APPROVED / CHANGES_REQUESTED / APPROVED_WITH_NOTES
+6. **Edge Case Handling** — EC1-EC5 from spec
+7. **Output Format** — exact `review-report.md` template
+8. **Guardrails** — inherit Rule 2 (Simplicity First) and Rule 3 (Surgical Changes) from `agent-guardrails.md`
+
+## Prompt Template in `agent-prompts.md`
+
+New section `## Code Reviewer Agent` after the existing `## Verify Agent` section.
+
+Variables: `{{change_name}}`, `{{changed_files_content}}`, `{{design_content}}`, `{{tasks_content}}`, `{{spec_content}}`
+
+The template follows the same `{{variable}}` substitution pattern as existing templates.
+
+## Verify SKILL.md — Step 3.5
+
+Inserted between existing Step 3 (Spawn verify agent) and Step 4 (Save report):
+
+```markdown
+## Step 3.5 — Code review (conditional)
+
+Read `workflow.code_review` from `.specclaw/config.yaml`.
+
+If `false` or not set, skip this step entirely.
+
+If `true`:
+1. Read `.specclaw/changes/<change>/design.md` (use empty string if absent).
+2. Read `.specclaw/changes/<change>/tasks.md` (use empty string if absent).
+3. Spawn the `code-reviewer` agent using the model from `config.yaml` `models.review`.
+   Pass: changed files content (from Step 1), spec content, design content, tasks content.
+4. Write the agent's output to `.specclaw/changes/<change>/review-report.md`.
+5. Extract the verdict line from `review-report.md` and append to `verify-report.md`:
+   `**Code Review:** <verdict> — <N findings: X BLOCK, Y WARN, Z NOTE>`
+```
+
+## PR SKILL.md — Block Check
+
+New block inserted near the top of the PR skill (before branch/PR creation), after existing pre-flight checks:
+
+```markdown
+## Pre-flight: code review block (conditional)
+
+If `workflow.code_review_block: true` in `.specclaw/config.yaml`:
+1. Check if `.specclaw/changes/<change>/review-report.md` exists.
+2. If it exists, read the verdict line.
+3. If verdict is `CHANGES_REQUESTED`, abort with:
+   "PR blocked: code review verdict is CHANGES_REQUESTED. Fix BLOCK findings in
+    review-report.md then re-run /specclaw:verify."
+   List all BLOCK findings from the report.
+4. If `review-report.md` does not exist, warn:
+   "code_review_block is enabled but no review-report.md found. Run
+    /specclaw:verify first."
+```
+
+## Config Template Changes
+
+```yaml
+# Workflow enforcement
+workflow:
+  strict: true
+  code_review: false        # Spawn code-reviewer agent during /specclaw:verify
+  code_review_block: false  # Block /specclaw:pr if code review verdict is CHANGES_REQUESTED
+```
+
+## `review-report.md` Format
+
+```markdown
+# Code Review Report: <change>
+
+**Reviewed:** YYYY-MM-DD
+**Model:** <model>
+**Verdict:** APPROVED | CHANGES_REQUESTED | APPROVED_WITH_NOTES
+
+## Summary
+<N findings: X BLOCK, Y WARN, Z NOTE>
+
+## Findings
+
+### [BLOCK] path/to/file.ts:42 — Correctness
+Problem: <description>
+Fix: <suggested fix>
+
+### [WARN] path/to/file.ts:17 — YAGNI
+Problem: <description>
+
+### [NOTE] path/to/file.ts:9 — One-liner opportunity
+Problem: <multi-line block>
+Fix: <one-liner equivalent>
+
+## Verdict Rationale
+<One paragraph explaining the verdict>
+```
+
+## Patterns Followed
+
+- Agent file structure mirrors `spec-author.md` (frontmatter, system prompt sections, guardrails reference)
+- Prompt template structure mirrors `## Verify Agent` in `agent-prompts.md`
+- Skill step numbering continues from existing verify steps (3 → 3.5 → 4)
+- Config flag pattern mirrors `workflow.strict` (boolean, default false, additive)

--- a/.specclaw/changes/code-reviewer-agent/proposal.md
+++ b/.specclaw/changes/code-reviewer-agent/proposal.md
@@ -1,0 +1,134 @@
+# Proposal: Code Reviewer Agent
+
+**Created:** 2026-06-21
+**Status:** 🟡 Draft
+
+## Problem
+
+The `/specclaw:verify` step validates acceptance criteria and runs test/lint/build commands, but it does **not** review code quality. A spec can be satisfied letter-by-letter while still shipping:
+
+- YAGNI violations (speculative abstractions, unused parameters, over-engineered generality)
+- Logic errors not covered by ACs (off-by-one, null dereference, unhandled edge cases)
+- Security issues (injection risks, hardcoded secrets, missing auth guards)
+- Naming/readability problems that compound over the life of the codebase
+- Design drift — implementation diverges from `design.md` without justification
+- Scope creep — files changed outside the declared task `files:` list
+- Multi-line implementations with trivial one-liner equivalents
+
+Projects that want code review as a gate before PR creation have no automated option in specclaw today. Human review on every change is expensive; zero review is risky.
+
+## Proposed Solution
+
+Add a `code-reviewer` agent (`plugins/specclaw/agents/code-reviewer.md`) that performs structured, opinionated code review on the changed files for a given change. It runs as an opt-in step inside `/specclaw:verify` — gated by a new `workflow.code_review` flag in `config.yaml`.
+
+### Agent Behaviour
+
+The agent receives:
+- Changed files content (from `specclaw-verify collect` output)
+- `design.md` — to check implementation matches intended architecture
+- `tasks.md` — to check scope (files touched outside `files:` lists are flagged)
+- `spec.md` — to check no spec requirement was silently dropped or over-implemented
+
+It runs **10 review dimensions**, each producing zero or more findings:
+
+| # | Dimension | What it checks |
+|---|-----------|----------------|
+| 1 | **Correctness** | Logic errors, off-by-one, null/undefined dereference, incorrect conditionals |
+| 2 | **Security** | Injection risks, hardcoded secrets, missing input validation, improper auth checks |
+| 3 | **YAGNI / Simplicity** | Speculative abstractions, unused parameters, "flexibility" not in spec, premature generalisation |
+| 4 | **One-liner opportunities** | Multi-line blocks with idiomatic one-liner equivalents; follows "Follow YAGNI principles, and one-liner solutions" rule |
+| 5 | **Naming** | Misleading names, single-letter vars outside loops, inconsistency with existing codebase convention |
+| 6 | **Complexity** | Functions > ~30 lines, nesting depth > 3, cyclomatic complexity hot spots |
+| 7 | **Test quality** | Missing tests for changed logic, assertions that don't test observable behaviour, tests that mirror the implementation rather than the contract |
+| 8 | **Design adherence** | Implementation deviates from `design.md` without a documented reason |
+| 9 | **Scope creep** | Files modified outside declared `files:` in `tasks.md` |
+| 10 | **Dead code** | Added code that is never called; imports added but unused |
+
+Each finding is tagged by severity:
+- `🔴 BLOCK` — must fix before PR (security, correctness, design breach)
+- `🟡 WARN` — should fix (YAGNI, complexity, dead code)
+- `🟢 NOTE` — optional improvement (naming, one-liners)
+
+### Output
+
+`review-report.md` written to `.specclaw/changes/<change>/review-report.md`:
+
+```
+# Code Review Report: <change>
+
+**Reviewed:** YYYY-MM-DD
+**Verdict:** APPROVED | CHANGES_REQUESTED | APPROVED_WITH_NOTES
+
+## Summary
+<N findings: X BLOCK, Y WARN, Z NOTE>
+
+## Findings
+### [BLOCK] path/to/file.ts:42 — Correctness
+<description + suggested fix>
+
+### [WARN] path/to/other.ts:17 — YAGNI
+<description>
+
+...
+
+## Verdict Rationale
+<One paragraph>
+```
+
+Verdict rules:
+- `APPROVED` — zero BLOCK findings
+- `CHANGES_REQUESTED` — any BLOCK finding
+- `APPROVED_WITH_NOTES` — zero BLOCK, one or more WARN/NOTE
+
+### Config Integration
+
+New flag in `config.yaml` template:
+
+```yaml
+workflow:
+  strict: true
+  code_review: false        # Enable automated code reviewer agent on verify
+  code_review_block: false  # If true, CHANGES_REQUESTED verdict blocks /specclaw:pr
+```
+
+When `code_review: true`, `/specclaw:verify` spawns the `code-reviewer` agent **after** the existing verify agent (Step 3.5). The review verdict is appended to Step 5 status update logic; `code_review_block: true` causes `CHANGES_REQUESTED` to propagate as a hard blocker to `/specclaw:pr`.
+
+### Integration Point in Verify Skill
+
+Step 3.5 (new, inserted between Step 3 and Step 4 of verify):
+
+```
+## Step 3.5 — Code review (if workflow.code_review: true)
+
+Spawn code-reviewer agent with the verify context payload + design.md + tasks.md.
+Save output as `.specclaw/changes/<change>/review-report.md`.
+Append review verdict to the verify-report.md summary section.
+```
+
+## Scope
+
+### In Scope
+- New `plugins/specclaw/agents/code-reviewer.md`
+- Edit `plugins/specclaw/skills/verify/SKILL.md` — add Step 3.5
+- Edit `plugins/specclaw/templates/config.yaml` — add `workflow.code_review` + `workflow.code_review_block`
+- Edit `plugins/specclaw/references/agent-prompts.md` — add Code Reviewer Agent prompt template
+- Update `README.md` — document the new config flags
+- Update `plugins/specclaw/skills/pr/SKILL.md` — respect `code_review_block` before allowing PR
+
+### Out of Scope
+- Inline auto-fix of review findings (future `/specclaw:fix-review`)
+- Per-dimension enable/disable flags (add later if needed)
+- Diff-only review mode (agent reviews full changed-file content, not patch hunks)
+- Integration with external review tools (GitHub PR review comments via gh API)
+
+## Impact
+
+- Files changed: ~5
+- Complexity: medium
+- Risk: low — purely additive, opt-in flag defaults to `false`
+
+## Open Questions
+
+1. Should `review-report.md` merge into `verify-report.md` as a new section, or stay a separate file? (Proposal: separate, keeps concerns clean)
+2. Should `code_review_block` default to `false` or follow `workflow.strict`? (Proposal: always default `false` — let projects opt in to hard blocking explicitly)
+3. Should the reviewer use `models.review` (Sonnet) or `models.planning` (Opus)? (Proposal: `models.review` — code review is pattern-matching at inference speed, not deep reasoning)

--- a/.specclaw/changes/code-reviewer-agent/spec.md
+++ b/.specclaw/changes/code-reviewer-agent/spec.md
@@ -1,0 +1,97 @@
+# Spec: Code Reviewer Agent
+
+**Change:** code-reviewer-agent
+**Created:** 2026-06-21
+**Status:** approved
+
+## Overview
+
+Add a `code-reviewer` subagent to specclaw that performs structured, opinionated code review on changed files during the verify step. The agent is opt-in via `workflow.code_review: true` in `config.yaml`. It runs after the existing verify agent (AC check), reviews 10 dimensions of code quality, tags findings by severity, and outputs `review-report.md`. A second flag, `workflow.code_review_block: true`, lets projects hard-block PR creation when the verdict is `CHANGES_REQUESTED`.
+
+## Functional Requirements
+
+**FR1** — The `code-reviewer` agent SHALL be defined at `plugins/specclaw/agents/code-reviewer.md` with frontmatter fields: `name`, `description`, `tools: [Read, Write, Bash]`, `model: sonnet`.
+
+**FR2** — The agent SHALL review changed files across exactly 10 dimensions: Correctness, Security, YAGNI/Simplicity, One-liner opportunities, Naming, Complexity, Test quality, Design adherence, Scope creep, Dead code.
+
+**FR3** — Each finding SHALL be tagged with one of three severity levels: `🔴 BLOCK`, `🟡 WARN`, `🟢 NOTE`.
+
+**FR4** — The agent SHALL output verdict as exactly one of: `APPROVED` (zero BLOCK findings), `CHANGES_REQUESTED` (one or more BLOCK findings), `APPROVED_WITH_NOTES` (zero BLOCK, one or more WARN/NOTE).
+
+**FR5** — The agent SHALL write its output to `.specclaw/changes/<change>/review-report.md` in the format specified in the Code Reviewer Agent prompt template.
+
+**FR6** — `/specclaw:verify` SKILL.md SHALL include a new Step 3.5 that: reads `workflow.code_review` from config; if `true`, spawns the `code-reviewer` agent with changed files + `design.md` + `tasks.md`; saves output as `review-report.md`; appends review verdict to the verify-report summary.
+
+**FR7** — `plugins/specclaw/templates/config.yaml` SHALL add two new fields under `workflow:`:
+- `code_review: false` — enables the code reviewer agent on verify
+- `code_review_block: false` — causes `CHANGES_REQUESTED` verdict to block `/specclaw:pr`
+
+**FR8** — `plugins/specclaw/references/agent-prompts.md` SHALL contain a new `## Code Reviewer Agent` section with the full prompt template including the 10-dimension review table and output format specification.
+
+**FR9** — `/specclaw:pr` SKILL.md SHALL check `workflow.code_review_block`; if `true` and `review-report.md` verdict is `CHANGES_REQUESTED`, abort with a message listing the BLOCK findings.
+
+**FR10** — `README.md` SHALL document the two new config flags with a brief description of the code review feature.
+
+**FR11** — The "Follow YAGNI principles, and one-liner solutions." rule SHALL be explicitly stated in the agent system prompt under the Dimension 3 (YAGNI/Simplicity) and Dimension 4 (One-liner opportunities) descriptions.
+
+## Non-Functional Requirements
+
+**NFR1** — Opt-in only: default value of `workflow.code_review` is `false`; existing projects are unaffected until they set the flag.
+
+**NFR2** — Agent uses `models.review` model (Sonnet) — not Opus — keeping cost proportional to a pattern-matching task.
+
+**NFR3** — Step 3.5 is silently skipped when `workflow.code_review: false`; no output, no error, no performance impact.
+
+**NFR4** — The agent system prompt is ≤ 800 words — concise enough to fit in a single context payload without crowding changed-file content.
+
+**NFR5** — `review-report.md` is a separate file from `verify-report.md`; the verify skill appends only a one-line summary of the review verdict to `verify-report.md`, not the full report.
+
+## Acceptance Criteria
+
+**AC1** — GIVEN `workflow.code_review: false` WHEN `/specclaw:verify` runs THEN `review-report.md` is NOT created and verify behaviour is identical to pre-change.
+
+**AC2** — GIVEN `workflow.code_review: true` WHEN `/specclaw:verify` runs THEN `review-report.md` is created at `.specclaw/changes/<change>/review-report.md`.
+
+**AC3** — GIVEN a `review-report.md` with zero BLOCK findings WHEN the file is read THEN the verdict line reads `APPROVED` or `APPROVED_WITH_NOTES`.
+
+**AC4** — GIVEN a `review-report.md` with one or more BLOCK findings WHEN the file is read THEN the verdict line reads `CHANGES_REQUESTED`.
+
+**AC5** — GIVEN `workflow.code_review_block: true` AND `review-report.md` verdict is `CHANGES_REQUESTED` WHEN `/specclaw:pr` runs THEN it aborts and prints the BLOCK findings before creating a PR.
+
+**AC6** — GIVEN `workflow.code_review_block: false` AND `review-report.md` verdict is `CHANGES_REQUESTED` WHEN `/specclaw:pr` runs THEN the PR is created (review findings shown as a warning, not a hard block).
+
+**AC7** — GIVEN a changed file with a multi-line implementation that has a one-liner equivalent WHEN the code reviewer runs THEN at least one finding appears under Dimension 4 (One-liner opportunities).
+
+**AC8** — GIVEN `plugins/specclaw/templates/config.yaml` WHEN inspected THEN it contains `code_review: false` and `code_review_block: false` under the `workflow:` key.
+
+**AC9** — GIVEN `README.md` WHEN inspected THEN it mentions `workflow.code_review` and `workflow.code_review_block` with descriptions.
+
+**AC10** — GIVEN `plugins/specclaw/agents/code-reviewer.md` WHEN inspected THEN the system prompt explicitly states "Follow YAGNI principles, and one-liner solutions." in the dimension descriptions.
+
+## Edge Cases
+
+**EC1** — `design.md` does not exist for the change (e.g. a tiny fix skipped design phase) — agent should skip Dimension 8 (Design adherence) and note "design.md not found — skipping design adherence check."
+
+**EC2** — `tasks.md` has no `files:` declarations — agent skips Dimension 9 (Scope creep) and notes "No files: declared in tasks.md — skipping scope check."
+
+**EC3** — Changed files list is empty (no files collected by `specclaw-verify collect`) — agent outputs a `review-report.md` with verdict `APPROVED` and a note "No changed files to review."
+
+**EC4** — `review-report.md` already exists from a prior verify run — Step 3.5 overwrites it (same as verify-report.md behaviour).
+
+**EC5** — `workflow.code_review: true` but `models.review` is not set in config — agent falls back to `anthropic/claude-sonnet-4-6` (hardcoded default in agent frontmatter).
+
+## Dependencies
+
+- Existing `specclaw-verify collect` output format (changed files content)
+- `models.review` config key (already exists in `templates/config.yaml`)
+- `plugins/specclaw/agents/spec-author.md` — structural reference for new agent file
+- `plugins/specclaw/skills/verify/SKILL.md` — edit target
+- `plugins/specclaw/skills/pr/SKILL.md` — edit target for block check
+- `plugins/specclaw/references/agent-prompts.md` — edit target for new prompt section
+
+## Notes
+
+- The proposal's open question #1 (merge vs. separate report file) resolved: separate `review-report.md`, one-line summary appended to `verify-report.md`.
+- Open question #2 (code_review_block default) resolved: always `false` — opt-in to hard blocking.
+- Open question #3 (which model) resolved: `models.review` (Sonnet).
+- Future: `/specclaw:fix-review` skill could read `review-report.md` BLOCK findings and spawn a coding agent to address them.

--- a/.specclaw/changes/code-reviewer-agent/status.md
+++ b/.specclaw/changes/code-reviewer-agent/status.md
@@ -1,4 +1,4 @@
 # Status: code-reviewer-agent
 
-**Status:** draft
+**Status:** approved
 **GitHub Issue:** —

--- a/.specclaw/changes/code-reviewer-agent/status.md
+++ b/.specclaw/changes/code-reviewer-agent/status.md
@@ -1,0 +1,4 @@
+# Status: code-reviewer-agent
+
+**Status:** draft
+**GitHub Issue:** —

--- a/.specclaw/changes/code-reviewer-agent/status.md
+++ b/.specclaw/changes/code-reviewer-agent/status.md
@@ -1,4 +1,4 @@
 # Status: code-reviewer-agent
 
-**Status:** approved
+**Status:** complete
 **GitHub Issue:** —

--- a/.specclaw/changes/code-reviewer-agent/tasks.md
+++ b/.specclaw/changes/code-reviewer-agent/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Code Reviewer Agent
+
+**Change:** code-reviewer-agent
+**Created:** 2026-06-21
+**Total Tasks:** 5
+
+## Summary
+
+Five tasks in two waves. Wave 1 creates the agent and prompt template (independent). Wave 2 wires the agent into verify and pr skills, adds config flags, and updates docs. All five tasks are small-medium file edits; no new shell scripts or binaries needed.
+
+## Tasks
+
+### Wave 1 — Create agent and prompt template
+
+- [ ] `T1` — Create `code-reviewer` subagent
+  - Files: `plugins/specclaw/agents/code-reviewer.md` (new)
+  - Estimate: medium
+  - Depends: —
+  - Notes: Frontmatter `name: code-reviewer`, `description`, `tools: [Read, Write, Bash]`, `model: sonnet`.
+    System prompt sections:
+    (a) Identity — "You are code-reviewer, a specclaw subagent that reviews code quality."
+    (b) Inputs — changed files content, spec content, design content (may be empty), tasks content (may be empty)
+    (c) Review Dimensions table — 10 rows. D3 (YAGNI/Simplicity) and D4 (One-liner opportunities) MUST include the rule: "Follow YAGNI principles, and one-liner solutions."
+    (d) Severity definitions — BLOCK (security/correctness/design breach), WARN (YAGNI/complexity/dead code), NOTE (naming/one-liners)
+    (e) Verdict rules — APPROVED / CHANGES_REQUESTED / APPROVED_WITH_NOTES
+    (f) Edge case handling — EC1 (no design.md → skip D8), EC2 (no files: in tasks.md → skip D9), EC3 (no changed files → APPROVED with note), EC4 (overwrite existing report), EC5 (missing models.review → default sonnet)
+    (g) Output format — exact review-report.md template from design.md
+    (h) Guardrails — reference `references/agent-guardrails.md` Rules 2 and 3
+
+- [ ] `T2` — Add Code Reviewer Agent prompt template to `agent-prompts.md`
+  - Files: `plugins/specclaw/references/agent-prompts.md` (edit)
+  - Estimate: small
+  - Depends: —
+  - Notes: Add `## Code Reviewer Agent` section after the existing `## Verify Agent` section.
+    Variables: `{{change_name}}`, `{{changed_files_content}}`, `{{design_content}}`, `{{tasks_content}}`, `{{spec_content}}`.
+    Template body mirrors the structure of the Verify Agent template — header, inputs, task description, output format.
+    Keep the template under 150 lines.
+
+### Wave 2 — Wire into verify/pr, config, docs
+
+- [ ] `T3` — Add Step 3.5 to `/specclaw:verify` SKILL.md
+  - Files: `plugins/specclaw/skills/verify/SKILL.md` (edit)
+  - Estimate: small
+  - Depends: T1
+  - Notes: Insert `## Step 3.5 — Code review (conditional)` between existing Step 3 and Step 4.
+    Step reads `workflow.code_review` from config; if false/absent, silent skip.
+    If true: read design.md and tasks.md (empty string if absent), spawn `code-reviewer` agent with `models.review` model,
+    write output to `review-report.md`, extract verdict line and append one-line summary to verify-report.md.
+    Format of appended line: `**Code Review:** <verdict> — <N findings: X BLOCK, Y WARN, Z NOTE>`
+
+- [ ] `T4` — Add code_review_block pre-flight check to `/specclaw:pr` SKILL.md
+  - Files: `plugins/specclaw/skills/pr/SKILL.md` (edit)
+  - Estimate: small
+  - Depends: T1
+  - Notes: Insert a new "Pre-flight: code review block" section near the top of the PR skill, after existing pre-flight checks.
+    If `workflow.code_review_block: true`: read review-report.md; if verdict is CHANGES_REQUESTED abort with BLOCK findings list;
+    if review-report.md missing, warn and continue (don't hard-block for missing file — that would be too aggressive).
+
+- [ ] `T5` — Add config flags and update README
+  - Files: `plugins/specclaw/templates/config.yaml` (edit), `README.md` (edit)
+  - Estimate: small
+  - Depends: —
+  - Notes: In config.yaml, add under `workflow:`:
+    ```yaml
+    code_review: false        # Spawn code-reviewer agent during /specclaw:verify
+    code_review_block: false  # Block /specclaw:pr if code review verdict is CHANGES_REQUESTED
+    ```
+    In README.md, add a "Code Review" subsection under the Configuration section (or workflow section).
+    Two-sentence description of each flag. Keep it brief.
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T<n>` — <title>
+  - Files: <files to create/modify>
+  - Estimate: small | medium | large
+  - Depends: <task ids> (if any)
+  - Notes: <additional context>
+```

--- a/.specclaw/changes/code-reviewer-agent/tasks.md
+++ b/.specclaw/changes/code-reviewer-agent/tasks.md
@@ -12,7 +12,7 @@ Five tasks in two waves. Wave 1 creates the agent and prompt template (independe
 
 ### Wave 1 — Create agent and prompt template
 
-- [ ] `T1` — Create `code-reviewer` subagent
+- [x] `T1` — Create `code-reviewer` subagent
   - Files: `plugins/specclaw/agents/code-reviewer.md` (new)
   - Estimate: medium
   - Depends: —
@@ -27,7 +27,7 @@ Five tasks in two waves. Wave 1 creates the agent and prompt template (independe
     (g) Output format — exact review-report.md template from design.md
     (h) Guardrails — reference `references/agent-guardrails.md` Rules 2 and 3
 
-- [ ] `T2` — Add Code Reviewer Agent prompt template to `agent-prompts.md`
+- [x] `T2` — Add Code Reviewer Agent prompt template to `agent-prompts.md`
   - Files: `plugins/specclaw/references/agent-prompts.md` (edit)
   - Estimate: small
   - Depends: —
@@ -38,7 +38,7 @@ Five tasks in two waves. Wave 1 creates the agent and prompt template (independe
 
 ### Wave 2 — Wire into verify/pr, config, docs
 
-- [ ] `T3` — Add Step 3.5 to `/specclaw:verify` SKILL.md
+- [x] `T3` — Add Step 3.5 to `/specclaw:verify` SKILL.md
   - Files: `plugins/specclaw/skills/verify/SKILL.md` (edit)
   - Estimate: small
   - Depends: T1
@@ -48,7 +48,7 @@ Five tasks in two waves. Wave 1 creates the agent and prompt template (independe
     write output to `review-report.md`, extract verdict line and append one-line summary to verify-report.md.
     Format of appended line: `**Code Review:** <verdict> — <N findings: X BLOCK, Y WARN, Z NOTE>`
 
-- [ ] `T4` — Add code_review_block pre-flight check to `/specclaw:pr` SKILL.md
+- [x] `T4` — Add code_review_block pre-flight check to `/specclaw:pr` SKILL.md
   - Files: `plugins/specclaw/skills/pr/SKILL.md` (edit)
   - Estimate: small
   - Depends: T1
@@ -56,7 +56,7 @@ Five tasks in two waves. Wave 1 creates the agent and prompt template (independe
     If `workflow.code_review_block: true`: read review-report.md; if verdict is CHANGES_REQUESTED abort with BLOCK findings list;
     if review-report.md missing, warn and continue (don't hard-block for missing file — that would be too aggressive).
 
-- [ ] `T5` — Add config flags and update README
+- [x] `T5` — Add config flags and update README
   - Files: `plugins/specclaw/templates/config.yaml` (edit), `README.md` (edit)
   - Estimate: small
   - Depends: —

--- a/README.md
+++ b/README.md
@@ -135,7 +135,18 @@ automation:
   auto_verify: true
   auto_archive: false
   max_tasks_per_run: 5
+
+workflow:
+  strict: true
+  code_review: false               # Spawn code-reviewer agent on /specclaw:verify
+  code_review_block: false         # Block /specclaw:pr if code review finds BLOCK issues
 ```
+
+### Code Review
+
+Set `workflow.code_review: true` to enable an automated code review step inside `/specclaw:verify`. After the acceptance-criteria check, a `code-reviewer` agent reviews changed files across 10 dimensions (correctness, security, YAGNI, one-liner opportunities, naming, complexity, test quality, design adherence, scope creep, dead code) and writes `review-report.md` with `APPROVED`, `CHANGES_REQUESTED`, or `APPROVED_WITH_NOTES`.
+
+Set `workflow.code_review_block: true` to hard-block `/specclaw:pr` when the review verdict is `CHANGES_REQUESTED`. Defaults to `false` so existing projects are unaffected.
 
 ## Workflow
 

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/agents/code-reviewer.md
+++ b/plugins/specclaw/agents/code-reviewer.md
@@ -1,0 +1,98 @@
+---
+name: code-reviewer
+description: Reviews changed files for a specclaw change across 10 quality dimensions (correctness, security, YAGNI/simplicity, one-liner opportunities, naming, complexity, test quality, design adherence, scope creep, dead code). Produces review-report.md with BLOCK/WARN/NOTE findings and an APPROVED/CHANGES_REQUESTED/APPROVED_WITH_NOTES verdict. Runs inside /specclaw:verify when workflow.code_review is true.
+tools: [Read, Write, Bash]
+model: sonnet
+---
+
+# Identity
+You are **code-reviewer**, a specclaw subagent. You review changed source files for a given change and produce a structured `review-report.md`.
+
+# Inputs
+You will be invoked with a change name and these context blocks in your prompt:
+- **Changed files** — content of every file modified for this change
+- **Spec** — `.specclaw/changes/<change>/spec.md`
+- **Design** — `.specclaw/changes/<change>/design.md` (may be empty if not authored)
+- **Tasks** — `.specclaw/changes/<change>/tasks.md` (may be empty)
+
+# Review Dimensions
+
+Review changed files across these 10 dimensions. For each dimension produce zero or more findings.
+
+| # | Dimension | What to check |
+|---|-----------|---------------|
+| 1 | **Correctness** | Logic errors, off-by-one, null/undefined dereference, incorrect conditionals, wrong operator |
+| 2 | **Security** | SQL/command/template injection, hardcoded secrets, missing input validation, improper auth checks, unsafe deserialization |
+| 3 | **YAGNI / Simplicity** | Speculative abstractions, unused parameters, "configurability" not in spec, premature generalisation. Rule: **Follow YAGNI principles, and one-liner solutions.** |
+| 4 | **One-liner opportunities** | Multi-line blocks that have a clear idiomatic one-liner equivalent in the same language. Rule: **Follow YAGNI principles, and one-liner solutions.** Flag each with the proposed one-liner. |
+| 5 | **Naming** | Misleading names, single-letter vars outside loops, abbreviations that obscure intent, inconsistency with the existing codebase convention visible in context |
+| 6 | **Complexity** | Functions longer than ~30 lines, nesting depth > 3 levels, high cyclomatic complexity hot spots |
+| 7 | **Test quality** | Missing tests for changed logic paths, assertions that mirror implementation rather than observable behaviour, tests that would pass even if the feature is broken |
+| 8 | **Design adherence** | Implementation diverges from `design.md` without a justification comment (skip this dimension if design content is empty — note "design.md absent, skipping D8") |
+| 9 | **Scope creep** | Files modified that do not appear in any `files:` list in `tasks.md` (skip if tasks content is empty or has no `files:` entries — note "No files: declared, skipping D9") |
+| 10 | **Dead code** | Functions, variables, or imports added by this change that are never referenced |
+
+# Severity
+
+Tag every finding with one severity level:
+
+- `🔴 BLOCK` — Must fix before PR. Use for: security vulnerabilities, correctness bugs that will cause wrong behaviour or data loss, direct breaches of the design architecture.
+- `🟡 WARN` — Should fix. Use for: YAGNI violations, complexity, dead code, missing tests for core paths.
+- `🟢 NOTE` — Optional improvement. Use for: naming, one-liner opportunities, style.
+
+# Verdict
+
+After all dimensions, assign one of:
+- **APPROVED** — zero BLOCK findings
+- **CHANGES_REQUESTED** — one or more BLOCK findings
+- **APPROVED_WITH_NOTES** — zero BLOCK findings, one or more WARN or NOTE findings
+
+# Edge Cases
+
+- **No design.md** — skip Dimension 8, add note: "design.md absent — skipping D8."
+- **No files: in tasks.md** — skip Dimension 9, add note: "No files: declared in tasks.md — skipping D9."
+- **No changed files provided** — output verdict APPROVED, add note: "No changed files to review."
+- **review-report.md already exists** — overwrite it.
+
+# Guardrails
+
+Follow `references/agent-guardrails.md`:
+- **Rule 2 (Simplicity First)** — flag complexity and YAGNI violations; do not suggest new abstractions in your findings.
+- **Rule 3 (Surgical Changes)** — your findings should address only the changed code, not pre-existing issues in files you happen to read.
+
+# Output
+
+Write a single file `.specclaw/changes/<change>/review-report.md` using this exact format:
+
+```markdown
+# Code Review Report: <change>
+
+**Reviewed:** <YYYY-MM-DD>
+**Model:** <your model name>
+**Verdict:** <APPROVED|CHANGES_REQUESTED|APPROVED_WITH_NOTES>
+
+## Summary
+
+<N findings: X BLOCK, Y WARN, Z NOTE>
+
+## Findings
+
+### [BLOCK] path/to/file:line — Dimension name
+**Problem:** <description>
+**Fix:** <concrete suggestion>
+
+### [WARN] path/to/file:line — Dimension name
+**Problem:** <description>
+
+### [NOTE] path/to/file:line — Dimension name
+**Problem:** <description>
+**Suggestion:** <one-liner or rename>
+
+_(If no findings, write: "No findings.")_
+
+## Verdict Rationale
+
+<One paragraph explaining the verdict.>
+```
+
+Write the file once, at the end, after completing all 10 dimensions.

--- a/plugins/specclaw/references/agent-prompts.md
+++ b/plugins/specclaw/references/agent-prompts.md
@@ -257,6 +257,84 @@ Be strict. If the spec says it, the code must do it. Do not pass criteria on int
 
 ---
 
+## Code Reviewer Agent
+
+```
+You are a strict code reviewer validating the quality of an implementation for change "{{change_name}}".
+
+## Change
+{{change_name}}
+
+## Specification
+{{spec_content}}
+
+## Design
+{{design_content}}
+
+## Tasks
+{{tasks_content}}
+
+## Changed Files
+{{changed_files_content}}
+
+## Your Task
+
+Review the changed files across these 10 dimensions. Produce zero or more findings per dimension.
+
+| # | Dimension | What to check |
+|---|-----------|---------------|
+| 1 | **Correctness** | Logic errors, off-by-one, null/undefined dereference, incorrect conditionals |
+| 2 | **Security** | Injection risks, hardcoded secrets, missing input validation, improper auth checks |
+| 3 | **YAGNI / Simplicity** | Speculative abstractions, unused parameters, premature generalisation. Rule: Follow YAGNI principles, and one-liner solutions. |
+| 4 | **One-liner opportunities** | Multi-line blocks with a clear idiomatic one-liner equivalent. Rule: Follow YAGNI principles, and one-liner solutions. |
+| 5 | **Naming** | Misleading names, single-letter vars outside loops, convention inconsistency |
+| 6 | **Complexity** | Functions > ~30 lines, nesting depth > 3 levels |
+| 7 | **Test quality** | Missing tests for changed logic, non-behavioural assertions |
+| 8 | **Design adherence** | Implementation diverges from design.md without justification (skip if design_content is empty) |
+| 9 | **Scope creep** | Files changed outside declared files: lists in tasks.md (skip if no files: present) |
+| 10 | **Dead code** | Added functions/vars/imports never referenced |
+
+## Severity Rules
+- `🔴 BLOCK` — security vulnerabilities, correctness bugs, design breaches
+- `🟡 WARN` — YAGNI violations, complexity, dead code, missing tests
+- `🟢 NOTE` — naming, one-liner opportunities, style
+
+## Verdict Rules
+- **APPROVED** — zero BLOCK findings
+- **CHANGES_REQUESTED** — one or more BLOCK findings
+- **APPROVED_WITH_NOTES** — zero BLOCK, one or more WARN/NOTE findings
+
+## Output Format
+
+---
+
+# Code Review Report: {{change_name}}
+
+**Reviewed:** <YYYY-MM-DD>
+**Model:** <your model name>
+**Verdict:** <APPROVED|CHANGES_REQUESTED|APPROVED_WITH_NOTES>
+
+## Summary
+
+<N findings: X BLOCK, Y WARN, Z NOTE>
+
+## Findings
+
+### [BLOCK] path/to/file:line — Correctness
+**Problem:** <description>
+**Fix:** <concrete suggestion>
+
+_(If no findings, write: "No findings.")_
+
+## Verdict Rationale
+
+<One paragraph explaining the verdict.>
+
+---
+```
+
+---
+
 ## Context Preparation Notes
 
 ### How to build `{{codebase_summary}}`:

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -8,7 +8,10 @@ description: Create a GitHub pull request for a verified change. Reads verify-re
 
 Create a GitHub PR for a verified change. Requires `verify-report.md` (build + verify must complete first).
 
-1. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Exits with a warning (exit 0) if a PR already exists for this change. Fails if `verify-report.md` is missing.
+1. **Code review block (conditional):** Read `workflow.code_review_block` from `.specclaw/config.yaml`. If `true`:
+   - Check if `.specclaw/changes/<change>/review-report.md` exists. If it does not exist, warn: "code_review_block is enabled but no review-report.md found — run /specclaw:verify first" and continue.
+   - If `review-report.md` exists and verdict is `CHANGES_REQUESTED`, **abort** with: "PR blocked: code review verdict is CHANGES_REQUESTED. Fix BLOCK findings in review-report.md then re-run /specclaw:verify." List all BLOCK findings from the report before aborting.
+2. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Exits with a warning (exit 0) if a PR already exists for this change. Fails if `verify-report.md` is missing.
 2. **Run:** `specclaw-pr .specclaw <change>`
    - **First run:** prompts for test policy (`none|unit|e2e|both`), saves it to `config.yaml` under `pr.test_policy`. Never prompts again.
    - **Test enforcement:** if policy is not `none`, verifies `build.test_command` is set and that `verify-report.md` contains test evidence. Fails (strict) or warns (non-strict) if evidence is missing.

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -36,9 +36,21 @@ Constructs the verification agent's context payload from the evidence and the Ve
 
 Spawn a verification agent using the context payload from Step 2. Use the model from `config.yaml` `models.review` (default: `anthropic/claude-sonnet-4-5`). Wait for completion.
 
+## Step 3.5 — Code review (conditional)
+
+Read `workflow.code_review` from `.specclaw/config.yaml`. If `false` or not set, skip this step entirely (no output, no error).
+
+If `true`:
+1. Read `.specclaw/changes/<change>/design.md` — use empty string if absent.
+2. Read `.specclaw/changes/<change>/tasks.md` — use empty string if absent.
+3. Spawn the `code-reviewer` agent using the model from `config.yaml` `models.review` (default: `anthropic/claude-sonnet-4-6`). Pass: changed files content (from Step 1), spec content, design content, tasks content, change name.
+4. Write the agent's output to `.specclaw/changes/<change>/review-report.md` (overwrite if exists).
+5. Extract the verdict line from `review-report.md` and append a one-line summary to the verify-report that will be written in Step 4:
+   `**Code Review:** <verdict> — <N findings: X BLOCK, Y WARN, Z NOTE>`
+
 ## Step 4 — Save report
 
-Save the agent's output as `.specclaw/changes/<change>/verify-report.md`.
+Save the agent's output as `.specclaw/changes/<change>/verify-report.md`. If Step 3.5 ran, append the code review summary line from Step 3.5 to the end of this report.
 
 ## Step 5 — Update status
 

--- a/plugins/specclaw/templates/config.yaml
+++ b/plugins/specclaw/templates/config.yaml
@@ -54,6 +54,8 @@ github:
 # Workflow enforcement
 workflow:
   strict: true                     # Enforce phase prerequisites (disable for rapid prototyping)
+  code_review: false               # Spawn code-reviewer agent during /specclaw:verify
+  code_review_block: false         # Block /specclaw:pr if code review verdict is CHANGES_REQUESTED
 
 # Automation
 automation:


### PR DESCRIPTION
## Proposal: Code Reviewer Agent

Adds a `code-reviewer` subagent that runs inside `/specclaw:verify` for projects with `workflow.code_review: true`.

### What it reviews (10 dimensions)
1. Correctness — logic errors, null dereference, off-by-one
2. Security — injection, hardcoded secrets, missing auth guards
3. YAGNI / Simplicity — speculative abstractions, unused params
4. One-liner opportunities — multi-line blocks with idiomatic equivalents
5. Naming — misleading names, convention inconsistency
6. Complexity — functions > ~30 lines, nesting depth > 3
7. Test quality — missing tests, non-behavioural assertions
8. Design adherence — drift from `design.md`
9. Scope creep — files outside declared `tasks.md` scope
10. Dead code — added code never called

### Rules
- "Follow YAGNI principles, and one-liner solutions." enforced as Dimension 3+4
- Severity: 🔴 BLOCK / 🟡 WARN / 🟢 NOTE
- Verdict: APPROVED | CHANGES_REQUESTED | APPROVED_WITH_NOTES
- Opt-in via `workflow.code_review: true` in config.yaml (default: false)
- Hard block on PR gated by `workflow.code_review_block: true` (default: false)

### Files to change (~5)
- `plugins/specclaw/agents/code-reviewer.md` (new)
- `plugins/specclaw/skills/verify/SKILL.md` (add Step 3.5)
- `plugins/specclaw/templates/config.yaml` (new flags)
- `plugins/specclaw/references/agent-prompts.md` (new prompt template)
- `README.md` + `plugins/specclaw/skills/pr/SKILL.md` (docs + block check)

Risk: low — purely additive, opt-in only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)