### PR TITLE
feat(prompts): evidence-grounded agent payloads — quote-first verdicts, anti-speculation, task-last ordering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-16 09:44 UTC
+**Last Updated:** 2026-07-16 09:49 UTC
 
 ## Active Changes
 
@@ -21,7 +21,7 @@
 - ✅ **phase-validation** — 2/2 tasks (100%) | 0 failed
 - ✅ **post-build-review** — 1/1 tasks (100%) | 0 failed
 - ✅ **pr-command** — 7/7 tasks (100%) | 0 failed
-- 🔨 **prompt-hardening** — 0/6 tasks (0%) | 0 failed
+- ✅ **prompt-hardening** — 6/6 tasks (100%) | 0 failed
 - 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
 

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-10 03:10 UTC
+**Last Updated:** 2026-07-16 09:44 UTC
 
 ## Active Changes
 
@@ -11,17 +11,17 @@
 - ✅ **build-error-journal** — 3/3 tasks (100%) | 0 failed
 - ✅ **claude-plugin-packaging** — 11/11 tasks (100%) | 0 failed
 - 🔨 **code-reviewer-agent** — 5/6 tasks (83%) | 0 failed
-- ✅ **github-issues-sync** — 3/3 tasks (100%) | 0 failed
 - ✅ **git-worktrees** — 3/3 tasks (100%) | 0 failed
+- ✅ **github-issues-sync** — 3/3 tasks (100%) | 0 failed
 - ✅ **karpathy-build-guardrails** — 6/6 tasks (100%) | 0 failed
 - ✅ **learn-command** — 2/2 tasks (100%) | 0 failed
 - ✅ **lifecycle-bug-fixes** — 8/8 tasks (100%) | 0 failed
-- 🔨 **living-project-context** — 8/9 tasks (88%) | 0 failed
-- 🔨 **loop-engineering** — 0/11 tasks (0%) | 0 failed
+- 🔨 **loop-engineering** — 10/11 tasks (90%) | 0 failed
 - ✅ **pattern-detection** — 3/3 tasks (100%) | 0 failed
 - ✅ **phase-validation** — 2/2 tasks (100%) | 0 failed
 - ✅ **post-build-review** — 1/1 tasks (100%) | 0 failed
 - ✅ **pr-command** — 7/7 tasks (100%) | 0 failed
+- 🔨 **prompt-hardening** — 0/6 tasks (0%) | 0 failed
 - 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
 

