### PR TITLE
specclaw: loop-engineering — autonomous build→verify→review loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-06-14 10:20 UTC
+**Last Updated:** 2026-07-10 03:10 UTC
 
 ## Active Changes
 
@@ -10,11 +10,14 @@
 - ✅ **build-engine** — 6/6 tasks (100%) | 0 failed
 - ✅ **build-error-journal** — 3/3 tasks (100%) | 0 failed
 - ✅ **claude-plugin-packaging** — 11/11 tasks (100%) | 0 failed
-- ✅ **git-worktrees** — 3/3 tasks (100%) | 0 failed
+- 🔨 **code-reviewer-agent** — 5/6 tasks (83%) | 0 failed
 - ✅ **github-issues-sync** — 3/3 tasks (100%) | 0 failed
+- ✅ **git-worktrees** — 3/3 tasks (100%) | 0 failed
 - ✅ **karpathy-build-guardrails** — 6/6 tasks (100%) | 0 failed
 - ✅ **learn-command** — 2/2 tasks (100%) | 0 failed
 - ✅ **lifecycle-bug-fixes** — 8/8 tasks (100%) | 0 failed
+- 🔨 **living-project-context** — 8/9 tasks (88%) | 0 failed
+- 🔨 **loop-engineering** — 0/11 tasks (0%) | 0 failed
 - ✅ **pattern-detection** — 3/3 tasks (100%) | 0 failed
 - ✅ **phase-validation** — 2/2 tasks (100%) | 0 failed
 - ✅ **post-build-review** — 1/1 tasks (100%) | 0 failed
@@ -32,6 +35,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 15
-- **Active:** 15
+- **Total changes:** 18
+- **Active:** 18
 - **Completed:** 0

--- a/.specclaw/changes/loop-engineering/design.md
+++ b/.specclaw/changes/loop-engineering/design.md
@@ -1,0 +1,118 @@
+# Design: Loop Engineering — Autonomous Build→Verify→Review Loop
+
+**Change:** loop-engineering
+**Created:** 2026-07-10
+
+## Technical Approach
+
+A new bash controller `specclaw-loop` owns all mechanical loop logic (gate evaluation, signature computation, progress/regression/oscillation detection, halt decisions, state/log persistence). A new `/specclaw:loop` skill is the orchestrator: it calls the controller for decisions and spawns the fix / verify / review agents. This mirrors the existing split — scripts do deterministic work, skills drive the LLM steps.
+
+The loop **reuses** existing engines: `specclaw-parse-tasks` (task-completion gate), `specclaw-verify` (verify gate), the `code-reviewer` agent (review gate), and `build.{test,lint,build}_command` (test gates). It does not reimplement any of them.
+
+State lives in two files per change:
+- `loop-state.json` — machine state: turn number, per-turn passing-gate count, last failure signature, signature history (for oscillation), CI turn count.
+- `loop-log.md` — human/audit trail: one entry per iteration.
+
+## Architecture
+
+```
+/specclaw:loop <change>
+  │
+  ├─ specclaw-loop init      → seed loop-state.json + loop-log.md
+  │
+  └─ repeat (turn = 1..max_iterations):
+       ├─ specclaw-loop gates .specclaw <change>
+       │     → runs: tasks-complete? tests? verify PASS? review 0 BLOCK?
+       │     → emits JSON: {all_green, gates:[{name,green,errors,files}], passing_count}
+       │
+       ├─ if all_green → specclaw-loop done → exit PASS
+       │
+       ├─ specclaw-loop decide .specclaw <change> <passing_count> <failure_sig>
+       │     → checks: cap? no-progress? regression? oscillation?
+       │     → emits: {action: "continue"|"halt", reason}
+       │
+       ├─ if halt → specclaw-loop escalate (commit partial, keep worktree, notify) → exit
+       │
+       └─ else:
+            ├─ build reflection + failure record (from gates JSON)
+            ├─ specclaw-build-context ... --failure-record <file>   (remediation payload)
+            ├─ spawn fix agent (models.coding)
+            ├─ specclaw-loop guard-tests .specclaw <change>   → reject turn if test files touched
+            ├─ commit fix
+            └─ specclaw-loop log-turn ...   (append to loop-log.md, update loop-state.json)
+
+  (opt-in, after PR push, loop.ci_gate: true)
+  └─ repeat (ci_turn = 1..ci_max_iterations):
+       ├─ specclaw-loop ci-poll .specclaw <change>   → gh pr checks / az pipelines
+       ├─ if green → done
+       ├─ if timeout/cap → escalate
+       └─ else pull failed logs (gh run view --log-failed) → fix cycle → push → re-poll
+```
+
+### Failure signature
+
+`failure_sig = sha1( sorted(red_gate_names) + normalized_error_fingerprint )`. Normalization strips line-number noise and timestamps so "same error, different run" collapses to one signature. Stored in `loop-state.json` history; drives no-progress (identical consecutive), oscillation (Nth identical / A→B→A), and new-vs-repeat flag in the failure record.
+
+### Reward-hacking guard (`guard-tests`)
+
+After the fix agent runs, `git diff --name-only` is intersected with the test-file globs (derived from `build.test_command` conventions + a configurable `loop.test_paths` glob list). Any intersection → turn rejected, logged as `reward_hack_guard` trip, diff of the test files reverted (or the whole fix turn reverted per `loop.guard_action`), and the turn counts as a failure (does not advance progress). Tests are executed from the committed HEAD reference, never from agent-staged changes within the same turn.
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/bin/specclaw-loop` | Create | Controller: `init`, `gates`, `decide`, `guard-tests`, `log-turn`, `escalate`, `done`, `ci-poll`, `--help`. Bash + git + coreutils; `gh`/`az` for ci-poll. |
+| `plugins/specclaw/skills/loop/SKILL.md` | Create | `/specclaw:loop` orchestrator skill. |
+| `plugins/specclaw/bin/specclaw-build-context` | Modify | Accept optional `--failure-record <file>` + `--reflection <file>` and inject into the remediation payload. |
+| `plugins/specclaw/templates/config.yaml` (or init default) | Modify | Add `loop:` block with defaults (`enabled: true`, caps, `no_progress_limit`, `ci_gate`, `test_paths`, `guard_action`, `ci_timeout_seconds`). |
+| `plugins/specclaw/bin/specclaw-init` | Modify | Emit the new `loop:` block in generated `config.yaml`. |
+| `plugins/specclaw/skills/build/SKILL.md` | Modify | Note: when `loop.enabled`, build is a loop turn; single-pass otherwise. |
+| `plugins/specclaw/skills/verify/SKILL.md` | Modify | Reference loop remediation instead of manual-only remediation. |
+| `plugins/specclaw/skills/pr/SKILL.md` + `pr-azdo/SKILL.md` | Modify | Trigger CI outer loop when `loop.ci_gate: true` after push. |
+| `plugins/specclaw/CLAUDE.md` | Modify | Document loop tier, `/specclaw:loop`, `loop:` config, reward-hack guard. |
+| `plugins/specclaw/.claude-plugin/plugin.json` | Modify | Version bump. |
+| `.claude-plugin/marketplace.json` | Modify | Version bump (in sync). |
+
+## Data Model Changes
+
+**`config.yaml` — new `loop:` block:**
+```yaml
+loop:
+  enabled: true            # default-on
+  max_iterations: 5        # local inner loop cap
+  no_progress_limit: 2     # consecutive identical/empty turns → halt
+  guard_action: "revert-tests"   # revert-tests | revert-turn
+  test_paths: []           # globs identifying test files (reward-hack guard)
+  ci_gate: false           # opt-in outer CI loop
+  ci_max_iterations: 3
+  ci_timeout_seconds: 1200 # per-cycle CI wall-clock before halt
+```
+
+**`loop-state.json` (per change):**
+```json
+{ "turn": 0, "passing_count": 0, "sig_history": [], "ci_turn": 0 }
+```
+
+**`loop-log.md` (per change):** markdown, one `## Turn N` section per iteration with gate table, signature, reflection, action, decision.
+
+## API Changes
+
+- `specclaw-loop <subcommand>` — new CLI (see file map).
+- `specclaw-build-context` gains optional `--failure-record` / `--reflection` flags (backward compatible — omitted = current behavior).
+
+## Key Decisions
+
+1. **Controller owns guardrails, skill owns LLM steps** — matches existing script/skill split; guardrails are code (a law), not prompt text (a suggestion).
+2. **Whole-change re-verify each turn** (per operator decision) — simpler, catches cross-gate regressions; accept the extra cost.
+3. **Default-on** (per operator decision) — ships enabled; correctness of guardrails is therefore gating.
+4. **CI tier reuses `gh`/`az`, lives in specclaw** — MCD only for detached runs (out of scope).
+5. **Signature-based detection** rather than semantic diffing — cheap, deterministic, no extra LLM calls for control flow.
+6. **Reward-hack guard defaults to `revert-tests`** — least destructive; agent keeps source progress, loses only illegal test edits.
+
+## Risks & Mitigations
+
+- **R1 — Runaway spend (default-on).** Mitigated by iteration cap + no-progress + regression tripwire, all checked before the next spawn. → Verified by AC2/AC3/AC4.
+- **R2 — Reward hacking slips through.** Highest-risk. Mitigated by test-file diff rejection + pinned test execution. → Verified by AC5; verify phase must exercise it adversarially.
+- **R3 — Signature normalization too aggressive/loose.** Too loose → misses no-progress; too tight → false oscillation halts. → Start conservative (strip only line numbers/timestamps), tune via loop-log evidence.
+- **R4 — CI polling hangs.** Mitigated by `ci_timeout_seconds` + "no checks = green after grace" rule. → Verified by AC8 + edge cases.
+- **R5 — Backward-compat break.** Mitigated by `loop.enabled: false` restoring single-pass exactly. → Verified by AC9.

