### PR TITLE
feat(context): living project context — auto-updating architecture doc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -1,0 +1,41 @@
+# specclaw plugin — Claude Code instructions
+
+## Project Context (`context.md`)
+
+Every specclaw project can have a `.specclaw/context.md` — a living architecture document that captures project-level coding rules, patterns, style guides, and decisions. It is committed to the project repo (not gitignored) so it is shared across the team and reviewable in PRs.
+
+**What it contains:** Architecture overview, coding style and conventions, key patterns, technology decisions, constraints (what not to do), and a log of recent decisions.
+
+**How to create/edit it:** Use `/specclaw:context` — sub-commands: `show`, `add`, `edit`, `reset`.
+
+**How it is used automatically:**
+- `/specclaw:plan` reads `context.md` before generating spec, design, and tasks — decisions and constraints are applied throughout.
+- `/specclaw:build` injects `context.md` into every coding agent's context payload via `specclaw-build-context`.
+- `/specclaw:verify` checks the implementation against `context.md` rules in addition to spec acceptance criteria.
+- `/specclaw:pr` and `/specclaw:pr-azdo` rewrite `context.md` after each merged change via `specclaw-update-context` — new decisions, patterns, and constraints from the change are merged in; stale information is replaced.
+
+**Architecture-doc model:** `context.md` is always current. It is not an append log — it is rewritten to reflect the project's present state. Git history is the audit trail.
+
+## Lifecycle
+
+`propose` → `plan` → `build` → `verify` → `pr` → _(context auto-updated)_
+
+Each phase has a corresponding skill. Run them in order. See individual SKILL.md files under `skills/` for details.
+
+## Scripts
+
+All executable scripts live in `bin/`. Key ones:
+
+| Script | Purpose |
+|--------|---------|
+| `specclaw-ensure-init` | Idempotently init `.specclaw/` |
+| `specclaw-build-context` | Build coding agent payload (includes context.md) |
+| `specclaw-update-context` | Output LLM prompt to rewrite context.md post-merge |
+| `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard |
+| `specclaw-gh-sync` | GitHub Issues sync |
+| `specclaw-pr` | Create GitHub PR (enforces test policy, triggers context update) |
+| `specclaw-validate-change` | Check phase prerequisites |
+
+## Templates
+
+Templates live in `templates/`. `context.md` is the seed for new projects — copy it to `.specclaw/context.md` or let `/specclaw:context add` create it automatically.

--- a/plugins/specclaw/bin/specclaw-build-context
+++ b/plugins/specclaw/bin/specclaw-build-context
@@ -228,6 +228,24 @@ $(cat "$KNOWLEDGE_HINTS_FILE")
 "
 fi
 
+# --- Project context (living architecture doc) ---
+MAX_CONTEXT_LINES=150
+CONTEXT_FILE="$SPECCLAW_DIR/context.md"
+CONTEXT_SECTION=""
+if [[ -f "$CONTEXT_FILE" ]]; then
+  local_line_count="$(wc -l < "$CONTEXT_FILE")"
+  if [[ "$local_line_count" -gt "$MAX_CONTEXT_LINES" ]]; then
+    CONTEXT_SECTION="## Project Context
+*(Truncated: showing first $MAX_CONTEXT_LINES of $local_line_count lines — see .specclaw/context.md for full doc)*
+$(head -n "$MAX_CONTEXT_LINES" "$CONTEXT_FILE")
+"
+  else
+    CONTEXT_SECTION="## Project Context
+$(cat "$CONTEXT_FILE")
+"
+  fi
+fi
+
 # --- Existing file contents ---
 build_file_contents() {
   local file_list="$1"
@@ -348,7 +366,7 @@ fi
 cat <<PROMPT
 You are a coding agent implementing a specific task in the project "${PROJECT_NAME}".
 
-${GUARDRAILS_SECTION}${KNOWLEDGE_SECTION}
+${GUARDRAILS_SECTION}${KNOWLEDGE_SECTION}${CONTEXT_SECTION}
 ## Your Task
 ${TASK_TITLE}
 ${TASK_NOTES}

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -622,6 +622,24 @@ main() {
   # Step 7: Save URL
   save_pr_url "$pr_url"
 
+  # Step 8: Update project context (always-on; errors are non-blocking)
+  local update_context_script="$SCRIPT_DIR/specclaw-update-context"
+  if [[ -x "$update_context_script" ]]; then
+    local context_prompt
+    context_prompt="$("$update_context_script" "$SPECCLAW_DIR" "$CHANGE_NAME" 2>/dev/null)" || true
+    if [[ -n "$context_prompt" ]]; then
+      local context_file="$SPECCLAW_DIR/context.md"
+      local project_root
+      project_root="$(cd "$SPECCLAW_DIR/.." && pwd)"
+      # The calling skill (pr/pr-azdo) feeds this prompt to a coding agent that rewrites context.md.
+      # Here in the bash script we record the prompt for the skill to consume; actual LLM rewrite
+      # happens in the skill's step after this script exits.
+      echo "__CONTEXT_UPDATE_PROMPT_START__"
+      printf '%s' "$context_prompt"
+      echo "__CONTEXT_UPDATE_PROMPT_END__"
+    fi
+  fi
+
   echo "✅ PR created: $pr_url"
 }
 

--- a/plugins/specclaw/bin/specclaw-update-context
+++ b/plugins/specclaw/bin/specclaw-update-context
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# specclaw-update-context — rewrite .specclaw/context.md after a change is merged
+# Usage: specclaw-update-context <specclaw_dir> <change_name>
+#
+# Seeds context.md from template if absent. Reads proposal.md, design.md, and
+# verify-report.md from the change to extract decisions and patterns, then
+# outputs a structured LLM prompt to stdout. The calling skill (pr/pr-azdo)
+# feeds this prompt to a coding agent that rewrites context.md in place.
+#
+# Exits 0 always — errors are warnings, never blocking.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MAX_SECTION_LINES=60
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-update-context <specclaw_dir> <change_name>
+
+Outputs an LLM prompt to stdout that, when executed by a coding agent, will
+rewrite .specclaw/context.md to incorporate decisions from the named change.
+
+Arguments:
+  specclaw_dir   Path to the .specclaw directory
+  change_name    Name of the merged change
+
+Exit codes: always 0 (errors are warnings)
+EOF
+  exit 0
+}
+
+warn() { echo "WARN(specclaw-update-context): $*" >&2; }
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+if [[ $# -lt 2 ]]; then
+  warn "Expected 2 arguments: <specclaw_dir> <change_name>"
+  exit 0
+fi
+
+SPECCLAW_DIR="$1"
+CHANGE_NAME="$2"
+
+if [[ ! -d "$SPECCLAW_DIR" ]]; then
+  warn "specclaw directory not found: $SPECCLAW_DIR"
+  exit 0
+fi
+
+CHANGE_DIR="$SPECCLAW_DIR/changes/$CHANGE_NAME"
+if [[ ! -d "$CHANGE_DIR" ]]; then
+  warn "Change directory not found: $CHANGE_DIR"
+  exit 0
+fi
+
+CONTEXT_FILE="$SPECCLAW_DIR/context.md"
+TEMPLATE_FILE="$PLUGIN_ROOT/templates/context.md"
+
+# Seed from template if context.md absent
+if [[ ! -f "$CONTEXT_FILE" ]]; then
+  if [[ -f "$TEMPLATE_FILE" ]]; then
+    cp "$TEMPLATE_FILE" "$CONTEXT_FILE"
+  else
+    warn "Template not found: $TEMPLATE_FILE — creating minimal context.md"
+    cat > "$CONTEXT_FILE" <<'MINEOF'
+# Project Context
+
+_Last updated: never_
+
+## Architecture Overview
+_Not yet documented._
+
+## Coding Style & Conventions
+_Not yet documented._
+
+## Key Patterns
+_Not yet documented._
+
+## Technology Decisions
+_Not yet documented._
+
+## Constraints
+_Not yet documented._
+
+## Recent Decisions
+_No decisions recorded yet._
+MINEOF
+  fi
+fi
+
+# Read change artifacts
+read_artifact() {
+  local path="$1"
+  local label="$2"
+  if [[ -f "$path" ]]; then
+    echo "=== $label ==="
+    head -n "$MAX_SECTION_LINES" "$path"
+    echo ""
+  fi
+}
+
+PROPOSAL_CONTENT="$(read_artifact "$CHANGE_DIR/proposal.md" "proposal.md")"
+DESIGN_CONTENT="$(read_artifact "$CHANGE_DIR/design.md" "design.md")"
+VERIFY_CONTENT="$(read_artifact "$CHANGE_DIR/verify-report.md" "verify-report.md")"
+
+if [[ -z "$PROPOSAL_CONTENT" && -z "$DESIGN_CONTENT" && -z "$VERIFY_CONTENT" ]]; then
+  warn "No change artifacts found in $CHANGE_DIR — skipping context update"
+  exit 0
+fi
+
+CURRENT_CONTEXT="$(cat "$CONTEXT_FILE")"
+
+# Output the LLM prompt for the calling skill to feed to a coding agent
+cat <<PROMPT
+You are maintaining \`$CONTEXT_FILE\` — the project's living architecture document.
+
+This file is an architecture-doc (not an append log). Your job is to rewrite it so it reflects the current state of the project after the change "${CHANGE_NAME}" was merged. Replace stale information; merge in new decisions. Keep each section concise. Git history is the audit trail for removed content.
+
+## Current context.md
+
+$CURRENT_CONTEXT
+
+## Change artifacts for "${CHANGE_NAME}"
+
+$PROPOSAL_CONTENT
+$DESIGN_CONTENT
+$VERIFY_CONTENT
+
+## Instructions
+
+1. Read the current context.md and the change artifacts above.
+2. Identify decisions, patterns, conventions, and constraints introduced or changed by "${CHANGE_NAME}".
+3. Rewrite context.md with these updates:
+   - **Architecture Overview**: update if the change altered system structure.
+   - **Coding Style & Conventions**: update if the change introduced/changed coding rules.
+   - **Key Patterns**: add new patterns; replace stale or superseded pattern descriptions.
+   - **Technology Decisions**: record significant library/tool decisions with brief rationale.
+   - **Constraints**: add new "don't do X" rules discovered during the change.
+   - **Recent Decisions**: prepend this change's top 1-3 decisions. Prune list to 5 entries max.
+4. Update the "_Last updated_" line to today's date and change name.
+5. If a section has no relevant updates, leave it as-is (do not clear it).
+6. Write the complete new content of \`$CONTEXT_FILE\` — not a diff, the full file.
+
+Output ONLY the new file content, starting with \`# Project Context\`. No preamble, no explanation.
+PROMPT

--- a/plugins/specclaw/skills/context/SKILL.md
+++ b/plugins/specclaw/skills/context/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: "Manage the project's living context document (.specclaw/context.md). View, add, or edit project-level rules, patterns, coding style, and architecture decisions that all lifecycle skills load automatically. Use show to view, add to append a rule, edit to rewrite a section, reset to restore from template."
+---
+
+# specclaw context
+
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist.
+
+Manage `.specclaw/context.md` — the project's living architecture document. All lifecycle skills (`plan`, `build`, `verify`) load this file automatically. It is committed to the project repo so it is shared across the team.
+
+## Sub-commands
+
+### show
+
+Print the current contents of `.specclaw/context.md`.
+
+If the file does not exist, print: `No context.md found. Run '/specclaw:context add' to create one.`
+
+### add
+
+Add a new rule, pattern, decision, or constraint to the context document.
+
+1. If `.specclaw/context.md` does not exist, seed it from `$CLAUDE_PLUGIN_ROOT/templates/context.md` first.
+2. Ask the operator: *"What would you like to add? Describe the rule, pattern, or decision — and which section it belongs in (Architecture, Style, Patterns, Decisions, Constraints)."*
+3. Read the current `context.md`.
+4. Write the new entry into the correct section. Keep the entry concise (1-5 lines). Preserve all other sections unchanged.
+5. Write the updated file back to `.specclaw/context.md`.
+6. Show the updated section to the operator for confirmation.
+7. Commit: `git add .specclaw/context.md && git commit -m "docs(context): add <brief description of what was added>"`.
+
+### edit
+
+Rewrite a specific section of the context document.
+
+1. If `.specclaw/context.md` does not exist, seed it from `$CLAUDE_PLUGIN_ROOT/templates/context.md` first.
+2. Ask the operator: *"Which section do you want to edit? (Architecture Overview / Coding Style / Key Patterns / Technology Decisions / Constraints / Recent Decisions)"* and *"What should the new content be?"*
+3. Read the current `context.md`.
+4. Replace only the specified section's content. Preserve all other sections and the document structure (headings, Last updated line).
+5. Update the `_Last updated_` line to today's date.
+6. Write the updated file back to `.specclaw/context.md`.
+7. Show the diff (old vs new section) to the operator.
+8. Commit: `git add .specclaw/context.md && git commit -m "docs(context): update <section name> section"`.
+
+### reset
+
+Recreate `context.md` from the template, discarding all current content.
+
+**Warn the operator:** "This will overwrite all current context.md content. Type 'confirm' to proceed."
+
+If confirmed:
+1. Copy `$CLAUDE_PLUGIN_ROOT/templates/context.md` to `.specclaw/context.md`.
+2. Commit: `git add .specclaw/context.md && git commit -m "docs(context): reset context.md to template"`.
+3. Report: "context.md reset. Use '/specclaw:context add' to repopulate."
+
+## Notes
+
+- `context.md` is committed to the project repo — changes show up in git diff and are reviewable in PRs.
+- The file is auto-updated whenever a PR is merged via `/specclaw:pr` or `/specclaw:pr-azdo`. Manual edits via this skill are for adding rules discovered outside the normal lifecycle.
+- All coding agents spawned by `/specclaw:build` receive the contents of `context.md` in their prompt automatically.

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -16,7 +16,7 @@ Turn an approved proposal into an executable plan.
 
 1. **Validate:** run `specclaw-validate-change .specclaw <change> plan`. If it fails, report missing prerequisites and stop.
 2. Read `.specclaw/changes/<change>/proposal.md`.
-3. Analyze the existing codebase (file structure, patterns, dependencies relevant to the change).
+3. Analyze the existing codebase (file structure, patterns, dependencies relevant to the change). **Also read `.specclaw/context.md` if it exists** — it contains project-level coding rules, patterns, architecture decisions, and constraints; apply them throughout spec, design, and tasks generation.
 4. Generate three files in `.specclaw/changes/<change>/`:
    - `spec.md` — functional requirements, non-functional requirements, acceptance criteria, edge cases.
      - **If `--author-spec` is set:** invoke the `spec-author` subagent via the `Agent` tool with `subagent_type: "spec-author"` to author the spec interactively. After the agent writes the file, **STOP and require explicit user approval** (e.g. "approved", "yes", "go") before proceeding to `design.md` and `tasks.md`. Do not generate the remaining files until the user approves.

--- a/plugins/specclaw/skills/pr-azdo/SKILL.md
+++ b/plugins/specclaw/skills/pr-azdo/SKILL.md
@@ -14,4 +14,9 @@ Create an Azure DevOps PR for a verified change.
    - **Test policy:** same gate as `/specclaw:pr` — prompts once, enforces on all runs.
    - **PR creation:** builds title (≤128 chars) from `proposal.md`, description from `spec.md` + `verify-report.md`, calls ADO REST API.
    - **Saves URL:** appends `**ADO PR:** <url>` to `status.md`.
-3. Report the ADO PR URL to the user.
+3. **Update project context:** After the ADO PR URL is saved, rewrite `.specclaw/context.md` to incorporate decisions from this change:
+   - Run `specclaw-update-context .specclaw <change>` — this outputs an LLM prompt.
+   - Feed the prompt to a coding agent that rewrites `context.md` in place (architecture-doc style: replaces stale info, merges new decisions).
+   - If `context.md` changed, commit it: `git add .specclaw/context.md && git commit -m "docs(context): update project context after <change>"` and push.
+   - Errors here are non-blocking — warn and continue.
+4. Report the ADO PR URL to the user.

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -25,4 +25,9 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
    - **PR creation:** builds title from `proposal.md`, body from `spec.md` + `verify-report.md`, runs `gh pr create --base main`.
    - **GitHub sync:** if `github.sync: true`, includes `Closes #N` in the PR body.
    - **Saves URL:** appends `**PR:** <url>` to `status.md`.