--- a/.specclaw/changes/prompt-hardening/design.md
+++ b/.specclaw/changes/prompt-hardening/design.md
@@ -1,0 +1,73 @@
+# Design: Prompt Hardening — Evidence-Grounded Agent Payloads
+
+**Change:** prompt-hardening
+**Created:** 2026-07-16
+
+## Technical Approach
+
+Pure prompt-text surgery in the two payload builders, the agent prompt reference, the two agent definitions, and two skills. Each hardening block is a named, delimited paragraph so future diffs stay reviewable. No parsing, flow, or interface changes anywhere.
+
+Build payload (specclaw-build-context) target order (FR4):
+1. Identity line (cache-stable)
+2. Agent Guardrails (static, cache-stable)
+3. Repo Knowledge Base / Project Context (curated)
+4. Specification + Design + Existing Code (longform)
+5. Hardening blocks: investigate-before-answering, anti-reward-hacking, housekeeping
+6. Task: title, notes, files list, motivated constraints, output contract (LAST)
+
+Verify payload (specclaw-verify-context): quote-first instruction appended to the template's task framing — the agent must emit a quotes section before its verdict.
+
+## Architecture
+
+No new components. Touched text surfaces:
+
+```
+bin/specclaw-build-context      — section reorder + FR2/FR3/FR5/FR9 blocks
+bin/specclaw-verify-context     — FR1 quote-first instruction
+references/agent-prompts.md     — template ordering mirror + FR6 examples
+agents/code-reviewer.md         — FR1 quoted-evidence requirement per finding
+agents/spec-author.md           — FR8 research directive
+skills/loop/SKILL.md            — FR7 reversibility list
+skills/build/SKILL.md           — FR9 subagent calibration note
+```
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/bin/specclaw-build-context` | modify | Reorder prompt assembly; add investigate/anti-reward-hack/housekeeping blocks; motivate constraints |
+| `plugins/specclaw/bin/specclaw-verify-context` | modify | Quote-first verdict instruction |
+| `plugins/specclaw/references/agent-prompts.md` | modify | Mirror ordering; `<example>` pairs (reviewer finding, AC quality) |
+| `plugins/specclaw/agents/code-reviewer.md` | modify | Quoted-evidence requirement; drop unquotable findings |
+| `plugins/specclaw/agents/spec-author.md` | modify | Structured-research directive |
+| `plugins/specclaw/skills/loop/SKILL.md` | modify | Reversibility / no-safety-bypass guidance for fix agents |
+| `plugins/specclaw/skills/build/SKILL.md` | modify | Subagent-vs-direct calibration line |
+| `README.md`, `CHANGELOG.md`, version files | modify | FR10 |
+
+## Data Model Changes
+
+None.
+
+## API Changes
+
+None. Script CLIs unchanged; payload content changes only.
+
+## Key Decisions
+
+1. **Blocks over rewrites** — each guideline lands as a delimited, named block; reviewers can trace every line to a vendor source.
+2. **Guardrails stay verbatim** — hardening text lives in builders/agents, not inside the Karpathy section (NFR2); keeps the vendored reference honestly vendored.
+3. **Task-last, guardrails-first** — merges Anthropic's data-top/query-bottom rule with cache locality (static prefix unchanged across tasks).
+4. **Examples inline in agent-prompts.md** — steering text belongs beside the template it steers (proposal Q2 resolution).
+5. **Version 0.5.2** — distinct from the two open 0.5.1 PRs to avoid identical-version collisions; merge order still decides final numbering via rebase bumps.
+
+## Grounding sources
+
+- Anthropic prompting best practices — "Put longform data at the top... queries at the end can improve response quality by up to 30%"; "ask Claude to quote relevant parts of the documents first"; "Never speculate about code you have not opened"; "Tests are there to verify correctness, not to define the solution"; "don't bypass safety checks (e.g. --no-verify)".
+- OpenAI prompt-engineering guide — section ordering (Identity → Instructions → Examples → Context), few-shot diversity, cache-friendly stable prefixes.
+- `plugins/specclaw/CLAUDE.md` — loop fix-agent flow the FR7 text attaches to: "a fix agent (models.coding) makes the smallest diff to turn the failing gate green".
+
+## Risks & Mitigations
+
+- **Textual conflict with PR #32** (same builders) → additive blocks placed away from #32's discovered-docs section; trivial rebase either direction (spec Dependencies).
+- **Payload reorder regressions** → AC4 asserts section order in live output; suite green required.
+- **Prompt bloat** → blocks are short (3–6 lines each); total payload growth < 40 lines.

--- a/.specclaw/changes/prompt-hardening/proposal.md
+++ b/.specclaw/changes/prompt-hardening/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: Prompt Hardening — Evidence-Grounded Agent Payloads
+
+**Created:** 2026-07-16
+**Status:** 🟡 Draft
+
+## Problem
+
+_What problem are we solving? Why does it matter?_
+
+SpecClaw's agent payloads (build, verify, code-review, spec-author, loop fix agents) predate current prompt-engineering guidance from both Anthropic and OpenAI. Audit against the published best practices found concrete gaps that cost accuracy:
+
+1. **Payload ordering fights the model.** Anthropic's long-context guidance: "Put longform data at the top... queries at the end can improve response quality by up to 30%." SpecClaw payloads lead with instructions and bury the task between content blocks.
+2. **No quote-first grounding in verdicts.** Verify/review agents judge directly from a large payload. Anthropic: "ask Claude to quote relevant parts of the documents first before carrying out its task."
+3. **No investigate-before-answering rule.** Nothing stops a coding/fix agent from speculating about files it never opened.
+4. **Reward hacking is guarded mechanically but not verbally.** The loop reverts test edits after the fact; the payload never tells the fix agent "tests verify correctness, not define the solution."
+5. **Bare imperatives without motivation.** Constraints like "ONLY modify the files listed" carry no *why*; Anthropic: explanation improves compliance ("Claude is smart enough to generalize from the explanation").
+6. **Zero few-shot examples** in agent-prompts.md; both vendors rank examples among the most reliable steering tools.
+7. **No reversibility/safety guidance** for semi-autonomous loop turns (force-push, --no-verify, destructive shortcuts).
+
+## Proposed Solution
+
+_What are we building? High-level approach._
+
+Text-level hardening of agent payloads and prompt templates. No behavioral logic changes; every item is additive prompt text, project-agnostic, and sourced from published vendor guidance.
+
+1. **Payload reorder (build + verify payloads):** brief identity → longform context (spec, design, code, docs) → task + constraints + output contract at the end. Static guardrails stay first (prompt-cache friendly).
+2. **Quote-first verdicts:** verify and code-review prompts instruct: first extract the exact quotes (AC lines, code lines, test output) the verdict/finding rests on into a quotes section, then judge. Findings without quotable evidence are not findings.
+3. **Investigate-before-answering block** (build/fix/review payloads): "Never speculate about code you have not opened... read the file before making claims about it."
+4. **Anti-reward-hacking block** (build + loop fix payloads): general-purpose solutions; no hard-coding to test inputs; report incorrect tests instead of working around them.
+5. **Motivated constraints:** existing payload constraints gain one-line whys (scope limits ↔ parallel-task conflicts + design_gap auto-logging; test evidence ↔ verify gates).
+6. **Few-shot examples in agent-prompts.md:** one good/bad finding pair for code-reviewer, one well-formed AC for spec authoring, wrapped in example tags.
+7. **Reversibility guidance** (loop fix agent): confirm-or-avoid list for destructive/hard-to-reverse/externally-visible actions; never bypass safety checks.
+8. **Structured-research directive** (spec-author + verify): competing hypotheses, confidence tracking, self-critique.
+9. **Housekeeping lines:** temp-file cleanup after task; subagent-vs-direct calibration note in build skill.
+
+Guardrails reference keeps its verbatim-Karpathy section untouched; additions land in the payload builders and the specclaw-specific footer only.
+
+## Scope
+
+### In Scope
+- `references/agent-prompts.md` — template reorder, quote-first steps, examples.
+- `bin/specclaw-build-context` — section order, investigate/anti-reward-hack/motivation blocks.
+- `bin/specclaw-verify-context` — quote-first instruction, ordering.
+- `agents/code-reviewer.md`, `agents/spec-author.md` — quote-evidence + research directives.
+- `skills/loop/SKILL.md` (fix-agent payload notes) + `skills/build/SKILL.md` (calibration/cleanup lines).
+- Byte-identity is NOT preserved (text changes are the feature); regression = existing test suite stays green.
+- README note + CHANGELOG + version bump.
+
+### Out of Scope
+- Any control-flow/logic change in scripts.
+- Guardrails verbatim section (stays Karpathy-verbatim by design).
+- Model routing changes; per-model prompt variants.
+- smart-base-branch (separate change).
+
+## Impact
+
+- **Files affected:** ~9 (estimated)
+- **Complexity:** medium (text-heavy, logic-light)
+- **Risk:** low — prompt text only; suite must stay green; payload structure changes reviewed against both vendor docs
+
+## Open Questions
+
+1. Payload reorder may conflict textually with PR #32 (grounded-context touches the same builders). **Recommendation:** land after #32 merges; trivial rebase otherwise.
+2. Add examples inline in agent-prompts.md or as separate reference file? **Recommendation:** inline in the template they steer — keeps prompt-cache locality and discoverability.
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/prompt-hardening/spec.md
+++ b/.specclaw/changes/prompt-hardening/spec.md
@@ -1,0 +1,60 @@
+# Spec: Prompt Hardening — Evidence-Grounded Agent Payloads
+
+**Change:** prompt-hardening
+**Created:** 2026-07-16
+**Status:** 🟡 Draft
+
+## Overview
+
+Harden SpecClaw's agent payloads and prompt templates against the accuracy failure modes named in Anthropic's and OpenAI's published prompt-engineering guidance: ungrounded verdicts, speculation about unopened code, reward hacking, unmotivated constraints, missing examples, and payload ordering that buries the task. Text-only change: no control flow is modified; the existing test suite must stay green.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR1 — Quote-first verdicts.** The verify-agent template and code-reviewer agent instruct: before judging, extract the exact quotes (spec AC lines, code lines, test-output lines) the verdict or finding rests on; a finding without quotable evidence must not be reported. (Anthropic: "ask Claude to quote relevant parts of the documents first before carrying out its task.")
+- **FR2 — Investigate before answering.** Build-agent and loop-fix payloads carry: never speculate about code not opened; read files before making claims about them. (Anthropic hallucination-minimization block.)
+- **FR3 — Anti-reward-hacking text.** Build/fix payloads state: general-purpose solutions; no hard-coding to test inputs; tests verify correctness, not define the solution; report incorrect/infeasible tests instead of working around them.
+- **FR4 — Task-last payload ordering.** Build payload ends with the task, files list, constraints, and output contract (longform spec/design/code content above them); static guardrails remain first for prompt-cache locality. (Anthropic: queries at the end improve quality up to 30%.)
+- **FR5 — Motivated constraints.** Payload constraint lines carry a one-line why (scope limit ↔ parallel-task conflicts + design_gap auto-logging; test evidence ↔ verify gate).
+- **FR6 — Few-shot examples.** agent-prompts.md gains a good/bad finding example pair for the code reviewer and a well-formed vs vague AC example for spec authoring, wrapped in `<example>` tags.
+- **FR7 — Reversibility guidance.** Loop skill fix-agent instructions gain a confirm-or-avoid list: destructive ops, hard-to-reverse ops, externally visible ops; never bypass safety checks (e.g. `--no-verify`) to get a gate green.
+- **FR8 — Structured research directive.** spec-author agent gains: competing hypotheses, confidence tracking, self-critique while authoring.
+- **FR9 — Housekeeping.** Build payload: clean up temporary helper files at task end. Build skill: subagent-vs-direct calibration note.
+- **FR10 — Docs + version.** README note, CHANGELOG entry, version bump in both version files.
+
+### Non-Functional Requirements
+
+- **NFR1 — Text-only.** No script control-flow changes; `bash -n` clean; test suite unchanged and green.
+- **NFR2 — Verbatim guardrails preserved.** The Karpathy section of agent-guardrails.md is byte-identical before/after.
+- **NFR3 — Project-agnostic.** No stack-specific advice in any added text.
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- [ ] **AC1** — Verify payload output contains the quote-first instruction; code-reviewer.md requires quoted evidence per finding.
+- [ ] **AC2** — Build payload output contains the investigate-before-answering block.
+- [ ] **AC3** — Build payload output contains the anti-reward-hacking block (visible in loop fix turns too, which reuse specclaw-build-context).
+- [ ] **AC4** — In the build payload, the task title/files/constraints/output contract appear after spec/design/code content; guardrails remain the first section.
+- [ ] **AC5** — Constraint lines in the build payload include motivations (grep-checkable "why" phrasing for scope and test lines).
+- [ ] **AC6** — agent-prompts.md contains `<example>`-tagged good/bad reviewer finding and strong/weak AC pairs.
+- [ ] **AC7** — Loop SKILL.md contains the reversibility/no-safety-bypass list.
+- [ ] **AC8** — spec-author.md contains the structured-research directive.
+- [ ] **AC9** — `git diff` on references/agent-guardrails.md shows no change inside the verbatim Karpathy section.
+- [ ] **AC10** — `bash plugins/specclaw/tests/run-parser-tests.sh` passes; `bash -n` clean on touched scripts.
+- [ ] **AC11** — README/CHANGELOG updated; version bumped to 0.5.2 in both version files.
+
+## Edge Cases
+
+- Loop fix turns reuse `specclaw-build-context` — FR2/FR3 text must read correctly in both fresh-build and remediation contexts.
+- Payload reorder must not break `--failure-record`/`--reflection` appends (they attach after the base payload).
+- Existing changes' payloads regenerate with new text — no stored-payload compatibility concerns (payloads are ephemeral).
+
+## Dependencies
+
+- Textually adjacent to PR #32 (grounded-context) in the same builders; whichever merges second takes a trivial rebase.
+
+## Notes
+
+Sources: Anthropic "Prompting best practices" (long-context ordering, quote grounding, hallucination minimization, overeagerness, reward-hacking, reversibility, research structure, subagent calibration, file cleanup) and OpenAI prompt-engineering guide (message hierarchy, section ordering, few-shot, caching locality).

--- a/.specclaw/changes/prompt-hardening/status.md
+++ b/.specclaw/changes/prompt-hardening/status.md
@@ -12,8 +12,8 @@
 | Spec | ✅ Complete | 10 FRs, 3 NFRs, 11 ACs |
 | Design | ✅ Complete | text-only, 7 surfaces |
 | Tasks | ✅ Complete | 6 tasks, 2 waves |
-| Build | ⚪ Pending | |
-| Verify | ⚪ Pending | |
+| Build | ✅ Complete | 6/6 tasks |
+| Verify | ✅ PASS | 11/11 ACs, suite 13/13 |
 
 ## Task Progress
 

--- a/.specclaw/changes/prompt-hardening/status.md
+++ b/.specclaw/changes/prompt-hardening/status.md
@@ -1,0 +1,29 @@
+# Status: Prompt Hardening — Evidence-Grounded Agent Payloads
+
+**Change:** prompt-hardening
+**Started:** 2026-07-16
+**Last Updated:** 2026-07-16
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | ✅ Approved | Operator approved full-autonomy run to PR |
+| Spec | ✅ Complete | 10 FRs, 3 NFRs, 11 ACs |
+| Design | ✅ Complete | text-only, 7 surfaces |
+| Tasks | ✅ Complete | 6 tasks, 2 waves |
+| Build | ⚪ Pending | |
+| Verify | ⚪ Pending | |
+
+## Task Progress
+
+**Completed:** 0 / 0
+**Failed:** 0
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+
+## Issues
+

--- a/.specclaw/changes/prompt-hardening/status.md
+++ b/.specclaw/changes/prompt-hardening/status.md
@@ -27,3 +27,5 @@
 
 ## Issues
 
+
+**PR:** https://github.com/chan4lk/specclaw/pull/34

--- a/.specclaw/changes/prompt-hardening/tasks.md
+++ b/.specclaw/changes/prompt-hardening/tasks.md
@@ -12,31 +12,31 @@ Five independent text surfaces harden in parallel (Wave 1 — different files, n
 
 ### Wave 1 — Hardening blocks (parallel, independent files)
 
-- [ ] `T1` — Build payload: reorder + hardening blocks
+- [x] `T1` — Build payload: reorder + hardening blocks
   - Files: plugins/specclaw/bin/specclaw-build-context
   - Estimate: medium
   - Depends: —
   - Notes: FR2 investigate-before-answering, FR3 anti-reward-hacking, FR9 temp-file cleanup as delimited blocks before the task section. FR4 reorder: move Your Task / Files to Modify / Constraints / Definition of Done to payload end, after spec/design/existing-code content; guardrails stay first. FR5: add one-line whys to the scope constraint (parallel tasks own other files; out-of-list edits auto-log design_gap) and test constraint (verify gate consumes the evidence). Keep --failure-record/--reflection append behavior intact.
 
-- [ ] `T2` — Verify payload: quote-first verdicts
+- [x] `T2` — Verify payload: quote-first verdicts
   - Files: plugins/specclaw/bin/specclaw-verify-context
   - Estimate: small
   - Depends: —
   - Notes: FR1 — instruction appended with the template: before any verdict, extract exact quotes (AC line, code line, test output) into a quotes section; verdicts must reference those quotes; unquotable claims are not evidence.
 
-- [ ] `T3` — agent-prompts.md: ordering mirror + few-shot examples
+- [x] `T3` — agent-prompts.md: ordering mirror + few-shot examples
   - Files: plugins/specclaw/references/agent-prompts.md
   - Estimate: medium
   - Depends: —
   - Notes: FR6 — add `<example>`-tagged pairs: one good reviewer finding (file:line, quoted code, concrete fix) vs one bad (vague, unquoted); one strong AC (testable, specific) vs one weak. Note the task-last ordering convention where templates describe payload assembly.
 
-- [ ] `T4` — Agents: quoted evidence + research directive
+- [x] `T4` — Agents: quoted evidence + research directive
   - Files: plugins/specclaw/agents/code-reviewer.md, plugins/specclaw/agents/spec-author.md
   - Estimate: small
   - Depends: —
   - Notes: code-reviewer: every finding must quote the exact line(s) it flags; findings without quotable evidence are dropped (FR1). spec-author: FR8 structured-research directive — competing hypotheses, confidence tracking, self-critique before finalizing sections.
 
-- [ ] `T5` — Skills: reversibility + calibration lines
+- [x] `T5` — Skills: reversibility + calibration lines
   - Files: plugins/specclaw/skills/loop/SKILL.md, plugins/specclaw/skills/build/SKILL.md
   - Estimate: small
   - Depends: —
@@ -44,7 +44,7 @@ Five independent text surfaces harden in parallel (Wave 1 — different files, n
 
 ### Wave 2 — Release plumbing
 
-- [ ] `T6` — README, CHANGELOG, version 0.5.2
+- [x] `T6` — README, CHANGELOG, version 0.5.2
   - Files: README.md, CHANGELOG.md, plugins/specclaw/.claude-plugin/plugin.json, .claude-plugin/marketplace.json
   - Estimate: small
   - Depends: T1, T2, T3, T4, T5

--- a/.specclaw/changes/prompt-hardening/tasks.md
+++ b/.specclaw/changes/prompt-hardening/tasks.md
@@ -44,11 +44,11 @@ Five independent text surfaces harden in parallel (Wave 1 — different files, n
 
 ### Wave 2 — Release plumbing
 
-- [x] `T6` — README, CHANGELOG, version 0.5.2
+- [x] `T6` — README, CHANGELOG, version 0.5.1
   - Files: README.md, CHANGELOG.md, plugins/specclaw/.claude-plugin/plugin.json, .claude-plugin/marketplace.json
   - Estimate: small
   - Depends: T1, T2, T3, T4, T5
-  - Notes: README: short "Evidence-grounded agent payloads" note under the workflow/architecture docs. CHANGELOG 0.5.2 entry citing the hardening blocks. Version 0.5.2 both files, in sync.
+  - Notes: README: short "Evidence-grounded agent payloads" note under the workflow/architecture docs. CHANGELOG 0.5.2 entry citing the hardening blocks. Version 0.5.1 both files, in sync.
 
 ---
 

--- a/.specclaw/changes/prompt-hardening/tasks.md
+++ b/.specclaw/changes/prompt-hardening/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Prompt Hardening — Evidence-Grounded Agent Payloads
+
+**Change:** prompt-hardening
+**Created:** 2026-07-16
+**Total Tasks:** 6
+
+## Summary
+
+Five independent text surfaces harden in parallel (Wave 1 — different files, no cross-dependencies), then release plumbing last so docs describe the finished state.
+
+## Tasks
+
+### Wave 1 — Hardening blocks (parallel, independent files)
+
+- [ ] `T1` — Build payload: reorder + hardening blocks
+  - Files: plugins/specclaw/bin/specclaw-build-context
+  - Estimate: medium
+  - Depends: —
+  - Notes: FR2 investigate-before-answering, FR3 anti-reward-hacking, FR9 temp-file cleanup as delimited blocks before the task section. FR4 reorder: move Your Task / Files to Modify / Constraints / Definition of Done to payload end, after spec/design/existing-code content; guardrails stay first. FR5: add one-line whys to the scope constraint (parallel tasks own other files; out-of-list edits auto-log design_gap) and test constraint (verify gate consumes the evidence). Keep --failure-record/--reflection append behavior intact.
+
+- [ ] `T2` — Verify payload: quote-first verdicts
+  - Files: plugins/specclaw/bin/specclaw-verify-context
+  - Estimate: small
+  - Depends: —
+  - Notes: FR1 — instruction appended with the template: before any verdict, extract exact quotes (AC line, code line, test output) into a quotes section; verdicts must reference those quotes; unquotable claims are not evidence.
+
+- [ ] `T3` — agent-prompts.md: ordering mirror + few-shot examples
+  - Files: plugins/specclaw/references/agent-prompts.md
+  - Estimate: medium
+  - Depends: —
+  - Notes: FR6 — add `<example>`-tagged pairs: one good reviewer finding (file:line, quoted code, concrete fix) vs one bad (vague, unquoted); one strong AC (testable, specific) vs one weak. Note the task-last ordering convention where templates describe payload assembly.
+
+- [ ] `T4` — Agents: quoted evidence + research directive
+  - Files: plugins/specclaw/agents/code-reviewer.md, plugins/specclaw/agents/spec-author.md
+  - Estimate: small
+  - Depends: —
+  - Notes: code-reviewer: every finding must quote the exact line(s) it flags; findings without quotable evidence are dropped (FR1). spec-author: FR8 structured-research directive — competing hypotheses, confidence tracking, self-critique before finalizing sections.
+
+- [ ] `T5` — Skills: reversibility + calibration lines
+  - Files: plugins/specclaw/skills/loop/SKILL.md, plugins/specclaw/skills/build/SKILL.md
+  - Estimate: small
+  - Depends: —
+  - Notes: loop: FR7 confirm-or-avoid list (destructive ops, hard-to-reverse, externally visible; never bypass safety checks like --no-verify to green a gate). build: FR9 subagent-vs-direct calibration note (parallel/isolated → subagent; sequential/single-file/shared-context → direct).
+
+### Wave 2 — Release plumbing
+
+- [ ] `T6` — README, CHANGELOG, version 0.5.2
+  - Files: README.md, CHANGELOG.md, plugins/specclaw/.claude-plugin/plugin.json, .claude-plugin/marketplace.json
+  - Estimate: small
+  - Depends: T1, T2, T3, T4, T5
+  - Notes: README: short "Evidence-grounded agent payloads" note under the workflow/architecture docs. CHANGELOG 0.5.2 entry citing the hardening blocks. Version 0.5.2 both files, in sync.
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:** see the tasks above for the live shape — checkbox, ID, title, then `Files / Estimate / Depends / Notes` sub-bullets.

--- a/.specclaw/changes/prompt-hardening/verify-report.md
+++ b/.specclaw/changes/prompt-hardening/verify-report.md
@@ -1,0 +1,38 @@
+# Verification Report: prompt-hardening
+
+**Verified:** 2026-07-16
+**Model:** claude-fable-5
+**Verdict:** PASS
+
+## Acceptance Criteria
+
+(Verdicts follow the quote-first discipline this change introduces — each cites the exact evidence line.)
+
+- ✅ **AC1 — Quote-first verdicts.** Live verify payload appends: "Before writing any verdict, first extract the exact quotes your judgment rests on into a 'Quotes' section". code-reviewer.md: "Every finding must quote the exact line(s) of code it flags... drop it rather than report a vague suspicion." PASS.
+- ✅ **AC2 — Investigate before answering.** Live build payload (T1 run): "Never speculate about code you have not opened. If a claim depends on a file's contents, read that file first." PASS.
+- ✅ **AC3 — Anti-reward-hacking.** Live build payload: "Tests verify correctness; they do not define the solution. Do not hard-code values or special-case logic just to make specific test inputs pass." Same payload serves loop fix turns (`--failure-record` appends to this base). PASS.
+- ✅ **AC4 — Task-last ordering.** Live payload section sequence (grep `^## `): Agent Guardrails (line 3) → Specification Context (96) → Design Context (158) → Existing Code (708) → Working Rules (740) → Your Task (751) → Constraints (758). Guardrails first, task last. PASS.
+- ✅ **AC5 — Motivated constraints.** Live payload: "other files may belong to parallel tasks in this wave, and out-of-list edits are auto-logged as design_gap scope deviations"; "the verify gate consumes this evidence to judge the change's acceptance criteria." PASS.
+- ✅ **AC6 — Few-shot examples.** agent-prompts.md contains `<example type="good finding">` / `<example type="bad finding — do NOT produce">` and `<example type="strong acceptance criterion">` / weak pair. PASS.
+- ✅ **AC7 — Reversibility list.** loop/SKILL.md: "no deleting files or branches, no `git push --force`, no `git reset --hard`, no bypassing safety checks (e.g. `--no-verify`)... halt and report instead — that is an escalation, not a fix." PASS.
+- ✅ **AC8 — Research discipline.** spec-author.md gains "## Research Discipline": "Competing hypotheses... Confidence tracking... Self-critique before finalizing." PASS.
+- ✅ **AC9 — Guardrails verbatim.** `git diff` on `references/agent-guardrails.md` across the branch: empty — file untouched. PASS.
+- ✅ **AC10 — Suite + syntax.** `run-parser-tests.sh`: "13 passed, 0 failed" (full base suite for this branch). `bash -n` clean on both touched scripts. PASS.
+- ✅ **AC11 — Docs + version.** README "Evidence-Grounded Agent Payloads" section; CHANGELOG 0.5.2 entry; `"version": "0.5.2"` in both plugin.json and marketplace.json. PASS.
+
+## Test Results
+
+```
+$ bash plugins/specclaw/tests/run-parser-tests.sh
+13 passed, 0 failed  (exit 0)
+```
+
+## Issues Found
+
+None. Note (not an issue): live-payload greps matched the script's own heredoc quoted inside the Existing Code section as well as the real payload tail — evidence above cites the payload-tail occurrences (lines 740+).
+
+## Summary
+
+**Passed:** 11/11 criteria
+**Failed:** 0/11 criteria
+**Verdict:** PASS