--- a/.specclaw/changes/loop-engineering/proposal.md
+++ b/.specclaw/changes/loop-engineering/proposal.md
@@ -1,0 +1,96 @@
+# Proposal: Loop Engineering — Autonomous Build→Verify→Review Loop
+
+**Created:** 2026-07-10
+**Status:** 🟡 Draft
+
+## Problem
+
+The specclaw lifecycle stops being autonomous exactly where it matters most. `/specclaw:build` runs the tasks and `/specclaw:verify` checks them, but when verify returns **FAIL** or **PARTIAL**, remediation is **manual**: the `verify` skill's "Remediation" section only *suggests* the user re-plan or hand-fix, then re-verify. A human has to read the report, decide what to fix, drive the next build, and re-run verify — every iteration.
+
+That means a change is never truly "done" by the tool. Tests can be red, code review can raise BLOCK findings, and the lifecycle still hands control back to the operator to babysit the fix-verify cycle. For anything non-trivial this is several manual round-trips.
+
+We want the build→verify→review steps to **run as a loop** that closes on its own: keep fixing and re-verifying until the change is actually complete — all tasks done, tests green, code review clean — with hard guardrails so it never thrashes forever.
+
+## Proposed Solution
+
+Add a **loop controller** that wraps build→verify→(code-review) into an autonomous iterate-until-done cycle, grounded in the *evaluator-optimizer* agent pattern (Anthropic, *Building Effective Agents*) with *Reflexion*-style feedback (Shinn et al.).
+
+**Loop shape** (owned by a controller script + a new `/specclaw:loop` skill, not by prompt text):
+
+```
+until all_gates_green:
+    build/fix           # optimizer: minimal-diff remediation
+    run gates           # evaluator: tests, lint, verify ACs, code review
+    if regressed OR duplicate-failure×N OR no-progress OR cap-hit:
+        escalate + preserve state   # commit partial, keep worktree, log trail
+        stop
+    else:
+        reflect → feed structured failure forward
+```
+
+**Two-tier loop.** The loop runs in two nested stages:
+- **Inner loop (local, default-on):** build → verify → code-review → local test/lint/typecheck. Fast (seconds–minutes), all in-session.
+- **Outer loop (CI, opt-in via `loop.ci_gate`):** after the PR branch is pushed, poll the remote pipeline (GitHub Actions or Azure Pipelines). On red, pull the failed-run logs, feed them back as a structured failure record, fix, push, re-poll — until checks are green. Reuses the already-wired `gh` / `az` CLIs (`gh pr checks --watch`, `gh run view --log-failed`; `az pipelines runs`), so it lives inside specclaw — **not** an MCD-only workflow. MCD's scheduling layer (ScheduleWakeup / cron) is only needed for *fully detached* runs across long CI waits; in-session it is a blocking poll.
+
+**Done = mechanical gate, all-green simultaneously:**
+1. All tasks in `tasks.md` complete.
+2. Configured `test_command` / lint / typecheck exit clean (local).
+3. `/specclaw:verify` verdict = **PASS** (all spec acceptance criteria met).
+4. Code review returns **zero BLOCK** findings.
+5. **(If `loop.ci_gate: true`)** all remote PR/merge checks (GitHub Actions / Azure Pipelines) green.
+
+**Feedback routing (Reflexion):** each failed iteration produces a *structured failure record* — which gate failed, specific errors, implicated files/lines, and whether the failure is **new or a repeat** — plus a compact verbal reflection. Only that record + reflection carry forward (not full transcripts), keeping context lean. Remediation agents are instructed to make the **smallest diff** that turns the failing gate green.
+
+**Anti-thrash guardrails (enforced in the controller, not the prompt):**
+- **Iteration ceiling** (`loop.max_iterations`, default e.g. 5) + optional wall-clock / spend cap that aborts *before* the next paid agent call.
+- **No-progress detection:** hash the diff + failure signature each turn; N identical/empty turns → halt.
+- **Oscillation detection:** track failure signatures; Nth identical failure and A→B→A flip-flops route to escalation, not another retry.
+- **Regression tripwire:** if the count of passing gates *drops* vs. the prior turn, stop — agent is going backwards.
+- **Escalate + preserve:** on any halt condition, commit partial work, keep the git worktree intact, log the reflection trail, notify the operator with a clear "why it stopped."
+
+**Reward-hacking defense (critical):** agents must not be able to fake a pass. Run tests from a **read-only / pinned copy** the fix agent can't edit; **diff the test files** each iteration and **reject** any change that touches the test harness within a fix turn; require the remediation diff to modify source, not the scorer.
+
+## Scope
+
+- New `specclaw-loop` controller script (`bin/`) owning gate evaluation, progress/regression/oscillation detection, and halt/escalate decisions.
+- New `/specclaw:loop` skill orchestrating build → verify → code-review → reflect → re-fix.
+- **Outer CI-gate stage:** poll GitHub Actions / Azure Pipelines after PR push, pull failed-run logs, feed back, fix, push, re-poll until green. Reuses `gh` / `az`. Opt-in via `loop.ci_gate`.
+- Structured failure-record + reflection format fed into remediation context (extend `specclaw-build-context`).
+- Config keys under `loop:` in `config.yaml` (`enabled` default **true**, `max_iterations`, caps, `protect_tests`, `ci_gate`, `ci_max_iterations`).
+- Reward-hacking guard: test-file diff rejection + read-only test execution.
+- Escalation + state-preservation path (partial commit, worktree kept, notification).
+- Wire into existing build/verify/pr skills so the loop runs by default (`loop.enabled: true`).
+
+### Out of Scope
+- Rewriting the existing single-pass build or verify engines — the loop *reuses* them.
+- Multi-change / cross-change orchestration (loop is per-change).
+- Model fine-tuning or training-based self-correction.
+- **Fully detached / unattended CI looping across long waits** — that needs MCD scheduling (ScheduleWakeup / cron) and is a separate integration. This proposal covers in-session CI polling only.
+- Defining or authoring the CI pipelines themselves — the loop only *consumes* their pass/fail signal.
+
+## Impact
+
+- **Files affected:** ~8–12 (estimated) — 1 new controller script, 1 new skill, edits to build/verify/pr skills, `specclaw-build-context`, config schema, plugin CLAUDE.md, version bumps.
+- **Complexity:** medium–large
+- **Risk:** medium — autonomous loop spends tokens and mutates code unattended; guardrails (caps, regression tripwire, reward-hack defense) are the primary risk mitigation and must be solid before enabling by default.
+
+## Decisions
+
+- **Default-on.** `loop.enabled: true` by default. Guardrails (caps, regression tripwire, reward-hack defense) must be solid since it runs unattended out of the box.
+- **CI gate is in scope**, as an opt-in outer loop tier reusing `gh` / `az`. Not MCD-only; MCD only needed for detached long-wait runs (out of scope).
+- **Iteration caps:** inner (local) loop `max_iterations: 5`; CI outer loop `ci_max_iterations: 3` (each cycle = full pipeline, expensive).
+- **Gate granularity:** re-verify the **whole change** each turn (not per-failing-gate scope) — simpler, avoids masking cross-gate regressions.
+- **Reflection trail persisted** to `.specclaw/changes/<change>/loop-log.md` — audit trail + enables resume.
+
+## Open Questions
+
+_Resolved. Ready to plan._
+
+Deferred to design (non-blocking):
+- Token/wall-clock spend ceiling in addition to iteration count — add now or later.
+- Require `git.strategy: worktree-per-change` when loop enabled.
+- CI poll cadence & per-cycle timeout for hung pipelines (default ~20 min wall-clock).
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/loop-engineering/spec.md
+++ b/.specclaw/changes/loop-engineering/spec.md
@@ -1,0 +1,68 @@
+# Spec: Loop Engineering — Autonomous Build→Verify→Review Loop
+
+**Change:** loop-engineering
+**Created:** 2026-07-10
+**Status:** 🟡 Draft
+
+## Overview
+
+Add an autonomous iterate-until-done loop around the existing build→verify→review phases. When a gate fails, the loop feeds a structured failure record back into a targeted fix, re-runs the whole change through all gates, and repeats until every gate is green — or a guardrail halts it and escalates to the operator. An optional outer tier extends the loop to remote CI (GitHub Actions / Azure Pipelines). Grounded in the evaluator-optimizer + Reflexion patterns.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR1 — Loop controller.** A new `specclaw-loop` script owns gate evaluation and all halt/continue decisions. The `/specclaw:loop` skill orchestrates: run gates → if all green, done → else reflect, fix, re-run.
+- **FR2 — Local gate set.** Each iteration evaluates, over the *whole change*: (a) all tasks in `tasks.md` complete, (b) `test_command` / `lint_command` / `build_command` exit clean (skipped if unset), (c) `/specclaw:verify` verdict = PASS, (d) code review returns zero BLOCK findings. Done = all applicable gates green simultaneously.
+- **FR3 — Structured failure feedback.** On any red gate, the controller emits a failure record: gate name, specific errors, implicated files/lines, and a new-vs-repeat flag (by failure signature). The fix agent receives this record + a compact reflection and is instructed to make the smallest diff that turns the failing gate green.
+- **FR4 — Iteration caps.** Local loop stops after `loop.max_iterations` (default 5). CI outer loop stops after `loop.ci_max_iterations` (default 3). Cap check happens *before* spawning the next agent / triggering the next CI cycle.
+- **FR5 — No-progress detection.** Each turn the controller records a signature = hash(diff) + failure-signature. If N consecutive turns produce an empty diff or the identical failure signature, the loop halts (`loop.no_progress_limit`, default 2).
+- **FR6 — Regression tripwire.** The controller tracks the count of passing gates per turn. If passing count drops vs. the prior turn, the loop halts immediately (agent went backwards).
+- **FR7 — Oscillation detection.** Failure signatures are tracked across turns; the Nth identical failure and A→B→A flip-flop patterns route to escalation rather than another retry.
+- **FR8 — Escalate + preserve state.** On any halt condition, the controller commits partial work, keeps the git worktree intact, finalizes `loop-log.md`, and emits an operator notification explaining exactly why it stopped and the current gate status.
+- **FR9 — Reward-hacking guard.** Within a fix turn the controller diffs the test files (paths under the configured test globs); if the fix agent modified any test file, that turn is rejected and counts as a failure. Tests run from a pinned/read-only reference so the harness itself cannot be gamed.
+- **FR10 — Reflection trail.** A per-change `loop-log.md` records each iteration: turn number, gate results, failure signature, reflection, action taken, and the halt/continue decision. Enables audit and resume.
+- **FR11 — CI outer loop (opt-in).** When `loop.ci_gate: true`, after the PR branch is pushed the controller polls remote checks (`gh pr checks` / `az pipelines runs`). On failure it pulls failed-run logs (`gh run view --log-failed`), feeds them back as a failure record, fixes, pushes, and re-polls until green or `ci_max_iterations` / CI wall-clock timeout is hit.
+- **FR12 — Config-driven, default-on.** All behavior is controlled by a `loop:` block in `config.yaml`. `loop.enabled` defaults to **true**. Existing single-pass build/verify still works when `loop.enabled: false`.
+
+### Non-Functional Requirements
+
+- **NFR1 — Bash + coreutils + git only** for the controller script, matching all existing `bin/` scripts (`gh` / `az` for CI tier). No new runtime dependency.
+- **NFR2 — Reuses existing engines.** The loop calls the existing `specclaw-build`, `specclaw-verify`, `code-reviewer` agent, and `specclaw-parse-tasks` — it does not reimplement them.
+- **NFR3 — Bounded context.** Only the compact reflection + current failure record carry across iterations; full transcripts are not accumulated.
+- **NFR4 — Backward compatible.** A change that never fails a gate behaves like today's single-pass flow (loop exits after iteration 1).
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- **AC1** — With `loop.enabled: true` and a change whose first build leaves a failing test, the loop performs at least one fix iteration and exits PASS once the test is fixed, without manual intervention.
+- **AC2** — The loop exits after exactly `loop.max_iterations` iterations when gates never go green, and emits an escalation notification stating the unmet gates.
+- **AC3** — When a fix turn produces an empty diff or repeats the identical failure signature `no_progress_limit` times, the loop halts and escalates (no further agent spawn).
+- **AC4** — When the count of passing gates drops between turns, the loop halts immediately (regression tripwire) and escalates.
+- **AC5** — If a fix agent modifies a test file within a fix turn, that turn is rejected and logged as a reward-hack guard trip; the test change is not counted as progress.
+- **AC6** — `loop-log.md` exists after any loop run and contains one entry per iteration with gate results, signature, reflection, and decision.
+- **AC7** — On any halt, partial work is committed and the worktree is left intact (verifiable via `git log` / worktree presence).
+- **AC8** — With `loop.ci_gate: true`, after a push the loop polls CI, and on a red check pulls the failed log, performs a fix cycle, and re-polls; it stops at `ci_max_iterations` or CI timeout with escalation.
+- **AC9** — With `loop.enabled: false`, build and verify behave exactly as before this change (no loop, no new files required).
+- **AC10** — `specclaw-loop --help`, config schema, and plugin CLAUDE.md document the `loop:` block and the `/specclaw:loop` skill.
+
+## Edge Cases
+
+- No test/lint/build commands configured → those gates are treated as trivially green (not failures).
+- `git.strategy: direct` (no worktree) → loop still runs; state-preservation commits to the current branch and warns that no isolated worktree exists.
+- CI configured but no pipeline attached to the PR → `ci_gate` treats "no checks" as green after a short grace poll, with a logged warning (avoids infinite wait).
+- Change already PASSing on entry → loop exits after iteration 1 with no fix.
+- Hung CI pipeline → CI wall-clock timeout triggers a halt+escalate rather than blocking forever.
+- Concurrent gate failures (e.g. test + review both red) → single failure record enumerates all red gates; fix agent addresses all, whole change re-verified next turn.
+
+## Dependencies
+
+- Existing `specclaw-build`, `specclaw-verify`, `specclaw-parse-tasks`, `specclaw-build-context`, `specclaw-update-status`.
+- `code-reviewer` agent (from `code-reviewer-agent` change).
+- `gh` / `az` CLIs for the opt-in CI tier only.
+
+## Notes
+
+- MCD scheduling (detached long-wait CI looping) is explicitly out of scope; CI polling here is in-session blocking.
+- Reward-hacking defense (FR9) is the highest-risk correctness requirement given default-on operation — it must be verified thoroughly.

--- a/.specclaw/changes/loop-engineering/status.md
+++ b/.specclaw/changes/loop-engineering/status.md
@@ -1,0 +1,31 @@
+# Status: Loop Engineering — Autonomous Build→Verify→Review Loop
+
+**Change:** loop-engineering
+**Started:** 2026-07-10
+**Last Updated:** 2026-07-10
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | ✅ Approved | Default-on, CI gate in scope |
+| Spec | ✅ Done | 12 FR, 4 NFR, 10 AC |
+| Design | ✅ Done | Controller + skill split |
+| Tasks | ✅ Done | 10 tasks, 4 waves |
+| Build | ⬜ Pending | |
+| Verify | ⬜ Pending | |
+
+## Task Progress
+
+**Completed:** 0 / 0
+**Failed:** 0
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+
+## Issues
+
+_None._
+**GitHub Issue:** N/A (Issues disabled on chan4lk/specclaw)

--- a/.specclaw/changes/loop-engineering/tasks.md
+++ b/.specclaw/changes/loop-engineering/tasks.md
@@ -1,0 +1,95 @@
+# Tasks: Loop Engineering — Autonomous Build→Verify→Review Loop
+
+**Change:** loop-engineering
+**Created:** 2026-07-10
+**Total Tasks:** 10
+
+## Summary
+
+Build the `specclaw-loop` controller (gates, guardrails, state/log, CI poll), a `/specclaw:loop` orchestrator skill, wire the failure-record feedback into `specclaw-build-context`, add the `loop:` config block (default-on), update the affected skills + docs, and bump the version. Wave 1 lays the config + controller skeleton; wave 2 adds the guardrails, reward-hack guard, and CI tier; wave 3 wires the skill and existing lifecycle skills; wave 4 documents and bumps.
+
+## Tasks
+
+### Wave 1 — Foundation: config schema + controller core
+
+- [x] `T1` — Add `loop:` config block (default-on) to init + template
+  - Files: `plugins/specclaw/bin/specclaw-init`, `plugins/specclaw/templates/config.yaml`
+  - Estimate: small
+  - Notes: Emit `loop:` block with defaults from design (`enabled: true`, `max_iterations: 5`, `no_progress_limit: 2`, `guard_action: revert-tests`, `test_paths: []`, `ci_gate: false`, `ci_max_iterations: 3`, `ci_timeout_seconds: 1200`). Reuse existing `yaml_val` reading convention.
+
+- [x] `T2` — `specclaw-loop` skeleton: `init`, `gates`, `done`, `--help`
+  - Files: `plugins/specclaw/bin/specclaw-loop`
+  - Estimate: large
+  - Notes: Bash + git + coreutils, `set -euo pipefail`, copy `yaml_val`/`die`/`warn`/`json_escape` helpers from `specclaw-verify`. `init` seeds `loop-state.json` + `loop-log.md`. `gates` runs the four local gates (tasks-complete via `specclaw-parse-tasks`, test/lint/build commands, verify verdict from `verify-report.md`, review BLOCK count from `review-report.md`) and emits JSON `{all_green, passing_count, gates:[{name,green,errors,files}]}`. `done` emits final PASS summary. Executable bit set.
+
+### Wave 2 — Guardrails, reward-hack guard, CI tier
+
+- [x] `T3` — Signature + `decide` (cap / no-progress / regression / oscillation)
+  - Files: `plugins/specclaw/bin/specclaw-loop`
+  - Estimate: large
+  - Depends: T2
+  - Notes: `failure_sig = sha1(sorted red gates + normalized error fingerprint)` (strip line numbers/timestamps). `decide` reads `loop-state.json` + args (`passing_count`, `failure_sig`), applies FR4–FR7, emits `{action, reason}`. `log-turn` appends to `loop-log.md` and updates `loop-state.json` (turn, passing_count, sig_history, ci_turn).
+
+- [x] `T4` — Reward-hack guard: `guard-tests`
+  - Files: `plugins/specclaw/bin/specclaw-loop`
+  - Estimate: medium
+  - Depends: T2
+  - Notes: After fix turn, intersect `git diff --name-only` with `loop.test_paths` globs. On hit: per `guard_action`, revert test files (`revert-tests`) or the whole turn (`revert-turn`); log `reward_hack_guard` trip; mark turn as non-progress failure. Tests execute from committed HEAD, never agent-staged same-turn changes.
+
+- [x] `T5` — `escalate` + state preservation
+  - Files: `plugins/specclaw/bin/specclaw-loop`
+  - Estimate: medium
+  - Depends: T3
+  - Notes: Commit partial work (specclaw prefix), keep worktree intact (warn if `git.strategy: direct`), finalize `loop-log.md`, emit operator notification text stating halt reason + current gate status.
+
+- [x] `T6` — CI outer loop: `ci-poll`
+  - Files: `plugins/specclaw/bin/specclaw-loop`
+  - Estimate: large
+  - Depends: T3
+  - Notes: When `loop.ci_gate: true`. GitHub: `gh pr checks` / `gh run view --log-failed`. Azure: `az pipelines runs`. Emit `{status: green|red|timeout|no-checks, failed_log}`. Honor `ci_max_iterations` + `ci_timeout_seconds`; "no checks after grace" → green + warn. In-session polling only (no MCD).
+
+### Wave 3 — Feedback wiring + orchestrator skill + lifecycle integration
+
+- [x] `T7` — `specclaw-build-context`: `--failure-record` / `--reflection`
+  - Files: `plugins/specclaw/bin/specclaw-build-context`
+  - Estimate: medium
+  - Depends: T2
+  - Notes: Optional flags inject failure record + reflection + "smallest diff to turn the failing gate green" instruction into the remediation payload. Backward compatible: omitted = current behavior.
+
+- [x] `T8` — `/specclaw:loop` orchestrator skill
+  - Files: `plugins/specclaw/skills/loop/SKILL.md`
+  - Estimate: large
+  - Depends: T3, T4, T5, T6, T7
+  - Notes: Orchestrate per design: init → turn loop (gates → done? / decide → halt? / build reflection+record → build-context --failure-record → spawn fix agent (models.coding) → guard-tests → commit → log-turn) → optional CI tier after PR push. `ensure_init` first. Notifications on done/halt.
+
+- [x] `T9` — Wire loop into build/verify/pr skills
+  - Files: `plugins/specclaw/skills/build/SKILL.md`, `plugins/specclaw/skills/verify/SKILL.md`, `plugins/specclaw/skills/pr/SKILL.md`, `plugins/specclaw/skills/pr-azdo/SKILL.md`
+  - Estimate: medium
+  - Depends: T8
+  - Notes: build/verify note loop behavior when `loop.enabled`; verify replaces manual-only remediation with loop remediation reference; pr/pr-azdo trigger CI outer loop when `loop.ci_gate: true` after push. Preserve single-pass path when `loop.enabled: false` (AC9).
+
+### Wave 4 — Docs + version bump
+
+- [ ] `T10` — Document loop + bump version
+  - Files: `plugins/specclaw/CLAUDE.md`, `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  - Estimate: small
+  - Depends: T8, T9
+  - Notes: Document loop tier, `/specclaw:loop`, `loop:` config block, reward-hack guard, CI tier + MCD boundary. Patch-bump version in both files (keep in sync).
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T<n>` — <title>
+  - Files: <files to create/modify>
+  - Estimate: small | medium | large
+  - Depends: <task ids> (if any)
+  - Notes: <additional context>
+```

--- a/.specclaw/changes/loop-engineering/tasks.md
+++ b/.specclaw/changes/loop-engineering/tasks.md
@@ -70,7 +70,7 @@ Build the `specclaw-loop` controller (gates, guardrails, state/log, CI poll), a 
 
 ### Wave 4 — Docs + version bump
 
-- [ ] `T10` — Document loop + bump version
+- [x] `T10` — Document loop + bump version
   - Files: `plugins/specclaw/CLAUDE.md`, `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
   - Estimate: small
   - Depends: T8, T9

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -22,6 +22,18 @@ Every specclaw project can have a `.specclaw/context.md` — a living architectu
 
 Each phase has a corresponding skill. Run them in order. See individual SKILL.md files under `skills/` for details.
 