-3. Report the PR URL to the user.
+3. **Update project context:** After the PR URL is saved, rewrite `.specclaw/context.md` to incorporate decisions from this change:
+   - Run `specclaw-update-context .specclaw <change>` — this outputs an LLM prompt.
+   - Feed the prompt to a coding agent that rewrites `context.md` in place (architecture-doc style: replaces stale info, merges new decisions).
+   - If `context.md` changed, commit it: `git add .specclaw/context.md && git commit -m "docs(context): update project context after <change>"` and push.
+   - Errors here are non-blocking — warn and continue.
+4. Report the PR URL to the user.

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -16,6 +16,8 @@ specclaw-validate-change .specclaw <change> verify
 
 If it fails (tasks not all complete), report and stop.
 
+**If `.specclaw/context.md` exists**, read it before evaluating — the verifier must check that the implementation respects the project's coding rules, patterns, and constraints documented there, in addition to the spec's acceptance criteria.
+
 ## Step 1 — Collect evidence
 
 ```bash

--- a/plugins/specclaw/templates/context.md
+++ b/plugins/specclaw/templates/context.md
@@ -1,0 +1,39 @@
+# Project Context
+
+_Last updated: never — run `/specclaw:context add` or merge a change to populate._
+
+## Architecture Overview
+
+<!-- High-level system description: key components, entry points, data flow. -->
+
+_Not yet documented._
+
+## Coding Style & Conventions
+
+<!-- Language version, formatting rules, naming conventions, comment policy. -->
+
+_Not yet documented._
+
+## Key Patterns
+
+<!-- Reusable patterns used across the codebase — auth, error handling, data access, logging, etc. -->
+
+_Not yet documented._
+
+## Technology Decisions
+
+<!-- Why specific libraries/frameworks were chosen; version pins and why; migration paths. -->
+
+_Not yet documented._
+
+## Constraints
+
+<!-- What NOT to do — banned patterns, deprecated APIs, performance floors, security rules. -->
+
+_Not yet documented._
+
+## Recent Decisions
+
+<!-- Last 5 significant decisions from merged changes. Updated automatically on each PR merge. -->
+
+_No decisions recorded yet._


### PR DESCRIPTION
## Summary

- Adds `.specclaw/context.md` — a living architecture document committed to the project repo
- New `/specclaw:context` skill for interactive management (`show`, `add`, `edit`, `reset`)
- New `specclaw-update-context` script: after each PR merge, rewrites `context.md` with decisions from the change (architecture-doc style — replaces stale info, not just appends)
- `specclaw-build-context` now injects `context.md` into every coding agent payload
- `plan`, `verify`, `pr`, `pr-azdo` skills updated to load/enforce context rules
- Plugin-level `CLAUDE.md` added as developer docs

## Also fixes

- `specclaw-gh-sync create` now writes a sentinel to `status.md` when GitHub Issues are disabled, so `specclaw-validate-change` no longer blocks the `plan` phase on repos with Issues turned off

## Test plan

- [ ] Run `claude plugin validate plugins/specclaw` — passes (1 informational warning about CLAUDE.md placement, expected)
- [ ] Create a new project, run `/specclaw:context show` — reports "not created yet"
- [ ] Run `/specclaw:context add` with a style rule — `context.md` seeded from template and rule added
- [ ] Run `/specclaw:build` on any change — agent prompt contains `## Project Context` section
- [ ] Run `/specclaw:pr` — `context.md` updated post-merge, committed

## Version

`0.4.4 → 0.4.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)