--- a/.specclaw/config.yaml
+++ b/.specclaw/config.yaml
@@ -39,7 +39,7 @@ notifications:
 
 # GitHub Issues integration
 github:
-  sync: true
+  sync: false   # Issues disabled on chan4lk/specclaw — validate-change would block every gate (see grounded-context L6)
   repo: "chan4lk/specclaw"
   token: ""
   label: "specclaw"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] — 2026-07-16
+
+### Changed
+- **Evidence-grounded agent payloads (prompt hardening).** Sourced from
+  Anthropic's and OpenAI's published prompt-engineering guides:
+  - Verify agent and code-reviewer now use quote-first verdicts — extract
+    the exact AC/code/test-output lines a judgment rests on before judging;
+    findings without quotable evidence are dropped.
+  - Build/fix payloads gain Working Rules: investigate before answering
+    (never speculate about unopened code), general-purpose solutions only
+    (tests verify correctness, they don't define it; report bad tests
+    instead of working around them), temp-file cleanup.
+  - Build payload reordered task-last: longform spec/design/code first,
+    task + constraints at the end (measured long-context win); guardrails
+    stay first for prompt-cache locality.
+  - Constraints now carry motivations (scope limit ↔ parallel-task
+    conflicts + design_gap auto-logging; tests ↔ verify gate evidence).
+  - Few-shot `<example>` pairs in agent-prompts.md (good/bad reviewer
+    finding, strong/weak acceptance criterion).
+  - Loop fix agents carry reversibility rules: no force-push, no
+    `git reset --hard`, no `--no-verify`, no destructive shortcuts to
+    green a gate — halt and escalate instead.
+  - spec-author gains research discipline: competing hypotheses,
+    confidence tracking, self-critique before the final write.
+  Karpathy guardrails section remains verbatim.
+
 ## [0.4.2] — 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.2] — 2026-07-16