+## Loop (autonomous build → verify → review)
+
+When `loop.enabled: true` (the default), `/specclaw:loop` closes the build→verify→review cycle automatically instead of stopping at a FAIL/PARTIAL verdict. Each turn: run the four **local gates** (tasks-complete, test/lint/build commands, verify verdict, review BLOCK count) → if all green, done → otherwise `decide` whether to keep going or halt → feed the failing gates back as a structured **failure record** via `specclaw-build-context --failure-record` → a fix agent (`models.coding`) makes the *smallest diff to turn the failing gate green* → guard → commit → log the turn. Repeats until every gate is green or a guardrail halts.
+
+**Guardrails (halt + escalate):** iteration cap (`max_iterations`), no-progress limit (`no_progress_limit` turns with no gate improvement), regression (a green gate goes red), and oscillation (a `failure_sig` repeats). On halt, `specclaw-loop escalate` commits partial work with the specclaw prefix, keeps the worktree intact, finalizes `loop-log.md`, and notifies the operator with the halt reason + current gate status.
+
+**Reward-hack guard:** after each fix turn, changed files are intersected with `loop.test_paths`. On a hit the guard reverts the test edits (`guard_action: revert-tests`) or the whole turn (`revert-turn`), logs the trip, and marks the turn a non-progress failure — tests always execute from committed HEAD, never same-turn agent edits.
+
+**CI outer loop:** when `loop.ci_gate: true`, after the PR branch is pushed the loop polls CI (`specclaw-loop ci-poll` — `gh pr checks` for GitHub, `az pipelines runs` for Azure) and iterates fixes until green, or `ci_max_iterations` / `ci_timeout_seconds` halts. Polling is **in-session only** (no MCD / background messaging); "no checks after grace" counts as green with a warning.
+
+**Config** — the `loop:` block (seeded default-on by `specclaw-init`): `enabled`, `max_iterations` (5), `no_progress_limit` (2), `guard_action` (`revert-tests`), `test_paths` ([]), `ci_gate` (false), `ci_max_iterations` (3), `ci_timeout_seconds` (1200). Set `loop.enabled: false` for the single-pass path — build/verify/pr behave exactly as their SKILL.md documents, no loop, no extra files.
+
 ## Scripts
 
 All executable scripts live in `bin/`. Key ones:
@@ -29,7 +41,8 @@ All executable scripts live in `bin/`. Key ones:
 | Script | Purpose |
 |--------|---------|
 | `specclaw-ensure-init` | Idempotently init `.specclaw/` |
