### PR TITLE
docs: fix stale CONTRIBUTING.md references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Open an issue on GitHub with:
    - `plugins/specclaw/.claude-plugin/plugin.json`
    - `.claude-plugin/marketplace.json` (the `"specclaw"` entry)
    Commit as `chore: bump version to X.Y.Z`.
-5. Test with OpenClaw: install the skill locally and run through the workflow
+5. Test with Claude Code: install the plugin from your local checkout and run through the lifecycle
 6. Commit with conventional commits: `feat: add X`, `fix: resolve Y`
 7. Open a PR with a clear description
 
@@ -30,7 +30,14 @@ git clone https://github.com/chan4lk/specclaw.git
 cd specclaw
 ```
 
-The skill is in `skill/` — test by symlinking or copying to your OpenClaw skills directory.
+The plugin lives in `plugins/specclaw/` (skills, agents, templates, references, tests). To test your changes locally, add the checkout as a marketplace and install from it inside Claude Code:
+
+```
+/plugin marketplace add /path/to/specclaw
+/plugin install specclaw@chan4lk
+```
+
+Then run the workflow (`/specclaw:init`, `/specclaw:propose`, ...) in a scratch project.
 
 ### What We Need Help With
 

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",


### PR DESCRIPTION
CONTRIBUTING.md still described the project as an OpenClaw skill living in a `skill/` directory — neither exists anymore. The repo is a Claude Code plugin under `plugins/specclaw/`.

Changes:
- Testing step references Claude Code and the local plugin-install workflow instead of OpenClaw
- Development Setup points to `plugins/specclaw/` and shows `/plugin marketplace add` from a local checkout
- Version bumped 0.5.0 → 0.5.1 per repo convention (note: #32 also bumps to 0.5.1 — whichever merges second needs a rebase bump; happy to handle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)