### PR TITLE
fix(azdo-issue): quote SKILL.md description — fixes YAML parse error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/skills/azdo-issue/SKILL.md
+++ b/plugins/specclaw/skills/azdo-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Create or update an Azure Boards Work Item that mirrors this proposal. Targets Azure DevOps Boards (Features / User Stories / Tasks / Bugs / Epics) using the credentials from /specclaw:auth-azdo. Mirrors /specclaw:issue (Jira) and the GitHub Issues sync but for ADO Boards. Requires `azdo.boards.sync: true` in config.yaml.
+description: "Create or update an Azure Boards Work Item that mirrors this proposal. Targets Azure DevOps Boards (Features / User Stories / Tasks / Bugs / Epics) using the credentials from /specclaw:auth-azdo. Mirrors /specclaw:issue (Jira) and the GitHub Issues sync but for ADO Boards. Requires `azdo.boards.sync: true` in config.yaml."
 ---
 
 # specclaw azdo-issue


### PR DESCRIPTION
## Problem
`claude plugin validate` fails with `YAML Parse error: Unexpected token` on `plugins/specclaw/skills/azdo-issue/SKILL.md`.

The description contained `` `azdo.boards.sync: true` `` unquoted — YAML interprets the colon as a mapping key, breaking the frontmatter parse.

## Fix
Wrap the description value in double quotes.

## Test
```
python3 -c "import re, yaml; content=open('plugins/specclaw/skills/azdo-issue/SKILL.md').read(); m=re.match(r'^---\n(.*?)\n---', content, re.DOTALL); yaml.safe_load(m.group(1)); print('OK')"
```

## Version
Bumped `0.4.3 → 0.4.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)