-| `specclaw-build-context` | Build coding agent payload (includes context.md) |
+| `specclaw-build-context` | Build coding agent payload (includes context.md; `--failure-record`/`--reflection` for loop remediation) |
+| `specclaw-loop` | Autonomous loop controller: `init` / `gates` / `decide` / `guard-tests` / `log-turn` / `escalate` / `ci-poll` / `done` |
 | `specclaw-update-context` | Output LLM prompt to rewrite context.md post-merge |
 | `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard |
 | `specclaw-gh-sync` | GitHub Issues sync |

--- a/plugins/specclaw/bin/specclaw-build-context
+++ b/plugins/specclaw/bin/specclaw-build-context
@@ -15,7 +15,7 @@ MAX_FILE_LINES=500
 # --- Help ---
 usage() {
   cat <<'EOF'
-Usage: specclaw-build-context <specclaw_dir> <change_name> <task_id>
+Usage: specclaw-build-context <specclaw_dir> <change_name> <task_id> [options]
 
 Build a context payload for a coding agent to implement a specific task.
 
@@ -24,18 +24,61 @@ Arguments:
   change_name    Name of the current change (subdirectory under changes/)
   task_id        Task ID to build context for (e.g. T1, T4)
 
+Options:
+  --failure-record <file>   Structured failure record from a failing gate (loop turn).
+  --reflection <file>       Compact reflection text on the failure (loop turn).
+
+When --failure-record or --reflection is given, a "Remediation Context (Loop Turn)"
+section is appended to the payload instructing the smallest diff to turn the failing
+gate(s) green. Omitting both leaves the payload byte-identical to the base behavior.
+
 The script reads spec.md, design.md, task details, and existing file contents,
 then outputs a formatted prompt to stdout.
 
 Examples:
   specclaw-build-context .specclaw my-feature T3
   specclaw-build-context /project/.specclaw auth-system T1
+  specclaw-build-context .specclaw my-feature T3 --failure-record fail.json --reflection reflect.md
 EOF
   exit 0
 }
 
 # --- Argument parsing ---
-[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+# Positionals: <specclaw_dir> <change_name> <task_id>
+# Optional flags (positional-agnostic): --failure-record <file>, --reflection <file>
+FAILURE_RECORD_FILE=""
+REFLECTION_FILE=""
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    --failure-record)
+      FAILURE_RECORD_FILE="${2:-}"
+      shift 2
+      ;;
+    --failure-record=*)
+      FAILURE_RECORD_FILE="${1#*=}"
+      shift
+      ;;
+    --reflection)
+      REFLECTION_FILE="${2:-}"
+      shift 2
+      ;;
+    --reflection=*)
+      REFLECTION_FILE="${1#*=}"
+      shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}"
 
 if [[ $# -lt 3 ]]; then
   echo "ERROR: Expected 3 arguments: <specclaw_dir> <change_name> <task_id>" >&2
@@ -362,6 +405,55 @@ ${TASK_ERRORS}"
   fi
 fi
 
+# --- Remediation context (loop turn) ---
+# When --failure-record or --reflection is provided, append a delimited section
+# instructing the smallest diff to turn the failing gate(s) green.
+# Missing/unreadable files warn to stderr and are treated as not provided.
+REMEDIATION_SECTION=""
+
+REFLECTION_CONTENT=""
+if [[ -n "$REFLECTION_FILE" ]]; then
+  if [[ -f "$REFLECTION_FILE" && -r "$REFLECTION_FILE" ]]; then
+    REFLECTION_CONTENT="$(cat "$REFLECTION_FILE")"
+  else
+    echo "WARNING: reflection file not found or unreadable: $REFLECTION_FILE — ignoring" >&2
+  fi
+fi
+
+FAILURE_RECORD_CONTENT=""
+if [[ -n "$FAILURE_RECORD_FILE" ]]; then
+  if [[ -f "$FAILURE_RECORD_FILE" && -r "$FAILURE_RECORD_FILE" ]]; then
+    FAILURE_RECORD_CONTENT="$(cat "$FAILURE_RECORD_FILE")"
+  else
+    echo "WARNING: failure record file not found or unreadable: $FAILURE_RECORD_FILE — ignoring" >&2
+  fi
+fi
+
+if [[ -n "$REFLECTION_CONTENT" || -n "$FAILURE_RECORD_CONTENT" ]]; then
+  REMEDIATION_SECTION="## Remediation Context (Loop Turn)
+
+A previous attempt at this task left one or more gates failing. Use the context
+below to fix it.
+"
+  if [[ -n "$REFLECTION_CONTENT" ]]; then
+    REMEDIATION_SECTION+="
+### Reflection
+${REFLECTION_CONTENT}
+"
+  fi
+  if [[ -n "$FAILURE_RECORD_CONTENT" ]]; then
+    REMEDIATION_SECTION+="
+### Failure Record
+\`\`\`
+${FAILURE_RECORD_CONTENT}
+\`\`\`
+"
+  fi
+  REMEDIATION_SECTION+="
+Make the SMALLEST diff that turns the failing gate(s) green. Do not touch unrelated code. Do not modify test files to force a pass.
+"
+fi
+
 # --- Build the prompt ---
 cat <<PROMPT
 You are a coding agent implementing a specific task in the project "${PROJECT_NAME}".
@@ -383,7 +475,7 @@ ${DESIGN_CONTENT}
 ## Existing Code
 ${EXISTING_CODE}
 
-${ERROR_HISTORY}
+${ERROR_HISTORY}${REMEDIATION_SECTION}
 ## Constraints
 1. ONLY modify/create the files listed above
 2. Follow existing code style and patterns

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -39,8 +39,15 @@ Subcommands (implemented):
                 <action> "<reflection>" "<gates_summary>"
                 Append a turn entry to loop-log.md and update loop-state.json.
 
+  guard-tests   <specclaw_dir> <change_name>
+                Reward-hack guard: run AFTER a fix agent, BEFORE committing the
+                fix turn. Intersect working-tree changes (git diff HEAD) with the
+                configured/built-in test globs. If the fix agent touched a test
+                file, revert it (per loop.guard_action: revert-tests|revert-turn)
+                and emit JSON {tripped, test_files:[...], action, message}. Exits
+                0 (clean, tripped=false) or 3 (guard tripped → turn rejected).
+
 Subcommands (planned — not yet implemented):
-  guard-tests   Reject a fix turn that touched test files (reward-hack guard).
   escalate      Commit partial work, keep worktree, emit halt notification.
   ci-poll       Poll remote CI checks (gh / az) for the opt-in outer loop.
 
@@ -611,6 +618,228 @@ cmd_log_turn() {
   echo "Logged turn ${new_turn} (passing ${passing_count}/4, action ${action})"
 }
 
+# ─── Subcommand: guard-tests ─────────────────────────────────────────────────
+#
+# Reward-hacking guard. Run AFTER a fix agent has edited the working tree but
+# BEFORE the fix turn is committed. Reward hacking = the fix agent games the
+# harness by editing test files instead of fixing the source. This detects it.
+#
+# Mechanism:
+#   1. Read loop.test_paths (a YAML list of globs) + loop.guard_action from
+#      config.yaml. yaml_val only reads single-line scalars, so test_paths is
+#      parsed here directly — tolerant of both inline `[a, b]` and block `- item`
+#      forms. If test_paths is empty, fall back to built-in test globs.
+#   2. Changed files this turn = `git diff --name-only HEAD` — every working-tree
+#      edit (staged + unstaged) since the last commit. Since the loop commits
+#      each turn, HEAD is the last good state, so diffing working-tree-vs-HEAD is
+#      exactly "what the fix agent changed this turn".
+#   3. Intersect changed files with the test globs.
+#        empty     → {"tripped":false,...}, exit 0.
+#        non-empty → revert per guard_action, {"tripped":true,...}, exit 3.
+#
+# guard_action (default "revert-tests"):
+#   revert-tests : revert ONLY the matched test files (git checkout -- <files>),
+#                  leaving the source edits intact so the agent keeps progress.
+#   revert-turn  : revert ALL working-tree changes this turn (git checkout -- .),
+#                  dropping the entire (poisoned) turn.
+#
+# SAFETY:
+#   - Operates only inside the repo working tree (all paths are git-tracked,
+#     repo-relative). It never touches anything outside the working tree.
+#   - Revert reverts working-tree-vs-HEAD only. HEAD is the last committed good
+#     state (the loop commits each turn), so this drops the current uncommitted
+#     fix and nothing else — committed work is untouched. revert-turn uses
+#     `git checkout -- .` (working-tree restore), NOT `git reset --hard`, so no
+#     commit history is disturbed.
+#   - git revert operations have their exit codes checked (die on failure);
+#     only grep/glob classification uses `|| true`.
+#
+# Built-in fallback test globs (used when loop.test_paths is empty):
+#   *_test.*  *.test.*  *_spec.*  *.spec.*  test_*.*  spec_*.*
+#   and any path containing a test directory segment:
+#   /tests/  /test/  /__tests__/  /spec/  (also matched at path start).
+GUARD_FALLBACK_GLOBS='*_test.* *.test.* *_spec.* *.spec.* test_*.* spec_*.*'
+
+# Does path $1 match test-glob classification given the space-separated glob
+# list $2? Uses shell `case` glob matching on the basename AND full path, plus a
+# built-in directory-segment check. Returns 0 (match) / 1 (no match).
+guard_is_test_file() {
+  local path="$1" globs="$2"
+  local base="${path##*/}"
+  local g rc=1
+  # Split the glob list on whitespace regardless of the caller's IFS (callers
+  # iterate with `while IFS= read`, which would otherwise leave IFS empty and
+  # collapse $globs into a single word). Disable pathname expansion too: an
+  # unquoted `for g in $globs` would expand each glob (e.g. test_*.*) against the
+  # CURRENT dir and replace the literal pattern with matching filenames,
+  # corrupting the per-file `case` match. noglob keeps patterns literal.
+  local IFS=$' \t\n'
+  set -f
+  for g in $globs; do
+    # Match against the basename and the full repo-relative path.
+    case "$base" in $g) rc=0; break ;; esac
+    case "$path" in $g) rc=0; break ;; esac
+    # A bare directory-ish glob like "tests/*" or "**/foo" — try a loose
+    # trailing form too so operator-supplied dir globs work intuitively.
+    case "/$path" in */$g) rc=0; break ;; esac
+  done
+  set +f
+  [ "$rc" -eq 0 ] && return 0
+  # Built-in directory-segment check (always applied — reward-hack safety net).
+  case "/$path/" in
+    */tests/*|*/test/*|*/__tests__/*|*/spec/*) return 0 ;;
+  esac
+  return 1
+}
+
+cmd_guard_tests() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local config_file="${specclaw_dir}/config.yaml"
+  local log_file="${change_dir}/loop-log.md"
+
+  # ── Read guard_action (single-line scalar → yaml_val is fine) ────────────────
+  local guard_action=""
+  [ -f "$config_file" ] && guard_action=$(yaml_val "$config_file" "loop.guard_action")
+  [ -z "$guard_action" ] && guard_action="revert-tests"
+
+  # ── Parse loop.test_paths (a YAML list) tolerantly ───────────────────────────
+  # yaml_val reads single-line scalars only, so parse the list by hand. Support:
+  #   inline flow form:   test_paths: [ "a/*", b/**, 'c' ]
+  #   block sequence:     test_paths:
+  #                         - "a/*"
+  #                         - b/**
+  local test_globs=""
+  if [ -f "$config_file" ]; then
+    # Grab the value on the test_paths: line itself (inline form, if any).
+    local tp_inline=""
+    tp_inline=$(grep -E '^[[:space:]]*test_paths:' "$config_file" 2>/dev/null | head -1 \
+                | sed -E 's/^[[:space:]]*test_paths:[[:space:]]*//' \
+                | sed -E 's/[[:space:]]+#.*$//') || true
+    # Inline flow list: strip [ ] and split on commas.
+    case "$tp_inline" in
+      \[*\]*)
+        local body="${tp_inline#*[}"; body="${body%]*}"
+        local IFS=','
+        local item
+        for item in $body; do
+          # trim whitespace + surrounding quotes.
+          item=$(printf '%s' "$item" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')
+          [ -n "$item" ] && test_globs="${test_globs}${item} "
+        done
+        ;;
+    esac
+    # Block sequence: `- item` lines following the test_paths: line, up to the
+    # next non-indented / differently-keyed line. Extract with awk (state machine).
+    local block=""
+    block=$(awk '
+      /^[[:space:]]*test_paths:[[:space:]]*$/ { inblk=1; next }
+      inblk==1 {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]*/) { print; next }
+        if ($0 ~ /^[[:space:]]*#/) { next }         # skip comment lines
+        if ($0 ~ /^[[:space:]]*$/) { next }          # skip blank lines
+        inblk=0                                       # any other line ends block
+      }
+    ' "$config_file" 2>/dev/null) || true
+    if [ -n "$block" ]; then
+      local line item
+      while IFS= read -r line; do
+        item=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*$//; s/[[:space:]]+$//; s/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')
+        [ -n "$item" ] && test_globs="${test_globs}${item} "
+      done <<< "$block"
+    fi
+  fi
+  # Trim trailing whitespace.
+  test_globs=$(printf '%s' "$test_globs" | sed -E 's/[[:space:]]+$//')
+
+  # Fallback to built-in globs when no configured test_paths.
+  local using_fallback=false
+  if [ -z "$test_globs" ]; then
+    test_globs="$GUARD_FALLBACK_GLOBS"
+    using_fallback=true
+  fi
+
+  # ── Compute changed files this turn (working tree vs HEAD) ───────────────────
+  # Staged + unstaged edits since the last commit. Run from the repo root so the
+  # emitted paths are repo-relative and glob matching is consistent.
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root="$(pwd)"
+
+  local changed=""
+  changed=$( ( cd "$repo_root" && git diff --name-only HEAD 2>/dev/null ) || true )
+
+  # ── Intersect changed files with the test globs ──────────────────────────────
+  local matched=""
+  if [ -n "$changed" ]; then
+    local f
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      if guard_is_test_file "$f" "$test_globs"; then
+        matched="${matched}${f}
+"
+      fi
+    done <<< "$changed"
+  fi
+  matched=$(printf '%s' "$matched" | grep -v '^$' || true)
+
+  # Build the JSON array of matched test files.
+  local files_json=""
+  if [ -n "$matched" ]; then
+    local mf
+    while IFS= read -r mf; do
+      [ -z "$mf" ] && continue
+      if [ -n "$files_json" ]; then
+        files_json="${files_json}, \"$(json_escape "$mf")\""
+      else
+        files_json="\"$(json_escape "$mf")\""
+      fi
+    done <<< "$matched"
+  fi
+
+  # ── Not tripped: no test files touched ───────────────────────────────────────
+  if [ -z "$matched" ]; then
+    printf '{"tripped": false, "test_files": [], "action": "none"}\n'
+    return 0
+  fi
+
+  # ── Tripped: revert per guard_action ─────────────────────────────────────────
+  local revert_rc=0
+  if [ "$guard_action" = "revert-turn" ]; then
+    # Drop ALL working-tree changes this turn (working-tree restore vs HEAD).
+    # NOT git reset --hard — history/commits are untouched.
+    ( cd "$repo_root" && git checkout -- . ) || revert_rc=$?
+  else
+    # revert-tests (default): revert ONLY the matched test files, leaving source
+    # edits intact. Feed matched paths via xargs (NUL-safe on newline list).
+    guard_action="revert-tests"
+    while IFS= read -r mf; do
+      [ -z "$mf" ] && continue
+      ( cd "$repo_root" && git checkout -- "$mf" ) || revert_rc=$?
+    done <<< "$matched"
+  fi
+  [ "$revert_rc" -eq 0 ] || die "guard-tests: git revert failed (exit ${revert_rc}) for action ${guard_action}"
+
+  local message="reward-hack guard: fix agent modified test files; reverted per ${guard_action}"
+
+  # ── Append a trip note to loop-log.md if it exists ───────────────────────────
+  if [ -f "$log_file" ]; then
+    local now files_flat
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    files_flat=$(printf '%s' "$matched" | tr '\n' ' ' | sed -E 's/[[:space:]]+$//')
+    {
+      printf '%s%s%s%s\n' '- **reward_hack_guard tripped** (' "$now" '): action=' "$guard_action"
+      printf '%s%s\n' '  - reverted test files: ' "$files_flat"
+      $using_fallback && printf '%s\n' '  - (matched via built-in fallback test globs)'
+    } >> "$log_file"
+  fi
+
+  # ── Emit JSON + exit nonzero (turn rejected, non-progress failure) ───────────
+  printf '{"tripped": true, "test_files": [%s], "action": "%s", "message": "%s"}\n' \
+    "$files_json" "$guard_action" "$(json_escape "$message")"
+  return 3
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
@@ -641,6 +870,10 @@ case "${1:-}" in
   log-turn)
     [ $# -ge 8 ] || die "Usage: specclaw-loop log-turn <specclaw_dir> <change_name> <passing_count> <failure_sig> <action> <reflection> <gates_summary>"
     cmd_log_turn "$2" "$3" "$4" "$5" "$6" "$7" "$8"
+    ;;
+  guard-tests)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop guard-tests <specclaw_dir> <change_name>"
+    cmd_guard_tests "$2" "$3"
     ;;
   "")
     usage

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# specclaw-loop — Autonomous build→verify→review loop controller for specclaw
+# Part of the specclaw skill. Bash + git + coreutils only (no jq dependency).
+# The controller owns all mechanical loop logic: gate evaluation, signature
+# computation, progress/regression/oscillation detection, halt decisions, and
+# state/log persistence. The /specclaw:loop skill orchestrates the LLM steps.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-loop <subcommand> [options]
+
+Subcommands (implemented):
+  init          <specclaw_dir> <change_name>
+                Seed loop-state.json and loop-log.md for a change. Idempotent.
+
+  gates         <specclaw_dir> <change_name>
+                Evaluate the four local gates over the whole change and emit a
+                single JSON object to stdout:
+                  {all_green, passing_count, gates:[{name,green,errors,files}]}
+
+  done          <specclaw_dir> <change_name>
+                Print the final PASS summary block for an operator notification.
+
+Subcommands (planned — not yet implemented):
+  decide        Check caps / no-progress / regression / oscillation → continue|halt.
+  guard-tests   Reject a fix turn that touched test files (reward-hack guard).
+  log-turn      Append a turn entry to loop-log.md and update loop-state.json.
+  escalate      Commit partial work, keep worktree, emit halt notification.
+  ci-poll       Poll remote CI checks (gh / az) for the opt-in outer loop.
+
+Options:
+  -h, --help    Show this help message
+EOF
+}
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARN: $*" >&2; }
+
+# JSON-escape a string: backslashes, quotes, newlines, tabs, carriage returns
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# Read a YAML value (simple single-line scalar) from config.yaml
+# Usage: yaml_val <file> <dotted.key>
+# e.g. yaml_val config.yaml build.test_command
+yaml_val() {
+  local file="$1" key="$2"
+  local field="${key##*.}"
+  local val
+  # Match line, strip "key:" prefix, strip inline comment (everything from
+  # whitespace+# to EOL), strip trailing whitespace, then strip surrounding quotes.
+  val=$(grep -E "^[[:space:]]*${field}:" "$file" 2>/dev/null | head -1 \
+        | sed -E 's/^[^:]*:[[:space:]]*//' \
+        | sed -E 's/[[:space:]]+#.*$//' \
+        | sed -E 's/[[:space:]]+$//' \
+        | sed 's/^"//' | sed 's/"$//' | sed "s/^'//" | sed "s/'$//")
+  printf '%s' "$val"
+}
+
+# Run a command, capture output (capped at 100 lines), return exit code.
+# Usage: run_capped <varname_output> <command_string>
+# Sets: <varname_output> to captured output, returns command exit code.
+run_capped() {
+  local -n _out_ref="$1"
+  local cmd="$2"
+  local tmpfile
+  tmpfile=$(mktemp)
+  local rc=0
+  eval "$cmd" >"$tmpfile" 2>&1 || rc=$?
+  _out_ref=$(head -100 "$tmpfile")
+  local total
+  total=$(wc -l < "$tmpfile")
+  if [ "$total" -gt 100 ]; then
+    _out_ref="${_out_ref}
+... (truncated, ${total} total lines)"
+  fi
+  rm -f "$tmpfile"
+  return "$rc"
+}
+
+# ─── Subcommand: init ──────────────────────────────────────────────────────────
+
+cmd_init() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local state_file="${change_dir}/loop-state.json"
+  local log_file="${change_dir}/loop-log.md"
+
+  mkdir -p "$change_dir"
+
+  # loop-state.json — do not clobber an existing state file.
+  if [ -f "$state_file" ]; then
+    echo "loop-state.json already exists at ${state_file} (not clobbered)"
+  else
+    printf '{"turn": 0, "passing_count": 0, "sig_history": [], "ci_turn": 0}\n' > "$state_file"
+    echo "Seeded ${state_file}"
+  fi
+
+  # loop-log.md — do not clobber an existing log.
+  if [ -f "$log_file" ]; then
+    echo "loop-log.md already exists at ${log_file} (not clobbered)"
+  else
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    {
+      printf '# Loop Log: %s\n\n' "$change_name"
+      printf '_Created: %s_\n' "$now"
+    } > "$log_file"
+    echo "Seeded ${log_file}"
+  fi
+}
+
+# ─── Subcommand: gates ─────────────────────────────────────────────────────────
+
+# Extract a normalized PASS/FAIL/PARTIAL verdict token from a report file.
+# Prints the token (PASS|FAIL|PARTIAL|UNKNOWN) to stdout.
+extract_verdict() {
+  local file="$1"
+  local raw
+  raw=$(grep -ioE '\b(PASS|FAIL|PARTIAL)\b' "$file" 2>/dev/null | head -1 | tr '[:lower:]' '[:upper:]') || true
+  [ -z "$raw" ] && raw="UNKNOWN"
+  printf '%s' "$raw"
+}
+
+cmd_gates() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local config_file="${specclaw_dir}/config.yaml"
+  local tasks_file="${change_dir}/tasks.md"
+  local verify_file="${change_dir}/verify-report.md"
+  local review_file="${change_dir}/review-report.md"
+
+  local parse_tasks="${SCRIPT_DIR}/specclaw-parse-tasks"
+
+  # ── Gate 1: tasks-complete ──────────────────────────────────────────────────
+  # Green iff zero pending AND zero failed tasks in tasks.md.
+  local g1_green=true g1_errors="" g1_files=""
+  if [ ! -f "$tasks_file" ]; then
+    g1_green=false
+    g1_errors="tasks.md not found at ${tasks_file}"
+  else
+    # Collect incomplete task ids (pending + failed). We capture output and exit
+    # codes explicitly so set -e does not abort on a nonzero parse result.
+    local pending_json="" failed_json="" rc=0
+    pending_json=$("$parse_tasks" --status pending "$tasks_file" 2>/dev/null) || rc=$?
+    failed_json=$("$parse_tasks" --status failed "$tasks_file" 2>/dev/null) || rc=$?
+
+    # Extract "id":"Tn" tokens from both filtered arrays.
+    local ids=""
+    ids=$(printf '%s\n%s\n' "$pending_json" "$failed_json" \
+          | grep -oE '"id"[[:space:]]*:[[:space:]]*"[^"]+"' \
+          | sed -E 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
+          | sort -u | tr '\n' ' ' | sed -E 's/[[:space:]]+$//') || true
+
+    if [ -n "$ids" ]; then
+      g1_green=false
+      g1_errors="incomplete tasks: ${ids}"
+    fi
+  fi
+
+  # ── Gate 2: tests ───────────────────────────────────────────────────────────
+  # Run build.{test,lint,build}_command from config.yaml. Unset → skipped
+  # (trivially green). Green iff every set command exits 0. Run from repo root.
+  local g2_green=true g2_errors="" g2_files=""
+  local test_cmd="" lint_cmd="" build_cmd=""
+  if [ -f "$config_file" ]; then
+    test_cmd=$(yaml_val "$config_file" "build.test_command")
+    lint_cmd=$(yaml_val "$config_file" "build.lint_command")
+    build_cmd=$(yaml_val "$config_file" "build.build_command")
+  fi
+
+  # Resolve the repo root to run commands from; fall back to cwd.
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root="$(pwd)"
+
+  local cmd_name cmd
+  for pair in "test:${test_cmd}" "lint:${lint_cmd}" "build:${build_cmd}"; do
+    cmd_name="${pair%%:*}"
+    cmd="${pair#*:}"
+    [ -z "$cmd" ] && continue   # unset → skipped, trivially green
+    local out="" rc=0
+    ( cd "$repo_root" && eval "$cmd" ) >/tmp/_specclaw_loop_gate_$$ 2>&1 || rc=$?
+    out=$(head -40 /tmp/_specclaw_loop_gate_$$)
+    rm -f /tmp/_specclaw_loop_gate_$$
+    if [ "$rc" -ne 0 ]; then
+      g2_green=false
+      local snippet
+      snippet=$(printf '%s' "$out" | tail -20)
+      if [ -n "$g2_errors" ]; then
+        g2_errors="${g2_errors}
+${cmd_name}_command failed (exit ${rc}): ${snippet}"
+      else
+        g2_errors="${cmd_name}_command failed (exit ${rc}): ${snippet}"
+      fi
+    fi
+  done
+
+  # ── Gate 3: verify ──────────────────────────────────────────────────────────
+  # Read verify-report.md; green iff verdict = PASS. Absent → not green.
+  local g3_green=false g3_errors="" g3_files="$verify_file"
+  if [ ! -f "$verify_file" ]; then
+    g3_green=false
+    g3_errors="no verify-report.md yet"
+  else
+    local verdict
+    verdict=$(extract_verdict "$verify_file")
+    if [ "$verdict" = "PASS" ]; then
+      g3_green=true
+    else
+      g3_green=false
+      g3_errors="verify verdict: ${verdict}"
+    fi
+  fi
+
+  # ── Gate 4: review ──────────────────────────────────────────────────────────
+  # Read review-report.md; green iff zero BLOCK findings. Absent → green iff
+  # workflow.code_review is false (review not required), else not green.
+  local g4_green=true g4_errors="" g4_files="$review_file"
+  local code_review=""
+  [ -f "$config_file" ] && code_review=$(yaml_val "$config_file" "workflow.code_review")
+  if [ ! -f "$review_file" ]; then
+    if [ "$code_review" = "true" ]; then
+      g4_green=false
+      g4_errors="no review-report.md yet"
+    else
+      g4_green=true
+    fi
+  else
+    local block_count
+    block_count=$(grep -oE '\bBLOCK\b' "$review_file" 2>/dev/null | wc -l | tr -d ' ') || true
+    [ -z "$block_count" ] && block_count=0
+    if [ "$block_count" -eq 0 ]; then
+      g4_green=true
+    else
+      g4_green=false
+      g4_errors="${block_count} BLOCK-severity finding(s)"
+    fi
+  fi
+
+  # ── Aggregate ───────────────────────────────────────────────────────────────
+  local passing_count=0
+  $g1_green && passing_count=$((passing_count + 1))
+  $g2_green && passing_count=$((passing_count + 1))
+  $g3_green && passing_count=$((passing_count + 1))
+  $g4_green && passing_count=$((passing_count + 1))
+
+  local all_green=false
+  if $g1_green && $g2_green && $g3_green && $g4_green; then
+    all_green=true
+  fi
+
+  # ── Emit JSON ───────────────────────────────────────────────────────────────
+  local output
+  output=$(cat <<ENDJSON
+{
+  "all_green": ${all_green},
+  "passing_count": ${passing_count},
+  "gates": [
+    {"name": "tasks-complete", "green": ${g1_green}, "errors": "$(json_escape "$g1_errors")", "files": "$(json_escape "$g1_files")"},
+    {"name": "tests", "green": ${g2_green}, "errors": "$(json_escape "$g2_errors")", "files": "$(json_escape "$g2_files")"},
+    {"name": "verify", "green": ${g3_green}, "errors": "$(json_escape "$g3_errors")", "files": "$(json_escape "$g3_files")"},
+    {"name": "review", "green": ${g4_green}, "errors": "$(json_escape "$g4_errors")", "files": "$(json_escape "$g4_files")"}
+  ]
+}
+ENDJSON
+)
+
+  printf '%s\n' "$output"
+}
+
+# ─── Subcommand: done ──────────────────────────────────────────────────────────
+
+cmd_done() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local state_file="${change_dir}/loop-state.json"
+
+  # Read turn count from loop-state.json (grep, no jq).
+  local turn="unknown"
+  if [ -f "$state_file" ]; then
+    local t
+    t=$(grep -oE '"turn"[[:space:]]*:[[:space:]]*[0-9]+' "$state_file" 2>/dev/null \
+        | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "$t" ] && turn="$t"
+  fi
+
+  cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ LOOP COMPLETE — ${change_name}
+All gates green (tasks-complete · tests · verify · review).
+Turns: ${turn}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  init)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop init <specclaw_dir> <change_name>"
+    cmd_init "$2" "$3"
+    ;;
+  gates)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop gates <specclaw_dir> <change_name>"
+    cmd_gates "$2" "$3"
+    ;;
+  done)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop done <specclaw_dir> <change_name>"
+    cmd_done "$2" "$3"
+    ;;
+  "")
+    usage
+    exit 2
+    ;;
+  *)
+    warn "Unknown subcommand: $1"
+    usage
+    exit 2
+    ;;
+esac

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -53,8 +53,17 @@ Subcommands (implemented):
                 an ## Escalation section to loop-log.md with a fresh gate snapshot,
                 and print an operator notification block to stdout. Exit 0.
 
-Subcommands (planned — not yet implemented):
-  ci-poll       Poll remote CI checks (gh / az) for the opt-in outer loop.
+  ci-poll       <specclaw_dir> <change_name>
+                Opt-in outer CI loop primitive (only meaningful when
+                loop.ci_gate == true). Runs ONE poll cycle for the PR on the
+                current branch: blocks up to loop.ci_timeout_seconds (default
+                1200), sleeping between checks, until CI concludes or the
+                wall-clock is exceeded. The orchestrator skill owns the
+                multi-iteration loop + the fix cycle between polls; this
+                subcommand is a pure observation primitive. Provider is
+                auto-detected (GitHub preferred over Azure). Emits ONE JSON
+                object: {status, provider, failed_log, pr}. status is one of
+                green | red | timeout | no-checks | disabled | none. Exit 0.
 
 Options:
   -h, --help    Show this help message
@@ -1014,6 +1023,287 @@ EOF
   return 0
 }
 
+# ─── Subcommand: ci-poll ─────────────────────────────────────────────────────
+#
+# Opt-in outer CI loop primitive. Poll the remote CI checks for the PR on the
+# CURRENT branch ONCE — i.e. this invocation blocks (in-session) up to
+# loop.ci_timeout_seconds, sleeping between checks, until CI concludes (green /
+# red) or the wall-clock is exceeded. The orchestrator skill owns the
+# multi-iteration loop (ci_turn 1..ci_max_iterations) and the fix cycle between
+# polls; this subcommand stays a pure decision/observation primitive.
+#
+# Provider detection + precedence:
+#   GitHub  — if `gh` CLI is available AND (github.sync true OR github.repo set
+#             OR an origin remote points at github.com). Preferred if both
+#             providers look viable.
+#   Azure   — else if azdo.enabled is true AND `az` CLI is available.
+#   none    — if neither the needed CLI nor config is present. Emits
+#             {"status":"none","provider":"none",...} + a warn, exit 0 (never
+#             hard-fail on a missing CLI).
+#
+# Status values (exactly one emitted):
+#   green      — checks concluded successfully.
+#   red        — checks concluded with a failure; failed_log carries the tail
+#                of the failed-run log.
+#   no-checks  — after a short grace period (CI_GRACE_SECONDS) NO checks are
+#                reported for the PR. Per the "no pipeline attached → treat as
+#                green after grace" edge case: distinctly labeled so the skill
+#                logs a warning and proceeds.
+#   timeout    — wall-clock exceeded ci_timeout_seconds before checks concluded
+#                (hung pipeline).
+#   disabled   — loop.ci_gate is not true (feature off). Exit 0 immediately.
+#   none       — required CLI / provider config missing.
+#
+# All gh/az/grep calls are `|| true`-guarded so a CLI error never aborts the
+# script — every path resolves to one JSON status object. failed_log is
+# json_escaped. pr is the PR number (GitHub) or the branch name (fallback).
+
+# Poll/grace/sleep knobs (wall-clock in seconds).
+CI_SLEEP_SECONDS=20      # interval between poll iterations
+CI_GRACE_SECONDS=60      # window to wait for any check to appear before "no-checks"
+
+# Emit the single ci-poll JSON result. Args: status provider failed_log pr
+ci_emit() {
+  local status="$1" provider="$2" failed_log="$3" pr="$4"
+  printf '{"status": "%s", "provider": "%s", "failed_log": "%s", "pr": "%s"}\n' \
+    "$status" "$provider" "$(json_escape "$failed_log")" "$(json_escape "$pr")"
+}
+
+cmd_ci_poll() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local config_file="${specclaw_dir}/config.yaml"
+
+  # ── Gate: only meaningful when loop.ci_gate == true ──────────────────────────
+  local ci_gate=""
+  [ -f "$config_file" ] && ci_gate=$(yaml_val "$config_file" "loop.ci_gate")
+  if [ "$ci_gate" != "true" ]; then
+    ci_emit "disabled" "none" "" ""
+    return 0
+  fi
+
+  # ── Read caps / knobs (defaults 3 / 1200) ────────────────────────────────────
+  local ci_max_iterations="" ci_timeout_seconds=""
+  if [ -f "$config_file" ]; then
+    ci_max_iterations=$(yaml_val "$config_file" "loop.ci_max_iterations")
+    ci_timeout_seconds=$(yaml_val "$config_file" "loop.ci_timeout_seconds")
+  fi
+  [ -z "$ci_max_iterations" ] && ci_max_iterations=3
+  [ -z "$ci_timeout_seconds" ] && ci_timeout_seconds=1200
+  # ci_max_iterations is owned by the orchestrator skill (multi-poll loop); read
+  # here only so a bad value never surprises the operator. Not used for control.
+  : "$ci_max_iterations"
+
+  # ── Current branch (source of the PR under test) ─────────────────────────────
+  local branch=""
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+  [ -z "$branch" ] && branch="HEAD"
+
+  # ── Provider detection (GitHub preferred over Azure) ─────────────────────────
+  # GitHub is viable if gh is installed AND we have a github signal:
+  #   github.sync true | github.repo set | origin remote is github.com.
+  local gh_ok=false az_ok=false
+  local github_sync="" github_repo="" azdo_enabled=""
+  if [ -f "$config_file" ]; then
+    github_sync=$(yaml_val "$config_file" "github.sync")
+    github_repo=$(yaml_val "$config_file" "github.repo")
+    azdo_enabled=$(yaml_val "$config_file" "azdo.enabled")
+  fi
+  local origin_url=""
+  origin_url=$(git remote get-url origin 2>/dev/null) || true
+
+  if command -v gh >/dev/null 2>&1; then
+    if [ "$github_sync" = "true" ] || [ -n "$github_repo" ] \
+       || printf '%s' "$origin_url" | grep -qi 'github\.com'; then
+      gh_ok=true
+    fi
+  fi
+  if [ "$azdo_enabled" = "true" ] && command -v az >/dev/null 2>&1; then
+    az_ok=true
+  fi
+
+  local provider="none"
+  if $gh_ok; then
+    provider="github"
+  elif $az_ok; then
+    provider="azure"
+  fi
+
+  # ── No provider / missing CLI → non-fatal none ───────────────────────────────
+  if [ "$provider" = "none" ]; then
+    warn "ci-poll: no CI provider available (gh/az missing or github.*/azdo.enabled unset) — treating as none"
+    ci_emit "none" "none" "" "$branch"
+    return 0
+  fi
+
+  # ── Wall-clock setup ─────────────────────────────────────────────────────────
+  local start_ts now_ts elapsed
+  start_ts=$(date +%s)
+
+  if [ "$provider" = "github" ]; then
+    ci_poll_github "$branch" "$start_ts" "$ci_timeout_seconds"
+    return 0
+  else
+    ci_poll_azure "$branch" "$start_ts" "$ci_timeout_seconds"
+    return 0
+  fi
+}
+
+# GitHub poll cycle. Args: branch start_ts timeout_seconds
+# Resolves the PR from the current branch, polls `gh pr checks`, and on a red
+# conclusion pulls `gh run view --log-failed`. Emits ONE JSON status.
+ci_poll_github() {
+  local branch="$1" start_ts="$2" timeout_seconds="$3"
+
+  # Resolve the PR number for the current branch (best-effort).
+  local pr_num=""
+  pr_num=$(gh pr view --json number --jq '.number' 2>/dev/null) || true
+  [ -z "$pr_num" ] && pr_num=$(gh pr view "$branch" --json number --jq '.number' 2>/dev/null) || true
+  local pr_ref="$pr_num"
+  [ -z "$pr_ref" ] && pr_ref="$branch"
+
+  local now_ts elapsed
+  while :; do
+    # `gh pr checks` exit codes: 0 = all passed, 8 = pending, nonzero (e.g. 1) =
+    # failure, and it errors when NO checks exist. Capture output + rc; guard rc.
+    local checks_out="" checks_rc=0
+    checks_out=$(gh pr checks "$pr_ref" 2>&1) || checks_rc=$?
+
+    now_ts=$(date +%s)
+    elapsed=$((now_ts - start_ts))
+
+    # No checks reported for the PR. `gh pr checks` prints a "no checks reported"
+    # message and exits nonzero. After the grace window → treat as no-checks.
+    if printf '%s' "$checks_out" | grep -qiE 'no checks reported|no check runs'; then
+      if [ "$elapsed" -ge "$CI_GRACE_SECONDS" ]; then
+        warn "ci-poll(github): no checks reported for PR ${pr_ref} after grace — treating as no-checks (green-ish)"
+        ci_emit "no-checks" "github" "" "$pr_ref"
+        return 0
+      fi
+      # still inside grace → fall through to sleep/timeout handling below.
+    else
+      # Parse the per-check states. `gh pr checks` prints TSV rows with a state
+      # column (pass|fail|pending|skipping|...). Determine aggregate outcome.
+      local n_pending n_fail n_total
+      n_total=$(printf '%s\n' "$checks_out" | grep -ciE 'pass|fail|pending|skipping|neutral|cancel' || true)
+      n_pending=$(printf '%s\n' "$checks_out" | grep -ciE '\bpending\b|in_progress|queued' || true)
+      n_fail=$(printf '%s\n' "$checks_out" | grep -ciE '\bfail\b|failing|error|cancel' || true)
+      [ -z "$n_total" ] && n_total=0
+      [ -z "$n_pending" ] && n_pending=0
+      [ -z "$n_fail" ] && n_fail=0
+
+      # Prefer gh's own exit code when it is decisive (0 pass / 8 pending),
+      # falling back to the parsed row states.
+      if [ "$checks_rc" -eq 0 ] && [ "$n_total" -gt 0 ] && [ "$n_pending" -eq 0 ] && [ "$n_fail" -eq 0 ]; then
+        ci_emit "green" "github" "" "$pr_ref"
+        return 0
+      fi
+      if [ "$n_pending" -eq 0 ] && [ "$n_total" -gt 0 ]; then
+        if [ "$n_fail" -gt 0 ]; then
+          # Concluded red → pull failed-run logs (tail only).
+          local failed_log=""
+          failed_log=$(gh run view --log-failed 2>/dev/null | tail -100) || true
+          [ -z "$failed_log" ] && failed_log=$(printf '%s' "$checks_out" | tail -40)
+          ci_emit "red" "github" "$failed_log" "$pr_ref"
+          return 0
+        fi
+        # No pending, no fail, but rc nonzero — treat as green (all resolved).
+        ci_emit "green" "github" "" "$pr_ref"
+        return 0
+      fi
+      # else: still pending → fall through to sleep/timeout.
+    fi
+
+    # ── Wall-clock timeout (hung pipeline) ─────────────────────────────────────
+    now_ts=$(date +%s)
+    elapsed=$((now_ts - start_ts))
+    if [ "$elapsed" -ge "$timeout_seconds" ]; then
+      local tail_log=""
+      tail_log=$(printf '%s' "$checks_out" | tail -40)
+      warn "ci-poll(github): wall-clock timeout (${timeout_seconds}s) before checks concluded"
+      ci_emit "timeout" "github" "$tail_log" "$pr_ref"
+      return 0
+    fi
+
+    sleep "$CI_SLEEP_SECONDS"
+  done
+}
+
+# Azure poll cycle. Args: branch start_ts timeout_seconds
+# Uses `az pipelines runs list` filtered to the branch, then `az pipelines runs
+# show` for status/result. Emits ONE JSON status.
+ci_poll_azure() {
+  local branch="$1" start_ts="$2" timeout_seconds="$3"
+  local pr_ref="$branch"
+  local branch_ref="refs/heads/${branch}"
+
+  local now_ts elapsed
+  while :; do
+    # Latest run for this branch. `--query` pulls id/status/result of the newest.
+    # az emits JSON; parse with grep/sed (no jq dependency in this controller).
+    local runs_out="" runs_rc=0
+    runs_out=$(az pipelines runs list --branch "$branch_ref" --top 1 --output json 2>/dev/null) || runs_rc=$?
+
+    now_ts=$(date +%s)
+    elapsed=$((now_ts - start_ts))
+
+    # No run found for the branch → within grace, keep polling; after grace,
+    # treat as no-checks (no pipeline attached).
+    if [ -z "$runs_out" ] || printf '%s' "$runs_out" | grep -qE '^\[\s*\]\s*$'; then
+      if [ "$elapsed" -ge "$CI_GRACE_SECONDS" ]; then
+        warn "ci-poll(azure): no pipeline run for branch ${branch} after grace — treating as no-checks (green-ish)"
+        ci_emit "no-checks" "azure" "" "$pr_ref"
+        return 0
+      fi
+    else
+      # status: notStarted|inProgress|completed ; result: succeeded|failed|canceled|partiallySucceeded
+      local status="" result=""
+      status=$(printf '%s' "$runs_out" | grep -oE '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+               | sed -E 's/.*"status"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+      result=$(printf '%s' "$runs_out" | grep -oE '"result"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+               | sed -E 's/.*"result"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+
+      if [ "$status" = "completed" ]; then
+        case "$result" in
+          succeeded)
+            ci_emit "green" "azure" "" "$pr_ref"
+            return 0
+            ;;
+          failed|canceled|partiallySucceeded)
+            # Pull a failing log summary from the run (best-effort).
+            local run_id="" failed_log=""
+            run_id=$(printf '%s' "$runs_out" | grep -oE '"id"[[:space:]]*:[[:space:]]*[0-9]+' | head -1 \
+                     | grep -oE '[0-9]+') || true
+            if [ -n "$run_id" ]; then
+              failed_log=$(az pipelines runs show --id "$run_id" --output json 2>/dev/null | tail -100) || true
+            fi
+            [ -z "$failed_log" ] && failed_log="azure pipeline run ${run_id:-?} result=${result}"
+            ci_emit "red" "azure" "$failed_log" "$pr_ref"
+            return 0
+            ;;
+          *)
+            # Completed but unknown result → treat as green-ish resolved.
+            ci_emit "green" "azure" "" "$pr_ref"
+            return 0
+            ;;
+        esac
+      fi
+      # else: notStarted / inProgress → still running, fall through to timeout.
+    fi
+
+    # ── Wall-clock timeout (hung pipeline) ─────────────────────────────────────
+    now_ts=$(date +%s)
+    elapsed=$((now_ts - start_ts))
+    if [ "$elapsed" -ge "$timeout_seconds" ]; then
+      warn "ci-poll(azure): wall-clock timeout (${timeout_seconds}s) before pipeline concluded"
+      ci_emit "timeout" "azure" "" "$pr_ref"
+      return 0
+    fi
+
+    sleep "$CI_SLEEP_SECONDS"
+  done
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
@@ -1052,6 +1342,10 @@ case "${1:-}" in
   escalate)
     [ $# -ge 4 ] || die "Usage: specclaw-loop escalate <specclaw_dir> <change_name> <reason>"
     cmd_escalate "$2" "$3" "$4"
+    ;;
+  ci-poll)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop ci-poll <specclaw_dir> <change_name>"
+    cmd_ci_poll "$2" "$3"
     ;;
   "")
     usage

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -47,8 +47,13 @@ Subcommands (implemented):
                 and emit JSON {tripped, test_files:[...], action, message}. Exits
                 0 (clean, tripped=false) or 3 (guard tripped → turn rejected).
 
