### PR TITLE
[specclaw] verify-glob-oom-fix: Fix infinite-loop OOM in specclaw-ver...

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-17 16:50 UTC
+**Last Updated:** 2026-07-18 10:59 UTC
 
 ## Active Changes
 
@@ -29,6 +29,7 @@
 - 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **update-check** — 4/4 tasks (100%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
+- 🔨 **verify-glob-oom-fix** — 0/4 tasks (0%) | 0 failed
 
 ## Pending Proposals
 
@@ -40,6 +41,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 23
-- **Active:** 23
+- **Total changes:** 24
+- **Active:** 24
 - **Completed:** 0

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-18 10:59 UTC
+**Last Updated:** 2026-07-18 11:27 UTC
 
 ## Active Changes
 
@@ -29,7 +29,7 @@
 - 🔨 **spec-author-agent** — 4/5 tasks (80%) | 0 failed
 - ✅ **update-check** — 4/4 tasks (100%) | 0 failed
 - ✅ **verification-engine** — 4/4 tasks (100%) | 0 failed
-- 🔨 **verify-glob-oom-fix** — 0/4 tasks (0%) | 0 failed
+- 🔨 **verify-glob-oom-fix** — 3/4 tasks (75%) | 0 failed
 
 ## Pending Proposals
 

--- a/.specclaw/changes/verify-glob-oom-fix/design.md
+++ b/.specclaw/changes/verify-glob-oom-fix/design.md
@@ -1,0 +1,57 @@
+# Design: Fix infinite-loop OOM in specclaw-verify path extraction
+
+**Change:** verify-glob-oom-fix
+**Created:** 2026-07-18
+
+## Technical Approach
+
+Replace the glob-unsafe strip in the backtick-extraction loop of `collect_change_data` in `plugins/specclaw/bin/specclaw-verify`. The current line:
+
+```bash
+paths_str="${paths_str#*\`${BASH_REMATCH[1]}\`}"
+```
+
+interpolates the captured path into the removal pattern, so `[`, `]`, `?`, `*` in the path are glob-interpreted and the strip silently no-ops. Replace with two content-agnostic strips that always advance past the just-matched token:
+
+```bash
+paths_str="${paths_str#*\`}"   # remove up to & including the opening backtick
+paths_str="${paths_str#*\`}"   # remove the path text and its closing backtick
+```
+
+Because neither strip references the captured content, no path value can defeat it — the loop is guaranteed to shorten `paths_str` by at least the `\`...\`` token each iteration and terminate.
+
+Audit the sibling comma-separated fallback branch (same function): it uses `IFS=','` splitting and `sed` trims, no `${var#glob}` on captured content — expected clean, confirm and leave as-is (FR3).
+
+Lock behavior with a regression case appended to the existing plain-bash suite `plugins/specclaw/tests/run-parser-tests.sh`, following its `make_change` + `VERIFY collect` + `jq` + `assert_eq` conventions, guarded by a `timeout` so a regression manifests as a fail, not a hung CI.
+
+## Architecture
+
+Single-function, single-file behavioral fix inside an existing bash parser. No structural change. Test suite gains one case block. No changes to `/specclaw:verify` skill logic, acceptance-criteria parsing, or output schema.
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/bin/specclaw-verify` | modify | Replace glob-unsafe strip with two content-agnostic backtick strips in the backtick loop (~L118–122). Confirm fallback branch clean. |
+| `plugins/specclaw/tests/run-parser-tests.sh` | modify | Add regression case: `**Files:**` with `app/[id]/page.tsx` (+ a multi-token `[...slug]` variant) → `verify collect` terminates under `timeout` and extracts literal paths. |
+| `plugins/specclaw/.claude-plugin/plugin.json` | modify | Patch version bump. |
+| `.claude-plugin/marketplace.json` | modify | Patch version bump (keep in sync). |
+
+## Data Model Changes
+
+None.
+
+## API Changes
+
+None. `specclaw-verify collect` output schema (`.changed_files[].path`, `.acceptance_criteria`) unchanged.
+
+## Key Decisions
+
+- **Two-strip over quoting the token** (`${paths_str#*\`"${BASH_REMATCH[1]}"\`}`): both fix the bug, but two content-agnostic strips don't depend on the captured value at all and read more obviously correct. Chosen.
+- **Guard the test with `timeout`**: without it a reintroduced infinite loop hangs the whole suite instead of failing the case. Use a small bound (e.g. `timeout 10`).
+- **Defer broad audit**: only fix the verify script now; note any sibling occurrences to learnings/patterns for a possible follow-up, per approved scope.
+
+## Risks & Mitigations
+
+- **Risk:** two strips behave differently from one on adjacent/empty tokens (e.g. two backticks with nothing between). **Mitigation:** the regex `\`([^\`]+)\`` requires ≥1 non-backtick char between backticks, so a matched token always has both delimiters present; two strips are exact. Covered by AC-2/AC-4.
+- **Risk:** regression to existing extraction. **Mitigation:** NFR2 / AC-3 — full suite must still pass; AC-4 asserts byte-identical output for plain paths.

--- a/.specclaw/changes/verify-glob-oom-fix/loop-log.md
+++ b/.specclaw/changes/verify-glob-oom-fix/loop-log.md
@@ -1,0 +1,3 @@
+# Loop Log: verify-glob-oom-fix
+
+_Created: 2026-07-18T11:27:20Z_

--- a/.specclaw/changes/verify-glob-oom-fix/loop-state.json
+++ b/.specclaw/changes/verify-glob-oom-fix/loop-state.json
@@ -1,0 +1,1 @@
+{"turn": 0, "passing_count": 0, "sig_history": [], "ci_turn": 0}

--- a/.specclaw/changes/verify-glob-oom-fix/proposal.md
+++ b/.specclaw/changes/verify-glob-oom-fix/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: Fix infinite-loop OOM in specclaw-verify path extraction
+
+**Created:** 2026-07-18
+**Status:** 🟡 Draft
+
+## Problem
+
+`specclaw-verify` extracts file paths from each `**Files:**` field in `tasks.md` with a loop that strips each matched backtick-quoted token off the front of the line (`plugins/specclaw/bin/specclaw-verify`, ~L118–122):
+
+```bash
+while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
+  file_paths+=("${BASH_REMATCH[1]}")
+  paths_str="${paths_str#*\`${BASH_REMATCH[1]}\`}"
+done
+```
+
+The strip `${paths_str#*\`${BASH_REMATCH[1]}\`}` interpolates the captured path **unquoted** into a `${var#pattern}` prefix-removal pattern, so the path is **glob-interpreted**, not matched literally. When a path contains glob metacharacters, the pattern fails to match and the strip is a no-op:
+
+- Next.js dynamic-route files — `app/[id]/page.tsx`, `app/[...slug]/route.ts` — `[id]` is a bracket character class matching a single char, not the literal 4-char text.
+- Any path with `?` or `*`.
+
+When the strip does nothing, `paths_str` never shrinks, the `=~` test keeps matching the **same** first backtick pair, and the loop appends the same path forever — unbounded array growth until the process is **OOM-killed**.
+
+Why it matters: any specclaw change whose `tasks.md` lists a bracketed/globby path (routine in Next.js, SvelteKit, Remix, and other file-based routers) hangs `/specclaw:verify` and takes down the host with an OOM. It is silent — no error, just a runaway process — and blocks the entire lifecycle at the verify gate.
+
+## Proposed Solution
+
+Make the strip glob-safe so the loop always advances regardless of path content. Strip up to and including the two backticks independent of the captured text:
+
+```bash
+while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
+  file_paths+=("${BASH_REMATCH[1]}")
+  paths_str="${paths_str#*\`}"   # drop up to & incl the opening backtick
+  paths_str="${paths_str#*\`}"   # drop the path and its closing backtick
+done
+```
+
+This never depends on the captured content, so glob metacharacters can't defeat it. (Alternative: quote the token — `${paths_str#*\`"${BASH_REMATCH[1]}"\`}` — but the two-strip form is simpler and content-agnostic.)
+
+Add a regression test: a `tasks.md` with a `**Files:**` field referencing `app/[id]/page.tsx` must make `specclaw-verify` path extraction terminate and return the literal path.
+
+## Scope
+
+### In Scope
+- Fix the glob-unsafe strip in the backtick-extraction loop in `specclaw-verify`.
+- Audit the sibling comma-separated fallback path in the same function for the same class of bug.
+- Regression test covering a bracketed/dynamic-route path.
+- Version bump per project rule.
+
+### Out of Scope
+- Rewriting path parsing / `tasks.md` format.
+- Auditing every `${var#...}` / `${var%...}` across all `specclaw-*` scripts (candidate for a follow-up hardening pass — flag to pattern registry).
+- Any change to `/specclaw:verify` acceptance-criteria logic beyond path extraction.
+
+## Impact
+
+- **Files affected:** 1 code + 1 test (estimated)
+- **Complexity:** small
+- **Risk:** low (localized; behavior-preserving for non-glob paths, fixes hang for glob paths)
+
+## Open Questions
+
+- Should the broader `${var#unquoted}` audit be a separate proposal, or folded in here as a bounded sweep of the verify script only? (Leaning separate — keeps this fix minimal.)
+- Any other lifecycle script that parses backtick-quoted paths from markdown the same way (e.g. `specclaw-build-context`, `specclaw-gh-sync` checklist builders)? Worth a quick grep before closing.
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/verify-glob-oom-fix/spec.md
+++ b/.specclaw/changes/verify-glob-oom-fix/spec.md
@@ -1,0 +1,56 @@
+# Spec: Fix infinite-loop OOM in specclaw-verify path extraction
+
+**Change:** verify-glob-oom-fix
+**Created:** 2026-07-18
+**Status:** 🟡 Draft
+
+## Overview
+
+`specclaw-verify collect` parses `**Files:**` fields in `tasks.md` by repeatedly matching a backtick-quoted token and stripping it off the front of the line. The strip pattern interpolates the captured path unquoted into a `${var#pattern}` prefix removal, so the path is glob-interpreted. A path containing glob metacharacters (`[`, `]`, `?`, `*`) — e.g. a Next.js dynamic route `app/[id]/page.tsx` — makes the strip a no-op; the line never shrinks, the regex re-matches the same token, and the loop grows an array without bound until the process is OOM-killed.
+
+Fix the strip so it always advances regardless of path content, and lock the behavior with a regression test.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR1** — The backtick path-extraction loop in `specclaw-verify` (`collect_change_data`, ~L118–122) MUST terminate for any `**Files:**` line, including paths containing glob metacharacters `[ ] ? *`.
+- **FR2** — Extracted paths MUST be the literal text between backticks (e.g. `app/[id]/page.tsx` extracted verbatim), unchanged from current behavior for non-glob paths.
+- **FR3** — The comma-separated fallback branch (no-backticks case) in the same function MUST be confirmed free of the same glob-strip defect; fix if present.
+
+### Non-Functional Requirements
+
+- **NFR1** — No new runtime dependencies; plain bash, consistent with existing `specclaw-*` scripts.
+- **NFR2** — Existing parser regression suite (`plugins/specclaw/tests/run-parser-tests.sh`) MUST still pass (no regression to B3/B4/NFR2 cases).
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- **AC-1** — Given a `tasks.md` with `**Files:** \`app/[id]/page.tsx\``, `specclaw-verify collect` completes within a short timeout (does not hang) and `.changed_files[].path` includes the literal `app/[id]/page.tsx`.
+- **AC-2** — Given a `**Files:**` line with multiple backtick paths where one contains `[...slug]`, all paths are extracted exactly once, in order, and the loop terminates.
+- **AC-3** — `bash plugins/specclaw/tests/run-parser-tests.sh` exits 0 with the new case(s) reported as PASS and no prior case regressed.
+- **AC-4** — For a plain non-glob path (`src/index.ts`), extraction output is byte-identical to pre-fix behavior.
+
+## Edge Cases
+
+- Path with a literal `?` or `*` (glob wildcards) — must extract verbatim, no hang.
+- Multiple backtick tokens on one line, mixed glob and non-glob.
+- `**Files:**` line with no backticks (comma-separated fallback) — unaffected.
+- Empty `**Files:**` field — no paths, loop does not enter.
+
+## Dependencies
+
+None. Self-contained fix in one script plus its test suite.
+
+## Notes
+
+Recommended fix (content-agnostic, glob-safe):
+```bash
+while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
+  file_paths+=("${BASH_REMATCH[1]}")
+  paths_str="${paths_str#*\`}"   # drop up to & incl opening backtick
+  paths_str="${paths_str#*\`}"   # drop path + closing backtick
+done
+```
+Broader `${var#unquoted}` audit across all lifecycle scripts is deferred to a follow-up (out of scope), but grep `specclaw-build-context` / `specclaw-gh-sync` checklist builders during build for the same pattern and note findings in learnings.md.

--- a/.specclaw/changes/verify-glob-oom-fix/status.md
+++ b/.specclaw/changes/verify-glob-oom-fix/status.md
@@ -13,7 +13,7 @@
 | Design | ⚪ Pending | |
 | Tasks | ⚪ Pending | |
 | Build | ⚪ Pending | |
-| Verify | ⚪ Pending | |
+| Verify | ✅ Passed |  |
 
 ## Task Progress
 

--- a/.specclaw/changes/verify-glob-oom-fix/status.md
+++ b/.specclaw/changes/verify-glob-oom-fix/status.md
@@ -1,0 +1,28 @@
+# Status: Fix infinite-loop OOM in specclaw-verify path extraction
+
+**Change:** verify-glob-oom-fix
+**Started:** 2026-07-18
+**Last Updated:** 2026-07-18
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | 🟡 Draft | Awaiting approval |
+| Spec | ⚪ Pending | |
+| Design | ⚪ Pending | |
+| Tasks | ⚪ Pending | |
+| Build | ⚪ Pending | |
+| Verify | ⚪ Pending | |
+
+## Task Progress
+
+**Completed:** 0 / 0
+**Failed:** 0
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+
+## Issues

--- a/.specclaw/changes/verify-glob-oom-fix/tasks.md
+++ b/.specclaw/changes/verify-glob-oom-fix/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Fix infinite-loop OOM in specclaw-verify path extraction
+
+**Change:** verify-glob-oom-fix
+**Created:** 2026-07-18
+**Total Tasks:** 3
+
+## Summary
+
+Fix the glob-unsafe backtick strip in `specclaw-verify` so path extraction terminates for dynamic-route paths, add a `timeout`-guarded regression test, and bump the plugin version. Small, low-risk.
+
+## Tasks
+
+### Wave 1 — Fix + test
+
+- [x] `T1` — Make the backtick path-strip glob-safe in `specclaw-verify`
+  - Files: `plugins/specclaw/bin/specclaw-verify`
+  - Estimate: small
+  - Depends:
+  - Notes: In `collect_change_data` (~L118–122) replace `paths_str="${paths_str#*\`${BASH_REMATCH[1]}\`}"` with two content-agnostic strips: `paths_str="${paths_str#*\`}"` then `paths_str="${paths_str#*\`}"`. Confirm the comma-separated fallback branch has no `${var#glob}` on captured content (FR3) — leave as-is if clean; note either way.
+
+- [x] `T2` — Add regression test for glob/dynamic-route paths
+  - Files: `plugins/specclaw/tests/run-parser-tests.sh`
+  - Estimate: small
+  - Depends: T1
+  - Notes: New case using `make_change` conventions. tasks.md `**Files:**` with `\`app/[id]/page.tsx\`` and a multi-token line containing `\`app/[...slug]/route.ts\``. Run `timeout 10 "$VERIFY" collect ...`, assert exit 0 (no hang) and `.changed_files[].path` contains the literal paths (AC-1, AC-2). Verify full suite still exits 0 (AC-3) and plain-path output unchanged (AC-4).
+
+### Wave 2 — Release
+
+- [x] `T3` — Bump plugin version (patch)
+  - Files: `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  - Estimate: small
+  - Depends: T1, T2
+  - Notes: Increment patch `X.Y.Z → X.Y.Z+1` in both files, kept in sync. Separate `chore: bump version` commit per project rule.
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed
+
+**Task format:**
+```
+- [ ] `T<n>` — <title>
+  - Files: <files to create/modify>
+  - Estimate: small | medium | large
+  - Depends: <task ids> (if any)
+  - Notes: <additional context>
+```

--- a/.specclaw/changes/verify-glob-oom-fix/verify-report.md
+++ b/.specclaw/changes/verify-glob-oom-fix/verify-report.md
@@ -1,0 +1,30 @@
+# Verify Report: verify-glob-oom-fix
+
+**Verdict:** PASS
+**Date:** 2026-07-18
+
+## Acceptance Criteria
+
+| AC | Result | Evidence |
+|----|--------|----------|
+| AC-1 — glob path `app/[id]/page.tsx` extracted, no hang | ✅ PASS | `specclaw-verify collect` on a change with `**Files:** \`app/[id]/page.tsx\`` returns rc=0 under `timeout` and `.changed_files[].path` includes the literal path. Regression Case 9 asserts termination. |
+| AC-2 — multi-token line incl. `[...slug]`, all extracted once, terminates | ✅ PASS | Case 9 tasks.md line `\`app/[...slug]/route.ts\`, \`src/plain.ts\`` → 3 paths extracted verbatim, count == 3, loop terminates. |
+| AC-3 — `run-parser-tests.sh` exits 0, new case PASS, no regression | ✅ PASS | Full suite: **41 passed, 0 failed** (with `jq` sideloaded — not installed on host). Case 9 (jq-free) all PASS. |
+| AC-4 — plain non-glob path byte-identical to pre-fix | ✅ PASS | Two content-agnostic strips only differ from the old strip when the path contained glob metachars; for plain paths both remove the exact `\`...\`` token. Case 4 (`src/a.ts`..`src/d.ts`) unchanged; Case 9 `src/plain.ts` extracted verbatim. |
+
+## Requirements
+
+- **FR1** (loop terminates for any Files line incl. `[ ] ? *`) — met via two content-agnostic backtick strips.
+- **FR2** (paths extracted literal) — met; verified verbatim extraction of bracketed paths.
+- **FR3** (comma-separated fallback free of same defect) — confirmed: fallback uses `IFS=','` split + `sed` trim, no `${var#glob}` on captured content. Left as-is.
+- **NFR1** (no new deps, plain bash) — met.
+- **NFR2** (existing suite still passes) — met; 41/0.
+
+## Commands
+
+- `test_command`: empty in config → no automated command run. Regression suite executed manually: `bash plugins/specclaw/tests/run-parser-tests.sh` → 41 passed, 0 failed.
+
+## Notes
+
+- Host lacks `jq`; the pre-existing suite's Cases 1/3/4/5 depend on it. New Case 9 was written jq-free so the OOM regression is covered regardless of `jq` availability. Recommend adding `jq` to the CI/runner (out of scope here).
+- Fix commit: `f4f7f56`. Test commit: `22624c7`. Version bump 0.5.5→0.5.6: `ff2ffdb`.

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -118,7 +118,11 @@ cmd_collect() {
     # Extract backtick-delimited paths
     while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
       file_paths+=("${BASH_REMATCH[1]}")
-      paths_str="${paths_str#*\`${BASH_REMATCH[1]}\`}"
+      # Advance past the matched `path` token with content-agnostic strips.
+      # Interpolating ${BASH_REMATCH[1]} into the pattern would glob-interpret
+      # the path (e.g. `app/[id]/page.tsx`), no-op the strip, and infinite-loop.
+      paths_str="${paths_str#*\`}"   # drop up to & incl the opening backtick
+      paths_str="${paths_str#*\`}"   # drop the path text and its closing backtick
     done
     # If no backticks, try comma-separated plain text
     if [ ${#file_paths[@]} -eq 0 ] 2>/dev/null; then

--- a/plugins/specclaw/tests/run-parser-tests.sh
+++ b/plugins/specclaw/tests/run-parser-tests.sh
@@ -406,6 +406,47 @@ fi
 echo
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Case 9 — verify-glob-oom-fix: `Files:` paths with glob metacharacters (e.g.
+# Next.js dynamic routes `app/[id]/page.tsx`) must extract verbatim and NOT
+# hang. Pre-fix the strip glob-interpreted the captured path, no-op'd, and
+# infinite-looped until OOM. Guard with `timeout` so a regression fails fast.
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--- Case 9: verify collect handles glob/dynamic-route paths (no hang) ---"
+gdir="$WORK/changes/glob-path"
+mkdir -p "$gdir"
+printf '# spec\n## Acceptance Criteria\n- [ ] AC-1: works\n' > "$gdir/spec.md"
+{
+  printf '# tasks\n'
+  printf -- '- [ ] `T1` — dynamic route\n'
+  printf -- '  - Files: `app/[id]/page.tsx`\n'
+  printf -- '- [ ] `T2` — catch-all + plain\n'
+  printf -- '  - Files: `app/[...slug]/route.ts`, `src/plain.ts`\n'
+} > "$gdir/tasks.md"
+
+# The critical assertion: collect terminates. `timeout` kills a runaway loop
+# (exit 124) so the hang manifests as a fail, not a stalled suite.
+gout="$(timeout 10 "$VERIFY" collect "$WORK" glob-path 2>/dev/null)"; grc=$?
+if [[ "$grc" -eq 0 ]]; then
+  pass "AC-1/AC-2 verify collect terminates on glob paths (no hang)"
+else
+  fail "AC-1/AC-2 verify collect terminates on glob paths (rc=$grc — 124=timeout/hang)"
+fi
+
+# jq-free asserts (jq is not guaranteed on every runner): count and match the
+# "path": entries directly in the JSON so a glob path that got dropped or
+# duplicated is caught regardless of jq availability.
+gcount="$(printf '%s' "$gout" | grep -c '"path":')"
+assert_eq "glob paths extracted count" "3" "${gcount:-0}"
+for needle in 'app/[id]/page.tsx' 'app/[...slug]/route.ts' 'src/plain.ts'; do
+  if grep -qF "\"path\": \"$needle\"" <<<"$gout"; then
+    pass "glob path extracted verbatim: $needle"
+  else
+    fail "glob path extracted verbatim: $needle"
+  fi
+done
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────────────────────────────────────
 echo "=================================================="


### PR DESCRIPTION
## Summary

`specclaw-verify` extracts file paths from each `**Files:**` field in `tasks.md` with a loop that strips each matched backtick-quoted token off the front of the line (`plugins/specclaw/bin/specclaw-verify`, ~L118–122):

```bash
while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
  file_paths+=("${BASH_REMATCH[1]}")
  paths_str="${paths_str#*\`${BASH_REMATCH[1]}\`}"
done
```
Make the strip glob-safe so the loop always advances regardless of path content. Strip up to and including the two backticks independent of the captured text:

```bash
while [[ "$paths_str" =~ \`([^\`]+)\` ]]; do
  file_paths+=("${BASH_REMATCH[1]}")
  paths_str="${paths_str#*\`}"   # drop up to & incl the opening backtick
  paths_str="${paths_str#*\`}"   # drop the path and its closing backtick
done
```
## Acceptance Criteria

Each criterion must pass for the change to be considered complete.

- **AC-1** — Given a `tasks.md` with `**Files:** \`app/[id]/page.tsx\``, `specclaw-verify collect` completes within a short timeout (does not hang) and `.changed_files[].path` includes the literal `app/[id]/page.tsx`.
- **AC-2** — Given a `**Files:**` line with multiple backtick paths where one contains `[...slug]`, all paths are extracted exactly once, in order, and the loop terminates.
- **AC-3** — `bash plugins/specclaw/tests/run-parser-tests.sh` exits 0 with the new case(s) reported as PASS and no prior case regressed.
- **AC-4** — For a plain non-glob path (`src/index.ts`), extraction output is byte-identical to pre-fix behavior.
## Verification
**Verdict:** PASS

# Verify Report: verify-glob-oom-fix

**Verdict:** PASS
**Date:** 2026-07-18

## Acceptance Criteria

| AC | Result | Evidence |
|----|--------|----------|
| AC-1 — glob path `app/[id]/page.tsx` extracted, no hang | ✅ PASS | `specclaw-verify collect` on a change with `**Files:** \`app/[id]/page.tsx\`` returns rc=0 under `timeout` and `.changed_files[].path` includes the literal path. Regression Case 9 asserts termination. |
| AC-2 — multi-token line incl. `[...slug]`, all extracted once, terminates | ✅ PASS | Case 9 tasks.md line `\`app/[...slug]/route.ts\`, \`src/plain.ts\`` → 3 paths extracted verbatim, count == 3, loop terminates. |
| AC-3 — `run-parser-tests.sh` exits 0, new case PASS, no regression | ✅ PASS | Full suite: **41 passed, 0 failed** (with `jq` sideloaded — not installed on host). Case 9 (jq-free) all PASS. |
| AC-4 — plain non-glob path byte-identical to pre-fix | ✅ PASS | Two content-agnostic strips only differ from the old strip when the path contained glob metachars; for plain paths both remove the exact `\`...\`` token. Case 4 (`src/a.ts`..`src/d.ts`) unchanged; Case 9 `src/plain.ts` extracted verbatim. |

## Requirements

- **FR1** (loop terminates for any Files line incl. `[ ] ? *`) — met via two content-agnostic backtick strips.
- **FR2** (paths extracted literal) — met; verified verbatim extraction of bracketed paths.
- **FR3** (comma-separated fallback free of same defect) — confirmed: fallback uses `IFS=','` split + `sed` trim, no `${var#glob}` on captured content. Left as-is.
- **NFR1** (no new deps, plain bash) — met.

---


🤖 Generated by SpecClaw