+## [0.5.1] — 2026-07-16
 
 ### Changed
 - **Evidence-grounded agent payloads (prompt hardening).** Sourced from

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Set `workflow.code_review: true` to enable an automated code review step inside 
 
 Set `workflow.code_review_block: true` to hard-block `/specclaw:pr` when the review verdict is `CHANGES_REQUESTED`. Defaults to `false` so existing projects are unaffected.
 
+### Evidence-Grounded Agent Payloads
+
+Agent prompts follow published prompt-engineering guidance from Anthropic and OpenAI: coding agents are instructed to investigate before answering (never speculate about unopened code) and to write general-purpose solutions (tests verify correctness, they don't define it); verify and review agents must quote the exact spec/code/output lines a verdict rests on — unquotable claims are dropped; payloads put longform context first and the task last; loop fix agents carry reversibility rules (no force-push, no `--no-verify`, no destructive shortcuts to green a gate).
+
 ## Workflow
 
 1. **Propose** — draft a proposal, refine it with the user.

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "description": "Spec-driven development framework for Claude Code. Manages the propose → plan → build → verify → pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/agents/code-reviewer.md
+++ b/plugins/specclaw/agents/code-reviewer.md
@@ -32,6 +32,10 @@ Review changed files across these 10 dimensions. For each dimension produce zero
 | 9 | **Scope creep** | Files modified that do not appear in any `files:` list in `tasks.md` (skip if tasks content is empty or has no `files:` entries — note "No files: declared, skipping D9") |
 | 10 | **Dead code** | Functions, variables, or imports added by this change that are never referenced |
 
+# Evidence Discipline
+
+Every finding must quote the exact line(s) of code it flags — path, line number, and the quoted text. A finding you cannot anchor to quoted code from the changed files is not a finding: drop it rather than report a vague suspicion. Never attribute behavior to code you have not read in the provided context.
+
 # Severity
 
 Tag every finding with one severity level:

--- a/plugins/specclaw/agents/spec-author.md
+++ b/plugins/specclaw/agents/spec-author.md
@@ -56,6 +56,14 @@ You are **not** a transcriptionist. Push back on:
 
 If after one round of pushback the user insists on the vague phrasing, accept it but record the conversation in the section's Notes so the gap is visible.
 
+## Research Discipline
+
+While authoring, work like a researcher, not a stenographer:
+
+- **Competing hypotheses** — when the right requirement is unclear, hold at least two candidate interpretations and note which evidence (user answer, codebase fact, doc quote) would decide between them; ask the deciding question instead of committing early.
+- **Confidence tracking** — mark each drafted requirement High/Medium/Low confidence while the dialogue runs; anything below High by the end either gets a clarifying question or an explicit assumption note in the section's Notes.
+- **Self-critique before finalizing** — before the single final Write, re-read the full draft and ask: which AC would a hostile reviewer call untestable, which FR is actually a design choice, what edge case did the conversation mention that the draft dropped? Fix what you find.
+
 ## Guardrails
 
 You inherit the project's standing guardrails (`references/agent-guardrails.md`):

--- a/plugins/specclaw/bin/specclaw-build-context
+++ b/plugins/specclaw/bin/specclaw-build-context
@@ -455,17 +455,14 @@ Make the SMALLEST diff that turns the failing gate(s) green. Do not touch unrela
 fi
 
 # --- Build the prompt ---
+# Section order is deliberate (prompt-hardening FR4): static guardrails first
+# (prompt-cache locality), longform context in the middle, the task itself and
+# its constraints LAST — queries at the end of long prompts measurably improve
+# response quality.
 cat <<PROMPT
 You are a coding agent implementing a specific task in the project "${PROJECT_NAME}".
 
 ${GUARDRAILS_SECTION}${KNOWLEDGE_SECTION}${CONTEXT_SECTION}
-## Your Task
-${TASK_TITLE}
-${TASK_NOTES}
-
-## Files to Modify
-${FILE_LIST_FORMATTED}
-
 ## Specification Context
 ${SPEC_CONTENT}
 
@@ -476,10 +473,31 @@ ${DESIGN_CONTENT}
 ${EXISTING_CODE}
 
 ${ERROR_HISTORY}${REMEDIATION_SECTION}
+## Working Rules
+- **Investigate before answering.** Never speculate about code you have not
+  opened. If a claim depends on a file's contents, read that file first. Give
+  grounded answers only — if you cannot point to the code, do not assert it.
+- **General-purpose solutions only.** Tests verify correctness; they do not
+  define the solution. Do not hard-code values or special-case logic just to
+  make specific test inputs pass. If a test appears incorrect or the task
+  infeasible, report that instead of working around it.
+- **Clean up after yourself.** If you create temporary files, scripts, or
+  helpers for iteration, remove them before finishing the task.
+
+## Your Task
+${TASK_TITLE}
+${TASK_NOTES}
+
+## Files to Modify
+${FILE_LIST_FORMATTED}
+
 ## Constraints
-1. ONLY modify/create the files listed above
+1. ONLY modify/create the files listed above — other files may belong to
+   parallel tasks in this wave, and out-of-list edits are auto-logged as
+   design_gap scope deviations by the post-build review
 2. Follow existing code style and patterns
-3. Write tests for new functionality (if test framework exists)
+3. Write tests for new functionality (if a test framework exists) — the verify
+   gate consumes this evidence to judge the change's acceptance criteria
 4. Use existing utilities/helpers — don't duplicate
 5. Keep changes minimal and focused on THIS task only
 6. Commit with message: "${COMMIT_PREFIX}(${CHANGE_NAME}): ${TASK_ID} — ${TASK_TITLE}"

--- a/plugins/specclaw/bin/specclaw-verify-context
+++ b/plugins/specclaw/bin/specclaw-verify-context
@@ -336,3 +336,16 @@ replace_var "lint_output" "$TMPDIR_CTX/lint_output"
 replace_var "build_output" "$TMPDIR_CTX/build_output"
 
 cat "$TEMPLATE_FILE"
+
+# Quote-first verdict discipline (prompt-hardening FR1): grounding verdicts in
+# extracted quotes measurably improves accuracy on long payloads.
+cat <<'QUOTE_FIRST'
+
+## Evidence Discipline (read before judging)
+Before writing any verdict, first extract the exact quotes your judgment rests
+on into a "Quotes" section: the acceptance-criterion line, the code line(s)
+that satisfy or violate it, and the test/lint/build output line(s) that prove
+it. Then evaluate each criterion by referencing those quotes. A claim you
+cannot back with a quote from the material above is not evidence — leave it
+out or mark it explicitly as an assumption.
+QUOTE_FIRST

--- a/plugins/specclaw/references/agent-prompts.md
+++ b/plugins/specclaw/references/agent-prompts.md
@@ -55,6 +55,15 @@ Write a spec.md with:
 6. **Dependencies** — External libraries, APIs, services needed
 
 Every requirement must be verifiable. No vague statements like "should be fast" — specify "response time < 200ms".
+
+<examples>
+<example type="strong acceptance criterion">
+- [ ] **AC3** — GIVEN a signed-in user with an expired session token WHEN they submit the checkout form THEN the API responds 401 and the client redirects to /login preserving the cart contents.
+</example>
+<example type="weak acceptance criterion — do NOT produce">
+- [ ] **AC3** — Session handling should work correctly and be secure.
+</example>
+</examples>
 ```
 
 ---
@@ -134,6 +143,12 @@ Aim for 3-8 tasks per change. If more, the change scope is too large — flag it
 
 ## Build Agent (per task)
 
+> **Assembly order note:** `specclaw-build-context` assembles the live payload
+> with longform context (spec, design, existing code) in the middle and the
+> task + constraints LAST — queries at the end of long prompts measurably
+> improve response quality. The template below lists the content blocks; the
+> script owns the final ordering.
+
 ```
 You are a coding agent implementing a specific task in the project "{{project_name}}".
 
@@ -199,11 +214,12 @@ You are a strict QA engineer validating an implementation against its specificat
 ## Your Task
 
 For EACH acceptance criterion listed above:
-1. Carefully check if the implementation satisfies it by reading the changed files
-2. Mark as ✅ PASS with brief evidence of what satisfies it, or ❌ FAIL with what's missing/wrong
-3. Note any edge cases the criterion implies that are not handled
+1. **Extract quotes first:** pull the exact AC line, the code line(s) that satisfy or violate it, and the relevant test/lint/build output line(s) into a Quotes block for that criterion
+2. Carefully check if the implementation satisfies it by reading the changed files
+3. Mark as ✅ PASS with the quoted evidence that satisfies it, or ❌ FAIL with the quote showing what's missing/wrong
+4. Note any edge cases the criterion implies that are not handled
 
-After checking all criteria, review test/lint/build output for additional problems.
+A verdict line you cannot back with a quote from the material above is not evidence — omit it or mark it explicitly as an assumption. After checking all criteria, review test/lint/build output for additional problems.
 
 ## Verdict Rules
 - **PASS** — ALL acceptance criteria pass AND no blocking issues in test/lint/build output
@@ -293,6 +309,20 @@ Review the changed files across these 10 dimensions. Produce zero or more findin
 | 8 | **Design adherence** | Implementation diverges from design.md without justification (skip if design_content is empty) |
 | 9 | **Scope creep** | Files changed outside declared files: lists in tasks.md (skip if no files: present) |
 | 10 | **Dead code** | Added functions/vars/imports never referenced |
+
+Every finding must quote the exact line(s) it flags. A finding you cannot anchor to quoted code is not a finding — drop it.
+
+<examples>
+<example type="good finding">
+### [BLOCK] src/auth/session.ts:42 — Correctness
+**Problem:** Token expiry uses `<` so a token expiring exactly now passes: `if (token.exp < Date.now())`.
+**Fix:** Use `<=`: `if (token.exp <= Date.now())`.
+</example>
+<example type="bad finding — do NOT produce">
+### [WARN] src/auth — Correctness
+**Problem:** The session handling looks like it might have timing issues somewhere.
+</example>
+</examples>
 
 ## Severity Rules
 - `🔴 BLOCK` — security vulnerabilities, correctness bugs, design breaches

--- a/plugins/specclaw/skills/build/SKILL.md
+++ b/plugins/specclaw/skills/build/SKILL.md
@@ -66,7 +66,7 @@ specclaw-update-task-status .specclaw/changes/<change>/tasks.md <TASK_ID> failed
    ```bash
    specclaw-build-context .specclaw <change> <TASK_ID>
    ```
-3. Spawn a coding agent with that payload as the task. Use the model from config. Run independent tasks in parallel up to `parallel_tasks`.
+3. Spawn a coding agent with that payload as the task. Use the model from config. Run independent tasks in parallel up to `parallel_tasks`. Calibrate delegation: spawn agents for tasks that are parallel, isolated, or independent workstreams; for a trivial sequential edit where spawning costs more than doing, apply the change directly and record it against the task as usual.
 
 **d.** Wait for all agents in the wave to complete.
 

--- a/plugins/specclaw/skills/loop/SKILL.md
+++ b/plugins/specclaw/skills/loop/SKILL.md
@@ -91,7 +91,7 @@ Paste the controller's stdout (the `🛑 LOOP HALTED` block) as the **escalation
      --failure-record .specclaw/changes/<change>/.loop-failure.txt \
      --reflection .specclaw/changes/<change>/.loop-reflection.md
    ```
-3. Spawn a fix agent with that payload as the task. Use the model from config `models.coding`. Instruct it to make the **SMALLEST diff** that turns the red gate(s) green, touch no unrelated code, and **never modify test files to force a pass**.
+3. Spawn a fix agent with that payload as the task. Use the model from config `models.coding`. Instruct it to make the **SMALLEST diff** that turns the red gate(s) green, touch no unrelated code, and **never modify test files to force a pass**. Additionally instruct it on reversibility: prefer local, reversible actions (editing files, running tests); do **not** take hard-to-reverse or externally visible actions to get a gate green — no deleting files or branches, no `git push --force`, no `git reset --hard`, no bypassing safety checks (e.g. `--no-verify`), no discarding unfamiliar files that may be in-progress work. If a gate seems to require such an action, halt and report instead — that is an escalation, not a fix.
 
 **f. Reward-hack guard — run AFTER the fix agent, BEFORE committing:**
 


### PR DESCRIPTION
## Summary

Hardens every SpecClaw agent payload against the accuracy failure modes named in Anthropic's and OpenAI's published prompt-engineering guides. Text-only change — no control flow touched; full planning trail in `.specclaw/changes/prompt-hardening/`.

## What changed

- **Quote-first verdicts** — verify payload + code-reviewer now require extracting the exact AC/code/test-output quotes a judgment rests on before judging; unquotable findings are dropped ("ask Claude to quote relevant parts of the documents first" — Anthropic).
- **Working Rules block in build/fix payloads** — investigate before answering (never speculate about unopened code); general-purpose solutions only (tests verify correctness, they don't define it; report bad tests instead of working around them — complements the loop's mechanical reward-hack guard with a prompt-level deterrent); temp-file cleanup.
- **Task-last payload ordering** — longform spec/design/code first, task + constraints at the end ("queries at the end can improve response quality by up to 30%" — Anthropic); guardrails stay first for prompt-cache locality.
- **Motivated constraints** — scope limit now explains parallel-task ownership + design_gap auto-logging; test rule explains the verify gate consuming the evidence.
- **Few-shot `<example>` pairs** in agent-prompts.md — good/bad reviewer finding, strong/weak acceptance criterion.
- **Reversibility rules for loop fix agents** — no force-push, `reset --hard`, `--no-verify`, or destructive shortcuts to green a gate; halt and escalate instead.
- **Research discipline for spec-author** — competing hypotheses, confidence tracking, self-critique before the final write.
- Karpathy guardrails reference stays **verbatim** (diff-empty on that file).

## Verification

11/11 ACs PASS (`.specclaw/changes/prompt-hardening/verify-report.md`, written quote-first — dogfooding the rule it ships). Suite 13/13, `bash -n` clean, live-payload greps confirm every block and the section order.

## Notes

- Version 0.5.2 (distinct from the open 0.5.1 PRs #32/#33; happy to rebase-bump per merge order).
- Textually adjacent to #32 in the same payload builders — whichever merges second takes a trivial rebase.
- `.specclaw/config.yaml` github.sync set false (Issues disabled on this repo; see #32 notes / learning L6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