+  escalate      <specclaw_dir> <change_name> "<reason>"
+                Controlled halt. Commit partial work (git.commit_prefix), preserve
+                state per git.strategy (worktree/branch kept; direct → warn), append
+                an ## Escalation section to loop-log.md with a fresh gate snapshot,
+                and print an operator notification block to stdout. Exit 0.
+
 Subcommands (planned — not yet implemented):
-  escalate      Commit partial work, keep worktree, emit halt notification.
   ci-poll       Poll remote CI checks (gh / az) for the opt-in outer loop.
 
 Options:
@@ -840,6 +845,175 @@ cmd_guard_tests() {
   return 3
 }
 
+# ─── Subcommand: escalate ────────────────────────────────────────────────────
+#
+# Called when a halt condition fires (cap / regression / no-progress /
+# oscillation). This is a CONTROLLED stop, not a script error — exit 0.
+#
+# Steps:
+#   1. Commit partial work with the configured git.commit_prefix. If there is
+#      nothing to commit, skip (do not error).
+#   2. Preserve state per git.strategy:
+#        worktree-per-change → worktree stays; note its path.
+#        branch-per-change   → branch is preserved; note the branch.
+#        direct              → WARN no isolated worktree; work is on current branch.
+#   3. Finalize loop-log.md: append an ## Escalation section with timestamp,
+#      the reason, and a fresh gate-status snapshot (reuses cmd_gates).
+#   4. Emit an operator notification block to stdout (Discord-pasteable).
+#
+# Reuses: cmd_gates (snapshot), yaml_val (config), json_escape (n/a here),
+# and the same loop-log append style as cmd_log_turn / cmd_guard_tests.
+
+# Render a fresh gate snapshot as a one-line-per-gate human summary.
+# Sets (nameref) the summary text; echoes nothing. Parses the JSON cmd_gates
+# emits (one gate per line) with the same per-line grep approach as
+# cmd_signature, so no jq is needed.
+escalate_gate_summary() {
+  local -n _sum_ref="$1"
+  local gates_json="$2"
+  local out="" line name green errors
+  while IFS= read -r line; do
+    case "$line" in
+      *'"name":'*'"green":'*) : ;;
+      *) continue ;;
+    esac
+    name=$(printf '%s' "$line" \
+      | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+    green=$(printf '%s' "$line" \
+      | grep -oE '"green"[[:space:]]*:[[:space:]]*(true|false)' \
+      | grep -oE '(true|false)' || true)
+    errors=$(printf '%s' "$line" \
+      | sed -E 's/.*"errors"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+    local mark="RED" ; [ "$green" = "true" ] && mark="GREEN"
+    local suffix=""
+    if [ "$green" != "true" ] && [ -n "$errors" ]; then
+      suffix=" — ${errors}"
+    fi
+    out="${out}  - ${name}: ${mark}${suffix}
+"
+  done <<< "$gates_json"
+  _sum_ref=$(printf '%s' "$out" | sed -E 's/[[:space:]]+$//')
+}
+
+cmd_escalate() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local reason="$3"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local config_file="${specclaw_dir}/config.yaml"
+  local log_file="${change_dir}/loop-log.md"
+
+  local now
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # ── Read config: commit_prefix (default "specclaw") + strategy ───────────────
+  local commit_prefix="" strategy="" worktree_dir=""
+  if [ -f "$config_file" ]; then
+    commit_prefix=$(yaml_val "$config_file" "git.commit_prefix")
+    strategy=$(yaml_val "$config_file" "git.strategy")
+    worktree_dir=$(yaml_val "$config_file" "git.worktree_dir")
+  fi
+  [ -z "$commit_prefix" ] && commit_prefix="specclaw"
+  [ -z "$strategy" ] && strategy="branch-per-change"
+
+  # ── Resolve repo root (run git from there so relative paths are consistent) ──
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root="$(pwd)"
+
+  # ── 1. Commit partial work (tolerate "nothing to commit") ────────────────────
+  # Stage all working-tree changes, then commit only if the staged index differs
+  # from HEAD. `git diff --cached --quiet` exits 1 when there is something staged.
+  local commit_note="" commit_msg="${commit_prefix}(${change_name}): loop escalation — partial work preserved"
+  ( cd "$repo_root" && git add -A ) 2>/dev/null || warn "git add -A failed (continuing)"
+  local staged_dirty=0
+  ( cd "$repo_root" && git diff --cached --quiet ) || staged_dirty=$?
+  if [ "$staged_dirty" -ne 0 ]; then
+    if ( cd "$repo_root" && git commit -m "$commit_msg" ) >/dev/null 2>&1; then
+      local sha
+      sha=$( ( cd "$repo_root" && git rev-parse --short HEAD ) 2>/dev/null || true )
+      commit_note="committed partial work (${sha}): ${commit_msg}"
+    else
+      commit_note="commit attempted but failed (see git output); work left in working tree"
+      warn "escalate: git commit failed"
+    fi
+  else
+    commit_note="nothing to commit — working tree already clean"
+  fi
+
+  # ── 2. State preservation per git.strategy ───────────────────────────────────
+  local branch
+  branch=$( ( cd "$repo_root" && git rev-parse --abbrev-ref HEAD ) 2>/dev/null || echo "unknown" )
+  local location_note=""
+  case "$strategy" in
+    worktree-per-change)
+      # The worktree stays — nothing destructive. Note its path (best effort).
+      local wt_path=""
+      [ -n "$worktree_dir" ] && wt_path="${worktree_dir}/${change_name}"
+      if [ -n "$wt_path" ]; then
+        location_note="worktree preserved at ${wt_path} (branch ${branch})"
+      else
+        location_note="worktree preserved (branch ${branch})"
+      fi
+      ;;
+    direct)
+      warn "escalate: git.strategy=direct — no isolated worktree; work committed to current branch ${branch}"
+      location_note="no isolated worktree (git.strategy=direct); work committed to current branch ${branch}"
+      ;;
+    branch-per-change|*)
+      location_note="branch ${branch} preserved"
+      ;;
+  esac
+
+  # ── 3. Fresh gate snapshot ───────────────────────────────────────────────────
+  local gates_json=""
+  gates_json=$(cmd_gates "$specclaw_dir" "$change_name" 2>/dev/null) || true
+  local all_green=""
+  all_green=$(printf '%s' "$gates_json" \
+    | grep -oE '"all_green"[[:space:]]*:[[:space:]]*(true|false)' \
+    | head -1 | grep -oE '(true|false)' || true)
+  local passing_count=""
+  passing_count=$(printf '%s' "$gates_json" \
+    | grep -oE '"passing_count"[[:space:]]*:[[:space:]]*[0-9]+' \
+    | head -1 | grep -oE '[0-9]+' || true)
+  [ -z "$passing_count" ] && passing_count="?"
+  local gate_summary=""
+  escalate_gate_summary gate_summary "$gates_json"
+  [ -z "$gate_summary" ] && gate_summary="  - (no gate snapshot available)"
+
+  # ── 4. Finalize loop-log.md (append ## Escalation) ───────────────────────────
+  if [ -d "$change_dir" ] || mkdir -p "$change_dir" 2>/dev/null; then
+    {
+      printf '%s\n\n' $'\n## Escalation'
+      printf '%s%s\n' '- **Timestamp:** ' "$now"
+      printf '%s%s\n' '- **Reason:** ' "$reason"
+      printf '%s%s\n' '- **State:** ' "$commit_note"
+      printf '%s%s\n' '- **Location:** ' "$location_note"
+      printf '%s%s\n\n' '- **Passing gates:** ' "${passing_count} / 4"
+      printf '%s\n' '### Gate status snapshot'
+      printf '%s\n' ''
+      printf '%s\n' "$gate_summary"
+    } >> "$log_file"
+  fi
+
+  # ── Operator notification (stdout, Discord-pasteable) ────────────────────────
+  cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🛑 LOOP HALTED — ${change_name}
+Reason: ${reason}
+Passing gates: ${passing_count} / 4
+
+Gate status:
+${gate_summary}
+
+State: ${commit_note}
+Where: ${location_note}
+Log: ${log_file}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF
+
+  return 0
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
@@ -874,6 +1048,10 @@ case "${1:-}" in
   guard-tests)
     [ $# -ge 3 ] || die "Usage: specclaw-loop guard-tests <specclaw_dir> <change_name>"
     cmd_guard_tests "$2" "$3"
+    ;;
+  escalate)
+    [ $# -ge 4 ] || die "Usage: specclaw-loop escalate <specclaw_dir> <change_name> <reason>"
+    cmd_escalate "$2" "$3" "$4"
     ;;
   "")
     usage

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -26,10 +26,21 @@ Subcommands (implemented):
   done          <specclaw_dir> <change_name>
                 Print the final PASS summary block for an operator notification.
 
