### PR TITLE
specclaw(pr): enforce planning-trail commit before opening a PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-azdo-pr
+++ b/plugins/specclaw/bin/specclaw-azdo-pr
@@ -395,16 +395,23 @@ main() {
   # see them in the PR. specclaw-build commit only stages each task's declared
   # files; the planning trail under .specclaw/changes/<change>/ would otherwise
   # never land in the PR. Skip .specclaw/.env (already gitignored).
+  # Use `git status --porcelain` (not `git diff HEAD`) so untracked new files
+  # are detected — `git diff HEAD` only shows changes to already-tracked files.
   local change_path="${SPECCLAW_DIR}/changes/${CHANGE_NAME}"
-  if [[ -d "$change_path" ]]; then
-    if ! git diff --quiet HEAD -- "$change_path" 2>/dev/null; then
-      echo "Staging .specclaw/changes/${CHANGE_NAME}/ artifacts for the PR…"
-      git add "$change_path" 2>/dev/null || true
-      if ! git diff --cached --quiet -- "$change_path" 2>/dev/null; then
-        git commit -m "specclaw(${CHANGE_NAME}): include .specclaw/ planning + verify artifacts in PR" \
-          --only -- "$change_path" >/dev/null 2>&1 || true
-      fi
+  if [[ -d "$change_path" ]] && [[ -n "$(git status --porcelain "$change_path" 2>/dev/null)" ]]; then
+    echo "Staging .specclaw/changes/${CHANGE_NAME}/ artifacts for the PR…"
+    git add "$change_path" 2>/dev/null || true
+    if ! git diff --cached --quiet -- "$change_path" 2>/dev/null; then
+      git commit -m "specclaw(${CHANGE_NAME}): include .specclaw/ planning + verify artifacts in PR" \
+        --only -- "$change_path" >/dev/null 2>&1 || true
     fi
+  fi
+  # Hard constraint: the planning trail MUST be committed before the PR opens.
+  # If anything under the change dir is still uncommitted, abort rather than
+  # open a PR missing the proposal artifacts. .env is gitignored so it never
+  # appears here.
+  if [[ -d "$change_path" ]] && [[ -n "$(git status --porcelain "$change_path" 2>/dev/null)" ]]; then
+    die "planning artifacts under $change_path are not committed — refusing to open a PR without the proposal trail. Commit them (git add '$change_path' && git commit) and re-run."
   fi
   # Push so the ADO branch has them before the PR is opened
   git push 2>/dev/null || true

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -601,15 +601,20 @@ main() {
   # Use `git status --porcelain` (not `git diff HEAD`) so untracked new files
   # are detected — `git diff HEAD` only shows changes to already-tracked files.
   local change_path="${SPECCLAW_DIR}/changes/${CHANGE_NAME}"
-  if [[ -d "$change_path" ]] && [[ -z "$(git status --porcelain "$change_path" 2>/dev/null)" ]]; then
-    : # nothing to add (working tree clean for this dir — no modified or untracked files)
-  elif [[ -d "$change_path" ]]; then
+  if [[ -d "$change_path" ]] && [[ -n "$(git status --porcelain "$change_path" 2>/dev/null)" ]]; then
     echo "Staging .specclaw/changes/${CHANGE_NAME}/ artifacts for the PR…"
     git add "$change_path" 2>/dev/null || true
     if ! git diff --cached --quiet -- "$change_path" 2>/dev/null; then
       git commit -m "specclaw(${CHANGE_NAME}): include .specclaw/ planning + verify artifacts in PR" \
         --only -- "$change_path" >/dev/null 2>&1 || true
     fi
+  fi
+  # Hard constraint: the planning trail MUST be committed before the PR opens.
+  # If anything under the change dir is still uncommitted (staging or commit
+  # failed above), abort rather than open a PR missing the proposal artifacts.
+  # .env is gitignored so it never appears here.
+  if [[ -d "$change_path" ]] && [[ -n "$(git status --porcelain "$change_path" 2>/dev/null)" ]]; then
+    die "planning artifacts under $change_path are not committed — refusing to open a PR without the proposal trail. Commit them (git add '$change_path' && git commit) and re-run."
   fi
   # Push any new commits to the remote branch so the PR sees them
   git push 2>/dev/null || true

--- a/plugins/specclaw/skills/pr-azdo/SKILL.md
+++ b/plugins/specclaw/skills/pr-azdo/SKILL.md
@@ -9,7 +9,7 @@ description: Create an Azure DevOps pull request for a verified change. Mirrors 
 Create an Azure DevOps PR for a verified change.
 
 1. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Fails if `verify-report.md` is missing.
-2. **Run:** `specclaw-azdo-pr .specclaw <change>`
+2. **Run:** `specclaw-azdo-pr .specclaw <change>` — **always** create the PR through this script, never hand-roll the ADO REST call. `specclaw-azdo-pr` stages and commits the full `.specclaw/changes/<change>/` planning trail (proposal, spec, design, tasks, status, verify-report) into the branch and **aborts if any of it is left uncommitted** — bypassing it ships a PR missing the proposal artifacts.
    - Requires `AZDO_TOKEN`, `AZDO_ORG`, `AZDO_PROJECT`, `AZDO_REPO` (set via `/specclaw:auth-azdo`).
    - **Test policy:** same gate as `/specclaw:pr` — prompts once, enforces on all runs.
    - **PR creation:** builds title (≤128 chars) from `proposal.md`, description from `spec.md` + `verify-report.md`, calls ADO REST API.

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -12,7 +12,7 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
    - Check if `.specclaw/changes/<change>/review-report.md` exists. If it does not exist, warn: "code_review_block is enabled but no review-report.md found — run /specclaw:verify first" and continue.
    - If `review-report.md` exists and verdict is `CHANGES_REQUESTED`, **abort** with: "PR blocked: code review verdict is CHANGES_REQUESTED. Fix BLOCK findings in review-report.md then re-run /specclaw:verify." List all BLOCK findings from the report before aborting.
 2. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Exits with a warning (exit 0) if a PR already exists for this change. Fails if `verify-report.md` is missing.
-2. **Run:** `specclaw-pr .specclaw <change>`
+2. **Run:** `specclaw-pr .specclaw <change>` — **always** create the PR through this script, never hand-roll `gh pr create`. `specclaw-pr` stages and commits the full `.specclaw/changes/<change>/` planning trail (proposal, spec, design, tasks, status, verify-report) into the branch and **aborts if any of it is left uncommitted** — a raw `gh pr create` skips this and ships a PR missing the proposal artifacts.
    - **First run:** prompts for test policy (`none|unit|e2e|both`), saves it to `config.yaml` under `pr.test_policy`. Never prompts again.
    - **Test enforcement:** if policy is not `none`, verifies `build.test_command` is set and that `verify-report.md` contains test evidence. Fails (strict) or warns (non-strict) if evidence is missing.
    - **Version bump:** if `plugin.version_files` is set in `config.yaml`, compares each file's `"version"` against the base branch. If unchanged, auto-bumps the patch version and commits before PR creation. Configure in `.specclaw/config.yaml`:


### PR DESCRIPTION
## Problem

PRs were shipping **without** the `.specclaw/changes/<change>/` proposal trail (proposal, spec, design, status). Surfaced on PR #30, where only `tasks.md` landed and `proposal.md`/`spec.md`/`design.md`/`status.md` were missing.

Two root causes:

1. **`specclaw-azdo-pr` missed untracked files** — used `git diff --quiet HEAD` to decide whether to stage, which only detects changes to *already-tracked* files. A brand-new `proposal.md` (untracked) was never staged. (`specclaw-pr` already used `git status --porcelain`; azdo drifted.)
2. **Both scripts swallowed failures** — staging/commit ran under `|| true`, so any failure still opened the PR silently.
3. **Hand-rolled `gh pr create` bypasses staging entirely** — which is exactly how PR #30 shipped incomplete.

## Fix

- `specclaw-azdo-pr`: switch detection to `git status --porcelain` (matches `specclaw-pr`) so untracked artifacts are staged.
- **Both scripts**: add a hard post-commit assertion — if anything under the change dir is still uncommitted, `die` instead of opening an incomplete PR.
- `pr` + `pr-azdo` SKILL.md: document that the PR must **always** go through the script, never a hand-rolled `gh pr create` / ADO REST call.
- Version bump 0.4.5 → 0.4.6.

## Note

Both this branch and PR #30 bump to **0.4.6** from the same 0.4.5 base — whichever merges second needs a trivial re-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)