+  signature     <specclaw_dir> <change_name>
+                Compute the failure signature (sha1 of sorted red-gate names +
+                normalized error fingerprint) from a fresh gates evaluation.
+                Emits the hex sha1 to stdout, or empty string if all gates green.
+
+  decide        <specclaw_dir> <change_name> <passing_count> <failure_sig>
+                Check caps / regression / no-progress / oscillation and emit
+                JSON {action:"continue"|"halt", reason:"..."}.
+
+  log-turn      <specclaw_dir> <change_name> <passing_count> <failure_sig> \
+                <action> "<reflection>" "<gates_summary>"
+                Append a turn entry to loop-log.md and update loop-state.json.
+
 Subcommands (planned — not yet implemented):
-  decide        Check caps / no-progress / regression / oscillation → continue|halt.
   guard-tests   Reject a fix turn that touched test files (reward-hack guard).
-  log-turn      Append a turn entry to loop-log.md and update loop-state.json.
   escalate      Commit partial work, keep worktree, emit halt notification.
   ci-poll       Poll remote CI checks (gh / az) for the opt-in outer loop.
 
@@ -308,6 +319,298 @@ Turns: ${turn}
 EOF
 }
 
+# ─── Subcommand: signature ───────────────────────────────────────────────────
+#
+# failure_sig = sha1( sorted(red_gate_names) + normalized_error_fingerprint )
+#
+# Runs a fresh `gates` evaluation, extracts the names + errors of every red
+# gate, normalizes the errors so "same error, different run" collapses to one
+# signature (strip line numbers, hex addresses, ISO-8601 timestamps), and emits
+# the hex sha1 to stdout. If all gates are green, emits an empty string.
+cmd_signature() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+
+  # Fresh gate evaluation. Guard against nonzero so set -e never aborts here.
+  local gates_json=""
+  gates_json=$(cmd_gates "$specclaw_dir" "$change_name" 2>/dev/null) || true
+
+  # If all gates green → no failure → empty signature.
+  local all_green=""
+  all_green=$(printf '%s' "$gates_json" \
+    | grep -oE '"all_green"[[:space:]]*:[[:space:]]*(true|false)' \
+    | head -1 | grep -oE '(true|false)' || true)
+  if [ "$all_green" = "true" ]; then
+    printf ''
+    return 0
+  fi
+
+  # Extract the red gates: walk each gate object, pull name + green + errors.
+  # Each gate is one line in the emitted JSON, so a per-line grep is reliable.
+  local red_names="" red_errors=""
+  local line name green errors
+  while IFS= read -r line; do
+    case "$line" in
+      *'"name":'*'"green":'*) : ;;   # a gate line
+      *) continue ;;
+    esac
+    name=$(printf '%s' "$line" \
+      | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+    green=$(printf '%s' "$line" \
+      | grep -oE '"green"[[:space:]]*:[[:space:]]*(true|false)' \
+      | grep -oE '(true|false)' || true)
+    [ "$green" = "false" ] || continue
+    errors=$(printf '%s' "$line" \
+      | sed -E 's/.*"errors"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/') || true
+    red_names="${red_names}${name}
+"
+    red_errors="${red_errors}${errors}
+"
+  done <<< "$gates_json"
+
+  # Sorted red-gate names.
+  local sorted_names=""
+  sorted_names=$(printf '%s' "$red_names" | grep -v '^$' | sort | tr '\n' ' ' \
+    | sed -E 's/[[:space:]]+$//') || true
+
+  # Normalized error fingerprint: strip line-number noise, hex addresses, and
+  # ISO-8601 timestamps so the same failure across runs collapses to one sig.
+  local norm_errors=""
+  norm_errors=$(printf '%s' "$red_errors" \
+    | sed -E 's/0x[0-9a-fA-F]+/0xADDR/g' \
+    | sed -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}([.,][0-9]+)?(Z|[+-][0-9]{2}:?[0-9]{2})?/TIMESTAMP/g' \
+    | sed -E 's/:[0-9]+:[0-9]+/:LINE:COL/g' \
+    | sed -E 's/:[0-9]+\b/:LINE/g' \
+    | sed -E 's/\bline[[:space:]]+[0-9]+/line N/gi' \
+    | sed -E 's/[0-9]+/N/g') || true
+
+  # Compute sha1 of the combined fingerprint.
+  local fingerprint sig
+  fingerprint="${sorted_names}
+${norm_errors}"
+  sig=$(printf '%s' "$fingerprint" | sha1sum | cut -d' ' -f1) || true
+  printf '%s' "$sig"
+}
+
+# ─── Subcommand: decide ────────────────────────────────────────────────────────
+#
+# Read loop-state.json + config, apply halt precedence, emit
+# {"action":"continue"|"halt","reason":"..."}.
+#
+# Halt precedence (checked in this exact order):
+#   1. CAP         — next turn > loop.max_iterations
+#   2. REGRESSION  — passing_count < prev_passing (prev set/>0)
+#   3. NO-PROGRESS — last no_progress_limit sigs (incl. this one) identical+nonempty
+#   4. OSCILLATION — A→B→A flip (sig == sig_history[-2]) OR sig occurs >= limit times
+#   5. continue
+cmd_decide() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local passing_count="$3"
+  local failure_sig="$4"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local state_file="${change_dir}/loop-state.json"
+  local config_file="${specclaw_dir}/config.yaml"
+
+  # ── Read state (flat JSON this script writes itself → tolerant grep/sed) ──────
+  local turn=0 prev_passing=0 sig_hist_raw=""
+  if [ -f "$state_file" ]; then
+    local t p
+    t=$(grep -oE '"turn"[[:space:]]*:[[:space:]]*[0-9]+' "$state_file" 2>/dev/null \
+        | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "$t" ] && turn="$t"
+    p=$(grep -oE '"passing_count"[[:space:]]*:[[:space:]]*[0-9]+' "$state_file" 2>/dev/null \
+        | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "$p" ] && prev_passing="$p"
+    # sig_history array contents (between the [ ]).
+    sig_hist_raw=$(grep -oE '"sig_history"[[:space:]]*:[[:space:]]*\[[^]]*\]' "$state_file" 2>/dev/null \
+        | head -1 | sed -E 's/.*\[([^]]*)\].*/\1/' || true)
+  fi
+
+  # sig_history as a newline-delimited list (order preserved).
+  local sig_list=""
+  if [ -n "$sig_hist_raw" ]; then
+    sig_list=$(printf '%s' "$sig_hist_raw" \
+      | grep -oE '"[^"]*"' | sed -E 's/^"//; s/"$//') || true
+  fi
+
+  # ── Read config caps (defaults 5 / 2) ────────────────────────────────────────
+  local max_iterations="" no_progress_limit=""
+  if [ -f "$config_file" ]; then
+    max_iterations=$(yaml_val "$config_file" "loop.max_iterations")
+    no_progress_limit=$(yaml_val "$config_file" "loop.no_progress_limit")
+  fi
+  [ -z "$max_iterations" ] && max_iterations=5
+  [ -z "$no_progress_limit" ] && no_progress_limit=2
+
+  local next_turn=$((turn + 1))
+
+  emit_decision() {
+    printf '{"action": "%s", "reason": "%s"}\n' "$1" "$(json_escape "$2")"
+  }
+
+  # ── 1. CAP ────────────────────────────────────────────────────────────────────
+  if [ "$next_turn" -gt "$max_iterations" ]; then
+    emit_decision "halt" "iteration cap ${max_iterations} reached"
+    return 0
+  fi
+
+  # ── 2. REGRESSION ─────────────────────────────────────────────────────────────
+  if [ "$prev_passing" -gt 0 ] && [ "$passing_count" -lt "$prev_passing" ]; then
+    emit_decision "halt" "regression: passing gates dropped ${prev_passing}→${passing_count}"
+    return 0
+  fi
+
+  # ── 3. NO-PROGRESS ──────────────────────────────────────────────────────────
+  # The last (no_progress_limit) signatures — this turn's plus the tail of
+  # history — all identical and non-empty → no progress.
+  if [ -n "$failure_sig" ]; then
+    # Build the candidate window: history tail + this turn's sig.
+    local window=""
+    window=$(printf '%s\n%s' "$sig_list" "$failure_sig" | grep -v '^$' || true)
+    local window_count
+    window_count=$(printf '%s\n' "$window" | grep -c '^' || true)
+    [ -z "$window_count" ] && window_count=0
+    if [ "$window_count" -ge "$no_progress_limit" ]; then
+      # Take the last no_progress_limit entries and check they are all == failure_sig.
+      local tail_win uniq_count
+      tail_win=$(printf '%s\n' "$window" | tail -n "$no_progress_limit") || true
+      uniq_count=$(printf '%s\n' "$tail_win" | sort -u | grep -c '^' || true)
+      local all_match=""
+      all_match=$(printf '%s\n' "$tail_win" | grep -v -x -F "$failure_sig" || true)
+      if [ "$uniq_count" = "1" ] && [ -z "$all_match" ]; then
+        emit_decision "halt" "no progress: identical failure signature ${no_progress_limit} turns"
+        return 0
+      fi
+    fi
+  fi
+
+  # ── 4. OSCILLATION ────────────────────────────────────────────────────────────
+  # A→B→A: this sig equals the second-to-last history entry.
+  # OR the same sig has occurred >= no_progress_limit times across history.
+  if [ -n "$failure_sig" ]; then
+    local hist_count
+    hist_count=$(printf '%s\n' "$sig_list" | grep -v '^$' | grep -c '^' || true)
+    [ -z "$hist_count" ] && hist_count=0
+
+    # sig_history[-2] : the entry before the last.
+    local second_last=""
+    if [ "$hist_count" -ge 2 ]; then
+      second_last=$(printf '%s\n' "$sig_list" | grep -v '^$' | tail -n 2 | head -n 1) || true
+    fi
+
+    # Total occurrences of this sig in history (history already contains prior
+    # turns; if we also count this turn, an equal or exceeding limit trips).
+    local occ
+    occ=$(printf '%s\n' "$sig_list" | grep -v '^$' | grep -c -x -F "$failure_sig" || true)
+    [ -z "$occ" ] && occ=0
+    local occ_incl=$((occ + 1))
+
+    if [ "$second_last" = "$failure_sig" ] || [ "$occ_incl" -ge "$no_progress_limit" ]; then
+      emit_decision "halt" "oscillation detected"
+      return 0
+    fi
+  fi
+
+  # ── 5. continue ───────────────────────────────────────────────────────────────
+  emit_decision "continue" "gates red but progress possible (turn ${next_turn}/${max_iterations})"
+}
+
+# ─── Subcommand: log-turn ──────────────────────────────────────────────────────
+#
+# Append a `## Turn N` section to loop-log.md and rewrite loop-state.json.
+#
+# sig_history tracking: empty-string signatures (all-green turns) are NOT
+# appended to sig_history — only real failure signatures are tracked, so
+# no-progress / oscillation math never trips on green turns. An empty-diff turn
+# is surfaced by the caller passing the same (repeated) signature, which the
+# `decide` no-progress rule catches.
+cmd_log_turn() {
+  local specclaw_dir="$1"
+  local change_name="$2"
+  local passing_count="$3"
+  local failure_sig="$4"
+  local action="$5"
+  local reflection="$6"
+  local gates_summary="$7"
+  local change_dir="${specclaw_dir}/changes/${change_name}"
+  local state_file="${change_dir}/loop-state.json"
+  local log_file="${change_dir}/loop-log.md"
+
+  mkdir -p "$change_dir"
+
+  # ── Read current state ────────────────────────────────────────────────────────
+  local turn=0 ci_turn=0 sig_hist_raw=""
+  if [ -f "$state_file" ]; then
+    local t c
+    t=$(grep -oE '"turn"[[:space:]]*:[[:space:]]*[0-9]+' "$state_file" 2>/dev/null \
+        | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "$t" ] && turn="$t"
+    c=$(grep -oE '"ci_turn"[[:space:]]*:[[:space:]]*[0-9]+' "$state_file" 2>/dev/null \
+        | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "$c" ] && ci_turn="$c"
+    sig_hist_raw=$(grep -oE '"sig_history"[[:space:]]*:[[:space:]]*\[[^]]*\]' "$state_file" 2>/dev/null \
+        | head -1 | sed -E 's/.*\[([^]]*)\].*/\1/' || true)
+  fi
+
+  local new_turn=$((turn + 1))
+
+  # ── Existing sig_history entries (preserve order) ─────────────────────────────
+  local sig_list=""
+  if [ -n "$sig_hist_raw" ]; then
+    sig_list=$(printf '%s' "$sig_hist_raw" \
+      | grep -oE '"[^"]*"' | sed -E 's/^"//; s/"$//') || true
+  fi
+
+  # Append this turn's failure_sig only if non-empty (green turns leave history
+  # untouched — see the tracking note above).
+  local new_sig_list=""
+  if [ -n "$sig_list" ] && [ -n "$failure_sig" ]; then
+    new_sig_list=$(printf '%s\n%s' "$sig_list" "$failure_sig")
+  elif [ -n "$sig_list" ]; then
+    new_sig_list="$sig_list"
+  elif [ -n "$failure_sig" ]; then
+    new_sig_list="$failure_sig"
+  fi
+
+  # Build the JSON array body: ["a","b",...]
+  local arr_body=""
+  if [ -n "$new_sig_list" ]; then
+    local s
+    while IFS= read -r s; do
+      [ -z "$s" ] && continue
+      if [ -n "$arr_body" ]; then
+        arr_body="${arr_body}, \"$(json_escape "$s")\""
+      else
+        arr_body="\"$(json_escape "$s")\""
+      fi
+    done <<< "$new_sig_list"
+  fi
+
+  # ── Append the turn section to loop-log.md ────────────────────────────────────
+  local now
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local sig_display="$failure_sig"
+  [ -z "$sig_display" ] && sig_display="(none — all gates green)"
+  # Note: printf format strings must not begin with a literal '-' (parsed as a
+  # flag), so every line's format starts with '%s' carrying the leading text.
+  {
+    printf '%s%s\n\n' $'\n## Turn ' "$new_turn"
+    printf '%s%s\n' '- **Timestamp:** ' "$now"
+    printf '%s%s\n' '- **Passing gates:** ' "${passing_count} / 4"
+    printf '%s%s%s\n' '- **Failure signature:** `' "$sig_display" '`'
+    printf '%s%s\n\n' '- **Decision:** ' "$action"
+    printf '%s%s\n\n' $'### Gate summary\n\n' "$gates_summary"
+    printf '%s%s\n' $'### Reflection\n\n' "$reflection"
+  } >> "$log_file"
+
+  # ── Rewrite loop-state.json (valid flat JSON via printf) ──────────────────────
+  printf '{"turn": %s, "passing_count": %s, "sig_history": [%s], "ci_turn": %s}\n' \
+    "$new_turn" "$passing_count" "$arr_body" "$ci_turn" > "$state_file"
+
+  echo "Logged turn ${new_turn} (passing ${passing_count}/4, action ${action})"
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
@@ -326,6 +629,18 @@ case "${1:-}" in
   done)
     [ $# -ge 3 ] || die "Usage: specclaw-loop done <specclaw_dir> <change_name>"
     cmd_done "$2" "$3"
+    ;;
+  signature)
+    [ $# -ge 3 ] || die "Usage: specclaw-loop signature <specclaw_dir> <change_name>"
+    cmd_signature "$2" "$3"
+    ;;
+  decide)
+    [ $# -ge 5 ] || die "Usage: specclaw-loop decide <specclaw_dir> <change_name> <passing_count> <failure_sig>"
+    cmd_decide "$2" "$3" "$4" "$5"
+    ;;
+  log-turn)
+    [ $# -ge 8 ] || die "Usage: specclaw-loop log-turn <specclaw_dir> <change_name> <passing_count> <failure_sig> <action> <reflection> <gates_summary>"
+    cmd_log_turn "$2" "$3" "$4" "$5" "$6" "$7" "$8"
     ;;
   "")
     usage

--- a/plugins/specclaw/skills/build/SKILL.md
+++ b/plugins/specclaw/skills/build/SKILL.md
@@ -148,3 +148,4 @@ Send a final **build summary**:
 - **Parallel within waves, sequential across waves.**
 - **Fail-fast on dependencies** — if a task fails, all dependents are immediately marked failed.
 - **Agent guardrails** — every coding agent is auto-prepended four behavioral rules (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution), vendored verbatim from Andrej Karpathy's CLAUDE.md. See `references/agent-guardrails.md`. Injection happens inside `specclaw-build-context`; no config flag.
+- **Loop-aware** — when `loop.enabled: true` (the default), this build is one turn of the autonomous loop driven by `/specclaw:loop`, which re-runs verify+review and fixes the smallest diff until every gate is green or a guardrail halts. Build produces the first implementation; the loop remediates it. When `loop.enabled: false`, build behaves single-pass exactly as documented above — no loop, no extra files.

--- a/plugins/specclaw/skills/loop/SKILL.md
+++ b/plugins/specclaw/skills/loop/SKILL.md
@@ -1,0 +1,167 @@
+---
+description: Autonomously iterate build→verify→review until every gate is green or a guardrail halts. Drives the specclaw-loop controller — evaluate gates, reflect, fix the smallest diff, re-verify the whole change, and repeat. Use when asked to loop, iterate until done, or keep fixing until tests pass / verify passes / review is clean. Default-on around /specclaw:build and /specclaw:verify.
+---
+
+# specclaw loop
+
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
+Autonomously drive the change to all-green. The **controller** (`specclaw-loop`) owns every mechanical decision — gate evaluation, signatures, caps, no-progress / regression / oscillation detection, the reward-hack guard, and state/log persistence. This skill only orchestrates the LLM steps: reflect, spawn a fix agent, commit. Follow the controller's JSON verbatim — do not second-guess a `halt`.
+
+## Step 0 — Validate prerequisites
+
+The loop presumes `/specclaw:plan` and at least one `/specclaw:build` pass have already run — it remediates an existing implementation, it does not create one. Confirm the change is built:
+
+```bash
+specclaw-validate-change .specclaw <change> verify
+```
+
+If it fails (tasks not all complete / no build), tell the user to run `/specclaw:build` first and stop.
+
+Read `loop.enabled` from `.specclaw/config.yaml`:
+
+```bash
+grep -A1 '^loop:' .specclaw/config.yaml
+```
+
+If `loop.enabled` is `false`, tell the user the autonomous loop is disabled and to run `/specclaw:build` and `/specclaw:verify` normally, then **stop**. Otherwise continue.
+
+## Step 1 — Init
+
+```bash
+specclaw-loop init .specclaw <change>
+```
+
+Seeds `loop-state.json` and `loop-log.md` (idempotent — never clobbers an existing state or log). Send a **loop started** notification:
+
+```
+🦞 **Loop Started**
+**Change:** <change>
+**Mode:** autonomous build→verify→review
+**Caps:** max <loop.max_iterations> local iterations
+```
+
+## Step 2 — Local loop
+
+Repeat up to `loop.max_iterations` (default 5). The controller enforces the cap in Step 2c — do not track it yourself.
+
+**a. Evaluate gates:**
+
+```bash
+specclaw-loop gates .specclaw <change>
+```
+
+Parse the JSON: `{all_green, passing_count, gates:[{name,green,errors,files}]}`. The four gates are `tasks-complete`, `tests`, `verify`, `review`.
+
+> To refresh the `verify` / `review` gate inputs, run `/specclaw:verify` first — it writes `verify-report.md` and (if `workflow.code_review: true`) `review-report.md`, which `gates` reads. On the first turn, run `/specclaw:verify` before this step so those gates have fresh reports.
+
+**b. If `all_green` is `true`:**
+
+```bash
+specclaw-loop done .specclaw <change>
+```
+
+Send the printed PASS block as a **success notification**. Proceed to Step 3 (CI outer loop) if `loop.ci_gate: true`, else skip to Step 4.
+
+**c. Else — compute the signature, then decide:**
+
+```bash
+sig=$(specclaw-loop signature .specclaw <change>)
+specclaw-loop decide .specclaw <change> <passing_count> "$sig"
+```
+
+Parse `{action, reason}`. `passing_count` is the value from the gates JSON in Step 2a.
+
+**d. If `action` is `halt`:**
+
+```bash
+specclaw-loop escalate .specclaw <change> "<reason>"
+```
+
+Paste the controller's stdout (the `🛑 LOOP HALTED` block) as the **escalation notification**. **STOP the loop.** Partial work is committed and the worktree/branch is preserved by the controller.
+
+**e. Else (`action` is `continue`) — reflect, fix:**
+
+1. From the red gates in the Step 2a JSON, write two files under the change dir:
+   - a compact **reflection** (`.specclaw/changes/<change>/.loop-reflection.md`) — 2-4 sentences: what failed, the likely cause, and the smallest fix hypothesis.
+   - a structured **failure record** (`.specclaw/changes/<change>/.loop-failure.txt`) — enumerate every red gate with its `name`, `errors`, and `files`. Concurrent failures (e.g. tests + review both red) go in one record.
+2. Build the remediation payload (use the failing task id, or the change name if the failure spans the whole change):
+   ```bash
+   specclaw-build-context .specclaw <change> <task_or_change> \
+     --failure-record .specclaw/changes/<change>/.loop-failure.txt \
+     --reflection .specclaw/changes/<change>/.loop-reflection.md
+   ```
+3. Spawn a fix agent with that payload as the task. Use the model from config `models.coding`. Instruct it to make the **SMALLEST diff** that turns the red gate(s) green, touch no unrelated code, and **never modify test files to force a pass**.
+
+**f. Reward-hack guard — run AFTER the fix agent, BEFORE committing:**
+
+```bash
+specclaw-loop guard-tests .specclaw <change>
+```
+
+If it exits **nonzero** (exit 3, `{tripped: true}`): the fix agent touched a test file. The controller has already reverted the illegal edit per `loop.guard_action`. Treat this turn as a **rejected, non-progress failure** — do NOT commit, log the turn (Step 2g with the same signature so `decide` catches the repeat), and continue the loop.
+
+**g. Commit the fix turn and log it:**
+
+```bash
+git add -A && git commit -m "specclaw(<change>): loop fix — turn <N>"
+specclaw-loop log-turn .specclaw <change> <passing_count> "$sig" <action> "<reflection>" "<gates_summary>"
+```
+
+`<gates_summary>` is a one-line-per-gate GREEN/RED summary from the Step 2a JSON. This appends a `## Turn N` section to `loop-log.md` and bumps `loop-state.json`.
+
+**h. Loop** back to Step 2a — re-evaluate the **whole change** through all gates.
+
+## Step 3 — CI outer loop (opt-in)
+
+Only if `loop.ci_gate: true`, and only **after the PR branch is pushed** — cross-reference `/specclaw:pr`, which creates and pushes the PR. Repeat up to `loop.ci_max_iterations` (default 3):
+
+**a. Poll one CI cycle** (blocks up to `loop.ci_timeout_seconds`, default 1200):
+
+```bash
+specclaw-loop ci-poll .specclaw <change>
+```
+
+Parse `{status, provider, failed_log, pr}`.
+
+**b. Route on `status`:**
+- `green` → CI passed; proceed to Step 4.
+- `no-checks` → no pipeline attached; **warn** the user and proceed to Step 4 (treated as green after grace).
+- `disabled` / `none` → CI not configured; proceed to Step 4.
+- `red` → feed `failed_log` back as the failure record, run a fix cycle exactly as in Steps 2e–2g, `git push`, and re-poll (next iteration).
+- `timeout` → hung pipeline; escalate (`specclaw-loop escalate .specclaw <change> "CI timeout after <ci_timeout_seconds>s"`) and STOP.
+
+**c. If the `ci_max_iterations` cap is reached** without green → `specclaw-loop escalate .specclaw <change> "CI cap <ci_max_iterations> reached"`, paste the halt block, and STOP.
+
+## Step 4 — Update dashboard
+
+```bash
+specclaw-update-status .specclaw
+```
+
+## Step 5 — Notify
+
+Send a final **loop summary** (build-summary style):
+
+```
+🦞 **Loop Complete**
+**Change:** <change>
+**Status:** <PASS|HALTED>
+**Turns:** <turns_used> / <loop.max_iterations>
+**Gates:** tasks-complete · tests · verify · review — <all green | which red>
+**Branch:** specclaw/<change>
+```
+
+On HALTED, also surface the escalation reason and point the user at `.specclaw/changes/<change>/loop-log.md`.
+
+## Key Principles
+
+- **Guardrails are enforced by the controller, not the prompt.** Caps, no-progress (identical/empty signature `loop.no_progress_limit` turns), regression (passing-gate count drops), and oscillation (A→B→A / Nth repeat) are code — a law, not a suggestion. When `decide` says `halt`, halt.
+- **Reward-hack guard protects the tests.** `guard-tests` diffs the working tree against the configured `loop.test_paths` (plus built-in test globs) after every fix agent. Any test-file edit rejects the turn and reverts it (`loop.guard_action`, default `revert-tests`). Tests run from committed HEAD, never from agent-staged changes — the harness cannot be gamed.
+- **Bounded context.** Only the compact reflection + the current failure record carry across iterations. Full transcripts are never accumulated (`specclaw-build-context --failure-record --reflection`).
+- **Whole-change re-verify each turn.** Every iteration re-runs all four gates over the entire change, catching cross-gate regressions — not just the one gate that was red.
+- **Goal-driven execution.** The loop is the explicit goal-check loop of **Rule 4 (Goal-Driven Execution)** in `references/agent-guardrails.md`: each gate is a success criterion the loop iterates against, and spec acceptance criteria (checked by `/specclaw:verify`) are the ground truth.
+
+## Relationship to build / verify / pr
+
+The loop is **default-on** (`loop.enabled: true`). It wraps the existing phases rather than replacing them: `/specclaw:build` produces the first implementation, `/specclaw:verify` writes the reports the `verify`/`review` gates read, and `/specclaw:pr` pushes the branch the CI outer loop (Step 3) polls. With `loop.enabled: false`, run `/specclaw:build` and `/specclaw:verify` as single-pass phases exactly as before.

--- a/plugins/specclaw/skills/pr-azdo/SKILL.md
+++ b/plugins/specclaw/skills/pr-azdo/SKILL.md
@@ -20,3 +20,5 @@ Create an Azure DevOps PR for a verified change.
    - If `context.md` changed, commit it: `git add .specclaw/context.md && git commit -m "docs(context): update project context after <change>"` and push.
    - Errors here are non-blocking — warn and continue.
 4. Report the ADO PR URL to the user.
+
+**CI outer loop (if `loop.ci_gate: true`):** once the PR branch is pushed, the CI tier of `/specclaw:loop` (Step 3 / `specclaw-loop ci-poll`) polls Azure Pipelines runs and iterates fixes until they are green, or `loop.ci_max_iterations` / `loop.ci_timeout_seconds` halts and escalates. This is a cross-reference only — PR creation above is unchanged, and nothing extra runs when `loop.ci_gate` is false.

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -31,3 +31,5 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
    - If `context.md` changed, commit it: `git add .specclaw/context.md && git commit -m "docs(context): update project context after <change>"` and push.
    - Errors here are non-blocking — warn and continue.
 4. Report the PR URL to the user.
+
+**CI outer loop (if `loop.ci_gate: true`):** once the PR branch is pushed, the CI tier of `/specclaw:loop` (Step 3 / `specclaw-loop ci-poll`) polls GitHub Actions checks and iterates fixes until they are green, or `loop.ci_max_iterations` / `loop.ci_timeout_seconds` halts and escalates. This is a cross-reference only — PR creation above is unchanged, and nothing extra runs when `loop.ci_gate` is false.

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -89,7 +89,9 @@ When `automation.auto_verify: true`, `/specclaw:build` automatically triggers ve
 
 ## Remediation
 
-If verdict is FAIL or PARTIAL:
+When `loop.enabled: true` (the default), remediation is automated by `/specclaw:loop`: the failed gates are fed back as a structured failure record, a fix agent makes the smallest diff to turn them green, and the whole change is re-verified — repeating until PASS or a guardrail (cap / no-progress / regression / oscillation) halts and escalates.
+
+When `loop.enabled: false`, remediation is manual. If verdict is FAIL or PARTIAL:
 1. List the failed acceptance criteria.
 2. Suggest creating remediation tasks targeting the gaps.
 3. The user can re-plan just the failed criteria or manually fix and re-verify.

--- a/plugins/specclaw/templates/config.yaml
+++ b/plugins/specclaw/templates/config.yaml
@@ -57,6 +57,18 @@ workflow:
   code_review: false               # Spawn code-reviewer agent during /specclaw:verify
   code_review_block: false         # Block /specclaw:pr if code review verdict is CHANGES_REQUESTED
 
+# Autonomous build→verify→review loop (loop engineering)
+# When enabled, build/verify/review iterate until all gates are green or a guardrail halts.
+loop:
+  enabled: true            # default-on; set false for single-pass build/verify
+  max_iterations: 5        # local inner loop cap
+  no_progress_limit: 2     # consecutive identical/empty turns → halt
+  guard_action: "revert-tests"   # reward-hack guard: revert-tests | revert-turn
+  test_paths: []           # globs identifying test files (reward-hack guard)
+  ci_gate: false           # opt-in outer CI loop (GitHub Actions / Azure Pipelines)
+  ci_max_iterations: 3     # CI outer loop cap
+  ci_timeout_seconds: 1200 # per-cycle CI wall-clock before halt
+
 # Automation
 automation:
   auto_mode: false


### PR DESCRIPTION
## Summary

Adds an autonomous **build → verify → review** loop tier to specclaw. Instead of stopping at a FAIL/PARTIAL verdict, `/specclaw:loop` closes the cycle: run local gates → feed failing gates back as a structured failure record → fix agent makes the smallest diff → re-verify → repeat until green or a guardrail halts.

## What's in it (T1–T10)

- **`loop:` config block** (default-on) seeded by `specclaw-init` — `enabled`, `max_iterations`, `no_progress_limit`, `guard_action`, `test_paths`, `ci_gate`, `ci_max_iterations`, `ci_timeout_seconds`.
- **`specclaw-loop` controller** — `init` / `gates` / `decide` / `guard-tests` / `log-turn` / `escalate` / `ci-poll` / `done`.
  - Four local gates: tasks-complete, test/lint/build, verify verdict, review BLOCK count.
  - Guardrails: iteration cap, no-progress limit, regression, oscillation (`failure_sig`). On halt → commit partial, keep worktree, finalize log, notify operator.
  - **Reward-hack guard**: changed files intersected with `loop.test_paths`; on hit revert test edits (or whole turn). Tests always run from committed HEAD.
  - **CI outer loop** (`ci_gate: true`): polls `gh pr checks` / `az pipelines runs` after PR push. In-session polling only (no MCD).
- **`specclaw-build-context --failure-record` / `--reflection`** — inject failure feedback + "smallest diff to green" instruction. Backward compatible.
- **`/specclaw:loop` orchestrator skill** — init → turn loop → optional CI tier.
- **Lifecycle wiring** — build/verify/pr/pr-azdo skills reference loop behavior; single-pass path preserved verbatim when `loop.enabled: false` (AC9).
- **Docs + version bump** 0.4.5 → 0.4.6 (plugin.json + marketplace.json in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)