### PR TITLE
specclaw: long-running test orchestration — detached execution, slow-test tier, bounded Playwright, PR-aware status (v0.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.5.10",
+      "version": "0.6.0",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: bash plugins/specclaw/tests/run-parser-tests.sh
       - name: Run memory-aware-parallelism tests
         run: bash plugins/specclaw/tests/run-memory-parallelism-tests.sh
+      - name: Run long-running-orchestration tests
+        run: bash plugins/specclaw/tests/run-long-orchestration-tests.sh
 
   shellcheck:
     name: ShellCheck bin scripts

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,12 +1,13 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-24 01:10 UTC
+**Last Updated:** 2026-07-25 01:51 UTC
 
 ## Active Changes
 
 
-- 🔨 **memory-aware-parallelism** — 0/6 tasks (0%) | 0 failed
+- 🔨 **long-running-test-orchestration** — 0/12 tasks (0%) | 0 failed
+- 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed
 
 ## Pending Proposals
 
@@ -43,6 +44,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 26
-- **Active:** 1
+- **Total changes:** 27
+- **Active:** 2
 - **Completed:** 25

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,12 +1,12 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-25 08:13 UTC
+**Last Updated:** 2026-07-25 09:10 UTC
 
 ## Active Changes
 
 
-- ✅ **long-running-test-orchestration** — 12/12 tasks (100%) | 0 failed
+- ✅ **long-running-test-orchestration** — 12/12 tasks (100%) | 0 failed | PR #48 open
 - 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed | PR #46 merged
 
 ## Pending Proposals

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,13 +1,13 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-25 01:51 UTC
+**Last Updated:** 2026-07-25 08:13 UTC
 
 ## Active Changes
 
 
-- 🔨 **long-running-test-orchestration** — 0/12 tasks (0%) | 0 failed
-- 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed
+- ✅ **long-running-test-orchestration** — 12/12 tasks (100%) | 0 failed
+- 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed | PR #46 merged
 
 ## Pending Proposals
 

--- a/.specclaw/changes/archive/2026-07-22-verify-glob-oom-fix/status.md
+++ b/.specclaw/changes/archive/2026-07-22-verify-glob-oom-fix/status.md
@@ -1,28 +1,56 @@
 # Status: Fix infinite-loop OOM in specclaw-verify path extraction
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 **Change:** verify-glob-oom-fix
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 **Started:** 2026-07-18
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 **Last Updated:** 2026-07-18
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 ## Progress
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Phase | Status | Notes |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 |-------|--------|-------|
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Proposal | 🟡 Draft | Awaiting approval |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Spec | ⚪ Pending | |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Design | ⚪ Pending | |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Tasks | ⚪ Pending | |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Build | ⚪ Pending | |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Verify | ✅ Passed |  |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 ## Task Progress
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 **Completed:** 0 / 0
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 **Failed:** 0
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 ## Agent Runs
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 | Task | Agent | Model | Status | Duration |
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 |------|-------|-------|--------|----------|
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |
 ## Issues
+| PR     | ✅ Raised | https://github.com/chan4lk/specclaw/pull/42 |

--- a/.specclaw/changes/long-running-test-orchestration/design.md
+++ b/.specclaw/changes/long-running-test-orchestration/design.md
@@ -1,0 +1,194 @@
+# Design: Long-running test orchestration
+
+**Change:** long-running-test-orchestration
+**Created:** 2026-07-24
+
+## Technical Approach
+
+Four independent seams, one per root cause, each shaped so the new behaviour is additive and the absent-config path is the current code path.
+
+### 1. `bin/specclaw-run-long` — detached execution with heartbeat
+
+A standalone bin script (not a sourced library) so it is independently testable and callable from both `specclaw-verify` and `specclaw-build` without either sourcing the other.
+
+```
+specclaw-run-long [--log-dir DIR] [--phase NAME] [--heartbeat N] [--reuse] -- <command string>
+```
+
+Mechanics:
+
+1. Resolve log path `<log-dir>/<phase>-<slug>-<pid>.log` (slug = command sanitized to `[a-z0-9-]`, truncated; PID discriminator per edge case 5).
+2. If `--reuse` and a sidecar exists whose `head` matches current HEAD **and** whose `dirty` is `false` and current tree is clean → print the stored tail, echo the stored exit code, return it. No execution.
+3. Otherwise: `eval "$cmd" >"$log" 2>&1 &` — keeping `eval` preserves today's metacharacter semantics (edge case 2). Record child PID.
+4. Poll loop: `wait -n`-style non-blocking check via `kill -0 "$child"`, sleeping in short ticks and emitting a heartbeat to **stderr** every `heartbeat` seconds. Heartbeat goes to stderr so stdout stays a clean captured payload for callers.
+5. `wait "$child"` to harvest the true exit code.
+6. Write the sidecar (always, pass or fail), then print the 100-line tail to stdout plus a log-path line.
+7. `trap` on INT/TERM: kill the child process **group**, write an interrupted sidecar, exit non-zero (NFR7).
+
+Sidecar is a flat `key=value` file (no `jq` — NFR3):
+
+```
+exit=3
+duration_s=412
+log=/abs/path.log
+head=1a2b3c…
+dirty=false
+cmd=npx playwright test
+interrupted=false
+```
+
+Heartbeat format, one line, terse enough not to bloat the transcript (NFR4):
+
+```
+[run-long] 120s elapsed | 84 log lines | last: Running 140 tests using 1 worker
+```
+
+**Why stderr for heartbeats:** `run_capped()` callers in `specclaw-verify` assign stdout to a variable that lands in the verify JSON payload. Heartbeats are for the *agent's* liveness, not the report. Splitting the streams keeps FR3's captured output identical to today (AC6).
+
+### 2. Slow-test tier
+
+`specclaw-verify cmd_collect` currently reads three commands and runs each through `run_capped` (`bin/specclaw-verify:185-214`). Extend to read `build.e2e_command` and `verify.e2e`, then order execution:
+
+```
+lint → build → test        (fast gates, unchanged order)
+  └─ policy=last:   run e2e only if all three passed
+     policy=always: run e2e regardless
+     policy=skip:   never run e2e
+```
+
+The payload gains `e2e_output` plus an `e2e_state` of `passed | failed | skipped_policy | skipped_gate_failure | not_configured`. A single enumerated state field is what makes FR9 structurally true — there is no "empty output" ambiguity for a reader to misinterpret as success. Unrecognised policy values warn and fall back to `last` (edge case 9).
+
+`skills/verify/SKILL.md` gains the policy semantics so the verify agent reports a skip as a skip.
+
+### 3. Bounded Playwright invocation
+
+New `wrap` subcommand on the existing `specclaw-browser-lock`. It **prints** a transformed command string; it does not execute (NFR6 — testable with no browser, no systemd).
+
+Transformation, in order:
+
+1. Playwright detection: command matches `playwright` → if no `--workers` present, append `--workers=1`. Already-present value is preserved (AC10). Non-Playwright commands skip this step entirely (edge case 13).
+2. Project fan-out: for each entry in `verify.playwright.projects`, emit `<cmd> --project=<quoted>`; join with `&&` so they run sequentially in one shell. Empty list → single unmodified invocation (AC12).
+3. Memory cap: if `systemd_run_usable` → prefix each invocation with `systemd-run --user --scope -q -p MemoryMax=<max_memory_mb>M`. Usability is *probed*, not assumed from `command -v` (edge case 11): run a trivial `systemd-run --user --scope -q true` once and cache the result for the process. Unusable → emit unwrapped + warn (AC11).
+
+Composition with the rest: `verify` acquires a slot (existing `acquire`), pipes `e2e_command` through `wrap`, hands the result to `specclaw-run-long`, releases the slot. Each script keeps one job: `browser-lock` decides *how the command should be constrained*, `run-long` decides *how it is executed and observed*.
+
+Exit-137 classification (FR13) lives at the reporting boundary in `specclaw-verify`, which knows both the exit code and whether a cap was applied. `wrap` therefore also reports whether it capped — via exit-code convention (`0` = capped, `10` = emitted uncapped) so no second parse of the emitted string is needed.
+
+### 4. PR-aware status
+
+`bin/specclaw-update-status` gains a `pr_state_for <change>` function returning a short rendered string (`PR #123 open`) or empty.
+
+- Resolution order: GitHub via `gh pr list --head <branch> --json number,state,updatedAt` when `gh` is available; else Azure DevOps via the existing auth path; else empty.
+- Branch name derives the same way `specclaw-build` does: `<git.branch_prefix><change_name>`, so the lookup matches what specclaw actually pushes.
+- Every invocation is wrapped in `timeout 5` and `|| true` (NFR5, and learning `[L2]`: no-match `grep | head | sed` under `set -e` in command substitution aborts the script).
+- Multiple PRs → sort by `updatedAt`, take the newest, render its real state (edge case 15).
+- A change with an open PR is emitted into the active section with its PR state; the `elif [ -f proposal.md ]` "awaiting planning" branch is reached only when there is no `tasks.md` **and** no PR (AC15).
+
+**Caching:** a lookup result is memoised per run so N changes cost at most N calls, and the whole PR block is skippable via `SPECCLAW_STATUS_NO_PR=1` — which is also the seam the tests use to prove NFR1's unchanged output.
+
+## Architecture
+
+```
+verify (skill)
+  │
+  ├─ specclaw-browser-lock acquire ──────────► slot-N
+  │
+  ├─ specclaw-browser-lock wrap "<e2e_cmd>" ─► "systemd-run … -p MemoryMax=4096M npx playwright test --workers=1 --project=desktop && …"
+  │        exit 0 = capped │ exit 10 = uncapped (warned)
+  │
+  ├─ specclaw-run-long --phase e2e -- "<wrapped>"
+  │        ├─ child: eval → logs/e2e-<slug>-<pid>.log
+  │        ├─ stderr: heartbeat every 60s        ← keeps host watchdog satisfied
+  │        ├─ stdout: 100-line tail + log path   ← feeds verify payload
+  │        └─ logs/e2e-<slug>-<pid>.result       ← survives a teardown
+  │
+  ├─ specclaw-browser-lock release slot-N
+  │
+  └─ specclaw-update-status ──► STATUS.md (+ PR state, timeout-bounded, fail-open)
+```
+
+Stream discipline is the load-bearing detail: **stderr = liveness, stdout = payload, disk = truth.**
+
+## File Changes Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/specclaw/bin/specclaw-run-long` | create | Detached exec + heartbeat + capped tail + HEAD-stamped sidecar (FR1–FR5) |
+| `plugins/specclaw/bin/specclaw-verify` | modify | `run_capped()` delegates to `run-long`; add e2e tier + `e2e_state`; exit-137 classification (FR6, FR8–FR9, FR13) |
+| `plugins/specclaw/bin/specclaw-build` | modify | `cmd_finalize` test/lint/build via `run-long` instead of bare `eval` (FR6) |
+| `plugins/specclaw/bin/specclaw-browser-lock` | modify | New `wrap` subcommand: `--workers=1`, sequential `--project`, `MemoryMax` scope, capped/uncapped exit convention (FR10, FR12) |
+| `plugins/specclaw/bin/specclaw-update-status` | modify | PR state per active change, memoised, timeout-bounded, fail-open (FR14) |
+| `plugins/specclaw/templates/config.yaml` | modify | `build.e2e_command`, `verify.e2e`, `verify.heartbeat_seconds`, `verify.playwright.max_memory_mb`, `verify.playwright.projects` (FR7, FR11) |
+| `plugins/specclaw/skills/verify/SKILL.md` | modify | Document e2e policy + that a skip must be reported as a skip |
+| `plugins/specclaw/tests/run-long-orchestration-tests.sh` | create | Regression suite for AC1–AC15 |
+| `.github/workflows/ci.yml` | modify | Register the new suite |
+| `plugins/specclaw/.claude-plugin/plugin.json` | modify | Version bump |
+| `.claude-plugin/marketplace.json` | modify | Version bump (must match plugin.json — CI `json` job asserts) |
+| `README.md` / `plugins/specclaw/CLAUDE.md` | modify | Config reference for the five new keys |
+
+## Data Model Changes
+
+**Sidecar file** (new, `key=value`): `exit`, `duration_s`, `log`, `head`, `dirty`, `cmd`, `interrupted`.
+
+**Verify payload** (additive): `e2e_output` (string), `e2e_state` (enum), `e2e_memory_limited` (bool). Existing fields keep their names, types, and values, so an unset `e2e_command` reproduces today's payload byte-for-byte (AC6).
+
+**Config** (all optional, defaults = current behaviour):
+
+```yaml
+build:
+  e2e_command: ""                  # slow tier; test_command stays the fast tier
+verify:
+  e2e: last                        # skip | last | always
+  heartbeat_seconds: 60
+  playwright:
+    max_browsers: 2                # existing
+    max_memory_mb: 4096            # new
+    projects: []                   # new; empty = single invocation, no --project
+```
+
+## API Changes
+
+New CLI surfaces (both additive; existing subcommands untouched):
+
+- `specclaw-run-long [--log-dir DIR] [--phase NAME] [--heartbeat N] [--reuse] -- <cmd>` → stdout: capped tail + log path; stderr: heartbeats; exit: the command's exit code.
+- `specclaw-browser-lock <dir> wrap <cmd>` → stdout: transformed command string; exit `0` capped / `10` uncapped.
+
+## Key Decisions
+
+1. **`run-long` as a bin, not a sourced function.** Two callers in different scripts; a bin is testable in isolation and avoids cross-sourcing. Cost: one extra process per command — negligible against a multi-minute suite.
+2. **Keep `eval`.** The whole point of the existing call sites is that command strings may carry pipes and `&&`. Swapping to an array exec would break real configs for a theoretical hygiene gain.
+3. **Heartbeats on stderr.** Only way to add liveness without mutating the captured payload that feeds `verify-report.md` (AC6).
+4. **`wrap` prints, does not execute.** Makes every FR10/FR12 assertion a pure string comparison — no browser, no systemd, no network in CI (NFR6).
+5. **Operator-declared `verify.playwright.projects`.** Rejected both parsing `playwright.config.*` (TS, not statically tractable) and `npx playwright test --list` (process spawn per verify, needs a working install, new failure mode). One config line beats a fragile inference (Rule 2).
+6. **Probe `systemd-run`, don't just detect it.** `command -v` succeeds in containers where `systemd-run --user` fails; the OOM we are fixing is exactly the case where a false-positive cap silently does nothing.
+7. **Enumerated `e2e_state` over empty-output sentinel.** Makes "skipped ≠ passed" a type-level property rather than a convention a downstream reader might miss (FR9).
+8. **Sidecar refuses reuse on a dirty tree.** HEAD-stamping alone would reuse a stale pass across uncommitted edits — masking the exact change under test (edge case 4).
+9. **Reuse is opt-in (`--reuse`).** Default stays "always run". Skipping tests must be an explicit request, never a default inference.
+10. **`e2e` default `last`, not `skip`.** `skip` is the safer default for a new consumer but silently weakens the gate; the observed failure shows exactly where that ends — the operator eventually instructed specclaw to skip its own test gate.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Touching the execution path of every build/verify | Every new behaviour is additive and defaults to current code path; AC6/AC11/AC14 exist specifically to prove byte-identical output when config is absent (NFR1) |
+| Detached child orphaned or leaking on interrupt | `trap` INT/TERM kills the child process group, writes an interrupted sidecar; AC-covered, mirrors the sleeper-cleanup pattern in `tests/run-memory-parallelism-tests.sh:41-49` |
+| `--reuse` masks a real failure | Two independent invalidators (HEAD change, dirty tree) plus opt-in-only; sidecar records both so a wrong reuse is diagnosable |
+| `set -e` + no-match `grep` pipeline aborts a script (learning `[L2]`) | `|| true` on every `grep\|head\|sed` inside command substitution; explicit review item in the PR-state task |
+| `systemd-run --scope` unavailable in CI, so the cap path goes untested | Test asserts the *emitted string*, not runtime enforcement; a stub `systemd-run` on `PATH` covers the present-case, `PATH` removal covers absent-case |
+| Heartbeat noise on fast commands | Nothing emitted before the first interval; a sub-60s command produces zero heartbeat lines (AC3 second half) |
+| Wrapping breaks a metacharacter-heavy command | Round-trip test with pipes, `&&`, and env prefixes (edge case 2) |
+| PR lookup slows status generation | `timeout 5`, memoised per run, `SPECCLAW_STATUS_NO_PR=1` escape hatch (NFR5) |
+| Scope creep across four fixes in one change | Four independently-committable waves; a failure in one leaves the others merged and useful |
+
+## Grounding sources
+
+Discovery (`specclaw-discover-context`) was not runnable in this environment (`Permission denied` on the plugin-cache bin), so grounding came from direct reads of the repo:
+
+- `plugins/specclaw/bin/specclaw-verify:63-81` — `run_capped()` is the exact inline-`eval` seam being replaced; its 100-line cap and `... (truncated, ${total} total lines)` marker are preserved verbatim by FR3.
+- `plugins/specclaw/bin/specclaw-build:337-361` — three sequential `if ! eval "$X" >&2 2>&1` blocks; the second `run-long` adoption site.
+- `plugins/specclaw/bin/specclaw-browser-lock:7-9` — *"Fail-open: on any degeneracy (unwritable lock dir, acquire timeout) proceed without a slot so a wedged pool can never hang the build (NFR2/NFR3)"* — the fail-open contract NFR2 extends to all four new capabilities.
+- `plugins/specclaw/bin/specclaw-update-status:48-51` — the `elif [ -f "$change_dir/proposal.md" ]` → `"proposal ready, awaiting planning"` branch that produced the wrong report; FR14 gates it on PR state.
+- `plugins/specclaw/tests/run-memory-parallelism-tests.sh:19-20` — *"Plain bash + coreutils — no jq/bats/npm"* — sets NFR3 and the new suite's shape.
+- `.specclaw/learnings.md` `[L2]` — *"Always append `|| true` to grep | head | sed pipelines used inside command substitution"* — applied to the PR-state lookups.
+- `plugins/specclaw/CLAUDE.md` (Scripts table) — new bins must be listed there; `.github/workflows/ci.yml:14-19` — new suites must be registered to actually run.
+- `CLAUDE.md` (repo root, Version bump rule) — both version files bumped and kept in sync every PR.

--- a/.specclaw/changes/long-running-test-orchestration/proposal.md
+++ b/.specclaw/changes/long-running-test-orchestration/proposal.md
@@ -1,0 +1,115 @@
+# Proposal: Long-running test orchestration
+
+**Created:** 2026-07-24
+**Status:** ✅ Approved (2026-07-24)
+
+## Problem
+
+On a downstream consumer project — a TypeScript web app with a two-project (mobile + desktop) Playwright e2e suite, driven from a chat-bridged agent session — specclaw's build/verify phases became effectively unusable for roughly a week of operator wall-clock time. The failure was not a single bug but four interacting defects, all observed over a ~48h window:
+
+- **9 agent teardowns** — repeating pattern `⏳ still working (5 min since last reply)` → `⚠️ agent stopped responding (no reply for 6 min). Tearing down`. One instance went 39 min before teardown.
+- **7 session rotations** at 519 KB / 556 KB / 797 KB / 819 KB / 886 KB / 1040 KB / 1156 KB transcripts.
+- **Repeated Playwright OOM kills** — `exit 137`, "got SIGKILL'd (OOM) even w/ workers:1".
+- **Wrong status reporting** — STATUS.md claimed four consecutive changes were "awaiting planning" when all four were already built, verified and PR'd.
+
+Net effect: the operator repeatedly asked for current status, got a stale or re-derived answer, and eventually instructed specclaw to *skip its own test gate* to escape the deadlock. A quality gate that gets disabled under pressure is worse than no gate.
+
+### Root cause 1 — blocking inline e2e triggers the host watchdog
+
+`plugins/specclaw/bin/specclaw-verify` and `plugins/specclaw/bin/specclaw-build` (finalize, ~lines 327-362) run `build.test_command` inline via `eval`. A Playwright suite is one Bash call lasting 262 s, 596 s, or longer, emitting nothing to the transcript until it exits. The host (claude-multi-channel-discord health monitor) treats 5–7 min of agent silence as a hung session and tears the agent down — mid-run, losing all progress. The next message respawns a fresh agent that starts the same suite from zero. This is the single largest time sink in the log.
+
+### Root cause 2 — no slow-test tier
+
+`plugins/specclaw/templates/config.yaml:47-49` defines exactly one `test_command` alongside `lint_command` and `build_command`. There is no separate slow/e2e tier and no policy knob, so when the operator asked twice for e2e to be deferred to the end of the run so it would stop OOM-ing the box, specclaw had no configuration surface capable of honouring either request. The only available workaround was abandoning the test gate entirely.
+
+### Root cause 3 — OOM survives the v0.5.9 browser cap
+
+v0.5.9 added `plugins/specclaw/bin/specclaw-browser-lock` with `verify.playwright.max_browsers` (default 2). That semaphore gates *specclaw's own parallel agents* — it does not constrain what happens inside a single slot. The consumer project's Playwright config declares two projects (mobile + desktop), so one lock slot still fans out to concurrent Chromium instances, and the box still OOM'd at `workers:1`. Because the OOM killer targets the whole process tree, the failure surfaces as an opaque `exit 137` with no test output — and both operator and agent initially read that as test flakiness rather than a memory kill, which sent the investigation down the wrong path.
+
+### Root cause 4 — status derived from tasks.md alone
+
+`plugins/specclaw/bin/specclaw-update-status` computes phase state from `tasks.md` completion counts within each active change directory. It never inspects PR state. So a change whose work is finished and PR'd, but whose `status.md` was never written back (because the agent was torn down before step 6), shows as un-started. After each session rotation the fresh agent re-investigated the whole backlog from scratch to reconstruct the truth — expensive, and it produced contradictory answers to the same operator question within minutes.
+
+## Proposed Solution
+
+Four coordinated changes, one per root cause. They share a single theme: **long-running commands must be observable while they run, bounded in what they can consume, and their outcome must be durable across a session teardown.**
+
+### 1. `run_long()` — detached execution with heartbeat
+
+New shared helper (a `specclaw-run-long` bin, sourced by `specclaw-verify` and `specclaw-build`) that replaces inline `eval` for any command expected to exceed a threshold:
+
+- Launch the command detached, redirecting stdout+stderr to `.specclaw/changes/<change>/logs/<phase>-<cmd>.log`.
+- Poll for completion. On each poll interval (~60 s default), emit one short progress line (elapsed time, log line count, last non-empty line) so the agent stays visibly alive and the host watchdog never fires.
+- On exit, tail only the last N lines (reuse the existing 100-line cap from `specclaw-verify:185-214`) into the transcript; the full log stays on disk and is referenced by path.
+- Write a small sidecar result file (exit code, duration, log path) *before* returning, so a teardown mid-poll leaves a recoverable record instead of nothing.
+
+The sidecar is what makes this survive teardown: a respawned agent reads the result rather than re-running a 10-minute suite.
+
+### 2. `build.e2e_command` + `verify.e2e` policy
+
+- New config key `build.e2e_command` (default `""`) for the slow tier. `build.test_command` keeps its current meaning: fast tests only.
+- New config key `verify.e2e` with values `skip | last | always`, default `last`.
+  - `last` — run lint, build, and fast tests first; run e2e only once those pass, as the final gate. Directly implements the operator's "run e2e at the end".
+  - `skip` — record e2e as skipped in `verify-report.md` (explicitly, not silently) and continue.
+  - `always` — current behaviour.
+- Absent `e2e_command` → behaviour is byte-identical to today, so existing consumers are unaffected.
+
+### 3. Bound Playwright's own fan-out and its memory
+
+Extend `specclaw-browser-lock` so holding a slot also constrains what runs inside it:
+
+- Force `--workers=1` when invoking a detected Playwright command, and iterate declared projects sequentially rather than letting Playwright run them concurrently.
+- Run the suite inside a memory-capped scope (`systemd-run --scope -p MemoryMax=…` where available, with a documented no-op fallback where it is not). This converts "OOM killer takes down the box and every sibling agent" into "this one command fails with a diagnosable error", which is the difference between a lost hour and a lost afternoon.
+- Surface the distinction explicitly: an `exit 137` under a memory cap must be reported as *memory limit exceeded*, never left to be guessed at as flakiness.
+
+### 4. PR-aware status
+
+Teach `specclaw-update-status` to fold PR state into `STATUS.md`: for each active change, look up its PR (GitHub via `gh`, Azure DevOps via the existing `specclaw-azdo-issue` path) and show that state alongside task counts. A change that is built, verified and PR'd must never render as "awaiting planning". Lookups must degrade gracefully — no network, no auth, or no PR yields the current tasks.md-only output rather than an error.
+
+## Scope
+
+### In Scope
+
+- New `specclaw-run-long` helper; adopt it in `specclaw-verify` and `specclaw-build` finalize for test/lint/build execution.
+- Per-command log files + result sidecars under `.specclaw/changes/<change>/logs/`.
+- New config keys: `build.e2e_command`, `verify.e2e` (`skip|last|always`). Documented in `templates/config.yaml`.
+- E2E ordering in the verify phase (last gate, after lint/build/fast tests pass).
+- `specclaw-browser-lock`: forced `--workers=1`, sequential project iteration, optional memory-capped scope, explicit OOM reporting.
+- `specclaw-update-status`: PR state in `STATUS.md`, with graceful degradation.
+- Regression tests extending `plugins/specclaw/tests/run-memory-parallelism-tests.sh` (or a sibling script): heartbeat emission, sidecar recovery, e2e policy branches, OOM classification, status output with and without PR data.
+- Docs: README / CLAUDE.md config reference for the new keys.
+
+### Out of Scope
+
+- Fixing non-idempotent e2e fixtures in a consumer project. Where a spec uses fixed (non-randomized) entity names, a run killed mid-test never fires its `finally` cleanup and leaves orphaned rows that cause HTTP 409 conflicts on the next run. Real bug, but it belongs to the consumer project, not specclaw. (Worth noting: fixing root cause 1 largely stops the mid-test kills that create those orphans.)
+- Changing the host health-monitor thresholds in `claude-multi-channel-discord`. Different repo. specclaw should be well-behaved under the existing thresholds rather than demand they be raised.
+- Any change to `build.parallel_tasks`, `build.memory`, or the v0.5.9 memory budgeting maths — that layer works; the gap is inside a slot, not in slot allocation.
+- Retry/quarantine logic for genuinely flaky tests.
+
+## Impact
+
+- **Files affected:** ~8 (estimated) — new `bin/specclaw-run-long`; edits to `bin/specclaw-verify`, `bin/specclaw-build`, `bin/specclaw-browser-lock`, `bin/specclaw-update-status`, `templates/config.yaml`, `skills/verify/SKILL.md`, plus tests
+- **Complexity:** medium
+- **Risk:** medium — touches the execution path of every build and verify run. Mitigated by making every new behaviour opt-in or default-identical: no `e2e_command` set → unchanged; no `systemd-run` available → unchanged; no PR found → unchanged status output.
+
+## Open Questions
+
+**Resolved at approval (2026-07-24)** — operator approved without amending; these are the decisions planning proceeds on:
+
+- **Q2 memory cap** → new key `verify.playwright.max_memory_mb`, default `4096`, explicitly configurable. Fixed default rather than derived from `build.memory.per_agent_mb`: verify runs one suite at a time and should not inherit build's per-agent sizing, which would couple the two phases for no gain.
+- **Q3 sidecar staleness** → HEAD-commit stamping. A sidecar is trusted only while the change's HEAD commit is unchanged; any new commit invalidates it. A TTL would let a stale pass survive a code change, which is the exact class of wrongness this proposal exists to remove.
+- **Q4 `verify.e2e` default** → `last`, as proposed.
+- **Q6 single change** → confirmed. Planning must keep the four parts as independently-committable waves.
+
+Still open, decide during `/specclaw:plan`:
+
+1. **Heartbeat interval and threshold.** 60 s poll assumes the host's ~5 min silence threshold. Should the interval be configurable (`verify.heartbeat_seconds`), and should `run_long()` kick in above a duration threshold or unconditionally for all test/lint/build commands? Unconditional is simpler and more predictable; the cost is a heartbeat line on fast commands that do not need one.
+2. **Memory cap value.** Fixed default (e.g. 4096 MB), a fraction of `MemAvailable`, or derived from the existing `build.memory.per_agent_mb`? Deriving keeps one source of truth but couples verify to build config.
+3. **Sidecar staleness.** How long may a respawned agent trust an existing result sidecar before re-running? Options: trust while the change's HEAD commit is unchanged (precise, needs commit stamping), or a simple TTL (crude but trivial). Commit-stamping seems right given the failure mode being fixed.
+4. **`verify.e2e` default.** `last` is proposed. `skip` would be safer for first-run consumers but silently weakens the gate — and the log shows exactly how that ends. Confirm `last`.
+5. **Project enumeration.** Reading Playwright projects requires parsing `playwright.config.*` (TS/JS, not statically trivial) or calling `npx playwright test --list`. The latter is more robust but costs a process spawn per verify. Preference?
+6. **Scope check.** Four fixes in one change means one PR touching the whole build/verify execution path. Confirmed as a single proposal — flagging that task ordering in `/specclaw:plan` should keep them as independently-committable waves so a problem in one does not block the others.
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/long-running-test-orchestration/review-report.md
+++ b/.specclaw/changes/long-running-test-orchestration/review-report.md
@@ -1,0 +1,162 @@
+# Code Review Report: long-running-test-orchestration
+
+**Reviewed:** 2026-07-25
+**Model:** claude-sonnet-4-6
+**Verdict:** APPROVED_WITH_NOTES
+
+## Summary
+
+10 findings: 0 BLOCK, 6 WARN, 4 NOTE
+
+## Findings
+
+### [WARN] plugins/specclaw/bin/specclaw-run-long:142 — Correctness (reuse cache)
+
+**Problem:** The dirty-tree detection uses `git diff --quiet` and `git diff --cached --quiet`, neither of which detects untracked files. A new file added to the working tree but not yet staged (`git add`) leaves `current_dirty="false"`, so `--reuse` will serve a cached result despite the working tree differing from the HEAD state the cache was recorded against. The spec says edge case 4 covers "uncommitted working-tree changes" without restriction.
+
+```bash
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  current_dirty="true"
+fi
+```
+
+A test file created but not `git add`'d — exactly the scenario described in the root-cause analysis ("the operator is testing") — escapes this check.
+
+### [WARN] plugins/specclaw/bin/specclaw-run-long:155–175 — Correctness (reuse cache)
+
+**Problem:** The reuse path finds the sidecar by `phase+slug` (newest_sidecar) but never compares the sidecar's stored `cmd=` value against the current command. The slug is the command sanitised to `[a-z0-9-]` and truncated to 40 characters. Two distinct long commands can produce the same 40-char slug, causing a false cache hit: the sidecar from command A is served as the result for command B without re-executing.
+
+```bash
+prior_sidecar=""
+"$reuse" && prior_sidecar="$(newest_sidecar)"
+
+if [[ -n "$prior_sidecar" ]]; then
+  cached_head="$(sidecar_val "$prior_sidecar" head)"
+  cached_dirty="$(sidecar_val "$prior_sidecar" dirty)"
+  cached_exit="$(sidecar_val "$prior_sidecar" exit)"
+  cached_log="$(sidecar_val "$prior_sidecar" log)"
+  # ... no check of sidecar_val "$prior_sidecar" cmd
+```
+
+**Fix:** After extracting `cached_head`, also read `cached_cmd="$(sidecar_val "$prior_sidecar" cmd)"` and add `elif [[ "$cached_cmd" != "$cmd" ]]; then warn "--reuse: command mismatch — re-executing"; fi` before the "all checks pass" branch.
+
+### [WARN] plugins/specclaw/bin/specclaw-run-long:190–195 — Correctness (process lifecycle)
+
+**Problem:** There is a race between trap registration and `child_pid` assignment. The trap is set for INT/TERM, then the child is backgrounded, then `child_pid="$!"` is assigned on the next line. If SIGTERM arrives in the window between the `&` and the assignment of `child_pid`, the trap fires with `child_pid=""`. The guard `[[ -n "$child_pid" ]]` prevents the kill, but the child runs without supervision: it becomes an orphan until it exits naturally, and no sidecar is written reflecting the interruption.
+
+```bash
+trap '_cleanup_interrupt' INT
+trap '_cleanup_interrupt' TERM
+
+# ─── Execute detached ─────────────────────────────────────────────────────────
+
+set -m
+( set +e; eval "$cmd" ) >"$log_file" 2>&1 &
+child_pid="$!"   # <-- signal between & and this line orphans the child
+```
+
+### [WARN] plugins/specclaw/bin/specclaw-verify:151–174 — Correctness (trap clobbering in acquire)
+
+**Problem:** `e2e_acquire_slot()` unconditionally installs `trap 'e2e_release_slot' EXIT`. If a caller of `cmd_collect` had previously installed a different EXIT trap (e.g. a temp-file cleanup), that trap is silently overwritten. Although no such pre-existing trap exists in the current codebase, this is a latent correctness issue: callers cannot safely compose traps with `e2e_acquire_slot`.
+
+```bash
+e2e_acquire_slot() {
+  local specclaw_dir="$1" slot=""
+  slot=$("$BROWSER_LOCK" "$specclaw_dir" acquire) || slot=""
+  case "$slot" in
+    ""|none) return 0 ;;
+  esac
+  E2E_SLOT="$slot"
+  E2E_SLOT_DIR="$specclaw_dir"
+  trap 'e2e_release_slot' EXIT          # overwrites any pre-existing EXIT trap
+  trap 'e2e_release_slot; exit 130' INT
+  trap 'e2e_release_slot; exit 143' TERM
+}
+```
+
+**Fix:** Capture the prior EXIT trap with `old_exit_trap=$(trap -p EXIT)` before overwriting, then chain in the new handler: `trap 'e2e_release_slot; '"$old_exit_trap" EXIT`.
+
+### [WARN] plugins/specclaw/bin/specclaw-build:329–333 — Correctness (redirect order)
+
+**Problem:** The inline fallback in `run_long_check` uses `>&2 2>&1`, which first redirects stdout to stderr then redirects stderr to where stdout currently points (i.e., the same stderr). Both streams end up on stderr, which is the intent. However the second redirect `2>&1` is redundant and misleading: when read by a maintainer, it looks like stdout and stderr are swapped relative to each other, not combined. This is distinct from the pre-existing call sites in the original `cmd_finalize` which had the same expression — this is a NEW function introduced by this change.
+
+```bash
+eval "$cmd" >&2 2>&1
+```
+
+The correct idiom for "send both stdout and stderr to stderr" is `>&2 2>&1` but a clearer and less error-prone spelling is `2>&1 >&2` (dup stderr first so >&2 points to actual stderr) or simply leaving stderr as-is and only redirecting stdout: `1>&2`. Given the intent is "all output to stderr", the inline path should use `>"$log_file" 2>&1 >&2` or just `1>&2`.
+
+### [WARN] plugins/specclaw/tests/run-long-orchestration-tests.sh:1289–1300 — Test quality
+
+**Problem:** Case 43 tests `count_of '--workers'` on the full output string, which includes the `systemd-run ... bash -c 'npx playwright test --workers=1'` wrapper text. The count of `--workers` occurrences includes both any occurrence inside a `bash -c` single-quoted string AND any injected flag. For a multi-project fan-out, `--workers=1` appears multiple times (once per project invocation) and the assertion `assert_eq "AC10 exactly one --workers flag is emitted" "1"` would fail even when the implementation is correct. The test fixture has no projects configured, so in this specific fixture there is only one invocation and the assertion passes — but it would silently fail to detect an over-duplication bug when projects are configured.
+
+```bash
+out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test')"
+assert_contains "AC10 a playwright command gains --workers=1" "--workers=1" "$out"
+assert_eq "AC10 exactly one --workers flag is emitted" "1" "$(count_of '--workers' "$out")"
+```
+
+The test is not vacuous — it correctly passes and fails for the single-invocation case — but the "exactly one" assertion would give false confidence if the same test were applied to a multi-project fixture.
+
+### [NOTE] plugins/specclaw/bin/specclaw-run-long:125–126 — Naming
+
+**Problem:** The variable `log_base` is computed but only used in the lines immediately following to derive `log_file` and `sidecar`. Using `log_base` as an intermediate is clear but the variable name `log_base` is visually close to `log_file`, making it easy to accidentally use the wrong one in a future edit.
+
+```bash
+log_base="${log_dir}/${phase}-${slug}-$$"
+log_file="${log_base}.log"
+sidecar="${log_base}.result"
+```
+
+**Suggestion:** No change required — this is the clearest way to express the derivation. NOTE level only.
+
+### [NOTE] plugins/specclaw/bin/specclaw-verify:299 — Correctness (minor)
+
+**Problem:** The `e2e_configured` detection searches for `e2e_command` and `e2e` as bare keys anywhere in the config file using `grep -qE "^[[:space:]]*${field}:"`. If a future config key begins with `e2e` (e.g. `e2e_timeout`) it would set `e2e_configured=true` even if `e2e_command` and `verify.e2e` are absent. This is not a current bug — only a fragile anchor for future config evolution.
+
+```bash
+if yaml_has_key "$config_file" "e2e_command" || yaml_has_key "$config_file" "e2e"; then
+  e2e_configured=true
+fi
+```
+
+**Suggestion:** Comment the exact keys this is looking for and why partial-key matches are acceptable (or tighten the regex to `^[[:space:]]*e2e:[[:space:]]` for the `verify.e2e` key).
+
+### [NOTE] plugins/specclaw/bin/specclaw-verify:311–342 — Complexity
+
+**Problem:** The `cmd_collect` function is substantially longer than 30 lines after this change (the e2e block from line 311 to 420 is ~110 lines). The e2e policy logic is correct and well-commented, but the nesting reaches 5 levels deep for the "execute and classify" path.
+
+```bash
+if [ "$e2e_configured" = true ]; then    # level 1
+  if [ -z "$e2e_cmd" ]; then             # level 2
+    ...
+  elif [ "$e2e_policy" = "skip" ]; then  # level 2
+    ...
+  else                                   # level 2
+    if [ -n "$failed_gates" ]; then      # level 3
+      ...
+    else                                 # level 3
+      if [ -n "$BROWSER_LOCK" ]; then    # level 4
+        ...
+        if [ -n "$wrapped" ] && ...; then # level 5
+```
+
+**Suggestion:** Extract the "acquire slot, wrap, execute, release, classify" block into a helper function such as `e2e_run()` — this reduces `cmd_collect` to a decision dispatcher and moves the nesting to a purpose-named function. Not required; NOTE only.
+
+### [NOTE] plugins/specclaw/bin/specclaw-run-long:180 — Simplicity
+
+**Problem:** The reuse section uses `"$reuse" && prior_sidecar="$(newest_sidecar)"` to conditionally invoke `newest_sidecar`. Running a boolean variable as a command string (`"$reuse"` expands to `true` or `false`, both of which are valid shell builtins) works but is non-idiomatic and trips up readers unfamiliar with the pattern.
+
+```bash
+"$reuse" && prior_sidecar="$(newest_sidecar)"
+```
+
+**Suggestion:** `[[ "$reuse" == "true" ]] && prior_sidecar="$(newest_sidecar)"` — same semantics, clearer intent.
+
+_(No findings for Dimension 9 (Scope creep): all modified files appear in the `files:` entries in tasks.md.)_
+
+_(Design adherence Dimension 8: implementation matches design.md across all four seams: run-long mechanics, slow-test tier, wrap subcommand, PR-aware status. No divergence found.)_
+
+## Verdict Rationale
+
+There are no BLOCK findings. The six WARN findings cover two reuse-cache correctness gaps (untracked files not detected as dirty; sidecar `cmd` field not compared on reuse), a narrow process-lifecycle race (SIGTERM between trap set and child PID assignment), a trap-clobbering risk in slot acquisition, a misleading redirect idiom in the inline fallback, and a test assertion that gives correct results for its fixture but would give false confidence on a multi-project fixture. None of these are reachable under the expected call patterns in the current codebase, but each describes a real failure mode that future callers or config changes could trigger. The four NOTE findings are style and complexity observations. The implementation correctly handles all 17 edge cases from the spec, passes NFR1 (byte-identical default output), correctly applies the [L2] `|| true` guard on every `grep`/`head`/`sed` pipeline in command substitution, and uses no `jq` or external runtime dependencies beyond coreutils (NFR3).

--- a/.specclaw/changes/long-running-test-orchestration/review-report.md
+++ b/.specclaw/changes/long-running-test-orchestration/review-report.md
@@ -157,6 +157,25 @@ _(No findings for Dimension 9 (Scope creep): all modified files appear in the `f
 
 _(Design adherence Dimension 8: implementation matches design.md across all four seams: run-long mechanics, slow-test tier, wrap subcommand, PR-aware status. No divergence found.)_
 
+## Resolution (2026-07-25)
+
+All 10 findings addressed. NOTE 1 was the reviewer's own "no change required".
+
+| # | Finding | Resolution |
+|---|---------|------------|
+| WARN | `run-long:142` untracked files not dirty | Fixed — `git ls-files --others --exclude-standard` joins the check. `--exclude-standard` keeps ignored build output from permanently disabling reuse. Test Case 12b, verified failing against the unfixed code. |
+| WARN | `run-long:155` sidecar `cmd` not compared | Fixed — reuse now refuses on a `cmd` mismatch. Test Case 12c reproduces the collision: without the fix, command B is served A's result. |
+| WARN | `run-long:190` trap/PID race | Fixed — the handler falls back to `jobs -p` when `child_pid` is still empty. |
+| WARN | `verify:151` EXIT trap clobbered | Fixed — the prior handler is captured with `trap -p EXIT` and chained rather than overwritten. |
+| WARN | `build:329` misleading redirect | Fixed — `1>&2`. Same effect, no longer reads as a stream swap. |
+| WARN | `tests:1289` "exactly one `--workers`" | Fixed — replaced with `assert_one_workers_per_invocation`, which asserts one flag per `bash -c` invocation. Fixture-independent, so it now also guards the fan-out path (new assertion in Case 45). |
+| NOTE | `run-long:125` `log_base` naming | No change, per the reviewer's own suggestion. |
+| NOTE | `verify:299` `e2e` key anchor | Fixed — the `verify.e2e` probe is anchored to `^[[:space:]]*e2e:[[:space:]]`, so a future `e2e_timeout:` cannot switch the block on. Fails closed on a valueless `e2e:`. |
+| NOTE | `verify:311` `cmd_collect` nesting | Fixed — "acquire slot, wrap, execute, release, classify" extracted to `e2e_run()`. `cmd_collect`'s e2e block is now a policy dispatcher; deepest nesting drops from 5 levels to 3. |
+| NOTE | `run-long:180` `"$reuse" &&` idiom | Fixed — `[[ "$reuse" == "true" ]]`. |
+
+Suite after all fixes: **272 passed, 0 failed** (was 261 at review time).
+
 ## Verdict Rationale
 
 There are no BLOCK findings. The six WARN findings cover two reuse-cache correctness gaps (untracked files not detected as dirty; sidecar `cmd` field not compared on reuse), a narrow process-lifecycle race (SIGTERM between trap set and child PID assignment), a trap-clobbering risk in slot acquisition, a misleading redirect idiom in the inline fallback, and a test assertion that gives correct results for its fixture but would give false confidence on a multi-project fixture. None of these are reachable under the expected call patterns in the current codebase, but each describes a real failure mode that future callers or config changes could trigger. The four NOTE findings are style and complexity observations. The implementation correctly handles all 17 edge cases from the spec, passes NFR1 (byte-identical default output), correctly applies the [L2] `|| true` guard on every `grep`/`head`/`sed` pipeline in command substitution, and uses no `jq` or external runtime dependencies beyond coreutils (NFR3).

--- a/.specclaw/changes/long-running-test-orchestration/spec.md
+++ b/.specclaw/changes/long-running-test-orchestration/spec.md
@@ -1,0 +1,131 @@
+# Spec: Long-running test orchestration
+
+**Change:** long-running-test-orchestration
+**Created:** 2026-07-24
+**Status:** 🟡 Draft
+
+## Overview
+
+specclaw's build and verify phases execute the project's test/lint/build commands inline via `eval` (`bin/specclaw-verify:71` in `run_capped()`, `bin/specclaw-build:337-361` in `cmd_finalize`). For fast unit suites this is fine. For a Playwright e2e suite it produces a single silent Bash call lasting 4–10+ minutes, which:
+
+- trips the host's agent-silence watchdog (5–7 min) and gets the agent torn down mid-run, discarding all progress;
+- streams the full suite output into the agent transcript, inflating it toward the rotation threshold;
+- runs Playwright's own project/worker fan-out unconstrained, so the box OOMs (`exit 137`) even at `workers:1`;
+- and, when the teardown happens before `specclaw-update-status` runs, leaves `STATUS.md` claiming work that is finished and PR'd is "awaiting planning".
+
+This change makes long command execution **observable while running, bounded in memory, and durable across a teardown**, and adds a slow-test tier so e2e can be ordered last or skipped explicitly rather than by abandoning the gate.
+
+Full evidence and root-cause analysis: `proposal.md`.
+
+## Requirements
+
+### Functional Requirements
+
+**FR1 — `specclaw-run-long` helper.** A new `bin/specclaw-run-long` runs a command string detached from the caller's stdout, writing combined stdout+stderr to a log file, and returns the command's exit code.
+
+**FR2 — Heartbeat progress.** While the command runs, `run-long` emits one progress line to stderr every `verify.heartbeat_seconds` (default `60`): elapsed seconds, log line count, and the last non-empty log line (truncated). No output is emitted before the first interval elapses, so commands faster than one interval stay silent — identical in practice to today's behaviour.
+
+**FR3 — Capped tail, full log on disk.** On completion, `run-long` prints the last `100` lines of the log to stdout (preserving `run_capped`'s existing cap and its `... (truncated, N total lines)` marker) and prints the log path. The complete log stays at `<change_dir>/logs/<phase>-<slug>.log`.
+
+**FR4 — Result sidecar.** Before returning, `run-long` writes `<change_dir>/logs/<phase>-<slug>.result` containing: exit code, duration, log path, the command string, and the repo HEAD commit SHA at start. Written even when the command fails, so a failure is as recoverable as a pass.
+
+**FR5 — HEAD-stamped sidecar reuse.** `specclaw-run-long --reuse` returns a cached sidecar result (skipping execution) only when the sidecar exists **and** its recorded HEAD SHA equals current HEAD. Any new commit invalidates it. Without `--reuse`, the command always runs.
+
+**FR6 — Adoption in verify and build.** `specclaw-verify`'s `run_capped()` and `specclaw-build`'s `cmd_finalize` execute test/lint/build through `specclaw-run-long` instead of bare `eval`. Captured output and exit-code semantics at each call site are unchanged.
+
+**FR7 — Slow-test tier config.** New config key `build.e2e_command` (default `""`), documented in `templates/config.yaml` beside `test_command`. `build.test_command` keeps its current meaning: the fast tier.
+
+**FR8 — E2E policy.** New config key `verify.e2e` with values `skip | last | always`, default `last`.
+- `last` — run `lint_command`, `build_command`, and `test_command` first; run `e2e_command` only if all three pass.
+- `skip` — do not run `e2e_command`; record it as explicitly skipped.
+- `always` — run `e2e_command` unconditionally, alongside the other commands.
+
+**FR9 — Explicit skip reporting.** When e2e is skipped (by policy, or by `last` because an earlier gate failed), the verify payload carries a distinct skipped state with its reason. A skipped e2e must never be reportable as a pass.
+
+**FR10 — Bounded Playwright invocation.** New `specclaw-browser-lock <dir> wrap <command>` prints a transformed command string that: appends `--workers=1` when the command is a Playwright invocation and does not already set `--workers`; and wraps it in a memory-capped scope (`systemd-run --scope -p MemoryMax=<N>M`) when `systemd-run` is available and usable.
+
+**FR11 — Memory cap config.** New config key `verify.playwright.max_memory_mb`, default `4096`, beside the existing `max_browsers`.
+
+**FR12 — Sequential projects.** New config key `verify.playwright.projects` (default `[]`, a list of Playwright project names). When non-empty, `wrap` emits one `--project=<name>` invocation per entry, chained so they run sequentially. When empty, a single invocation is emitted and project selection is left to the project's own Playwright config. specclaw does not parse `playwright.config.*` and does not shell out to enumerate projects.
+
+**FR13 — Memory-kill classification.** When a command run under a memory cap exits `137`, the reported failure states that the memory limit was exceeded and names the cap value. It is never reported as a generic or flaky failure.
+
+**FR14 — PR-aware status.** `specclaw-update-status` includes each active change's PR state in `STATUS.md` (GitHub via `gh`, Azure DevOps via the existing `specclaw-azdo-*` path). A change with an open PR renders as PR-open, never as "proposal ready, awaiting planning".
+
+### Non-Functional Requirements
+
+**NFR1 — Byte-identical default behaviour.** With no new config keys present, no `e2e_command` set, no `systemd-run` available, and no PR discoverable, every observable output must match v0.5.9. This is the acceptance bar, not an aspiration — each of the four conditions gets its own test.
+
+**NFR2 — Fail-open.** Every new capability degrades to the current behaviour rather than blocking a build: unwritable log dir → run inline as today; `systemd-run` missing or unusable → run uncapped; `gh`/`az` missing, unauthenticated, offline, or slow → omit PR state. A wedged new feature must never be able to stall a build. Matches the existing `specclaw-browser-lock` fail-open contract (`bin/specclaw-browser-lock:7-9`).
+
+**NFR3 — Bash + coreutils only.** No `jq`, `bats`, `npm`, or Python runtime dependency in `bin/` or in the test suite, consistent with the existing suites (`tests/run-memory-parallelism-tests.sh:19-20`).
+
+**NFR4 — Transcript economy.** A long command must contribute at most the 100-line tail plus one heartbeat line per interval to the transcript, regardless of how much the suite prints.
+
+**NFR5 — PR-state lookup is bounded.** Status generation must not hang on network calls: each lookup is timeout-bounded and its failure is non-fatal.
+
+**NFR6 — Testability without side effects.** New logic must be testable without launching a browser, contacting a network, or requiring systemd: `wrap` emits a command string rather than executing it, and PR lookups go through an injectable/stubbable seam.
+
+**NFR7 — No orphaned processes.** A `run-long` child must not outlive its parent: interrupted runs clean up the detached process and leave a sidecar recording the interruption.
+
+## Acceptance Criteria
+
+Each criterion must pass for the change to be considered complete.
+
+- **AC1** — `specclaw-run-long` running `sh -c 'echo hi; exit 3'` returns exit 3, prints `hi` in its tail, and writes a log file containing `hi`.
+- **AC2** — A command producing 500 lines yields exactly a 100-line tail plus the `... (truncated, 500 total lines)` marker, while the on-disk log holds all 500 lines.
+- **AC3** — With `heartbeat_seconds=1`, a 3-second command emits at least 2 heartbeat lines to stderr, each carrying elapsed seconds. A command shorter than one interval emits none.
+- **AC4** — After any run, pass or fail, the `.result` sidecar exists and records exit code, duration, log path, command, and a 40-char HEAD SHA.
+- **AC5** — `--reuse` with a sidecar whose HEAD SHA matches current HEAD does not re-execute the command (proven by a command with a side effect, e.g. appending to a counter file). After a new commit, the same invocation re-executes.
+- **AC6** — With `build.e2e_command` unset, `specclaw-verify collect` output is byte-identical to v0.5.9 for the same fixture. (NFR1)
+- **AC7** — `verify.e2e: last` with a failing `lint_command` does not run `e2e_command`, and the payload marks e2e skipped with the failing gate as the reason.
+- **AC8** — `verify.e2e: skip` never runs `e2e_command` and marks it explicitly skipped; no code path lets that state read as a pass. (FR9)
+- **AC9** — `verify.e2e: always` runs `e2e_command` even when `lint_command` fails.
+- **AC10** — `browser-lock wrap 'npx playwright test'` emits a string containing `--workers=1`. Given a command that already contains `--workers=2`, the original value is preserved and not duplicated.
+- **AC11** — With `systemd-run` present, the wrapped string contains `MemoryMax=4096M` (or the configured value). With `systemd-run` absent (stubbed off `PATH`), the emitted string is the unwrapped command and a warning goes to stderr. (NFR2)
+- **AC12** — With `verify.playwright.projects: [desktop, mobile]`, `wrap` emits two sequential invocations carrying `--project=desktop` and `--project=mobile`. With the key absent, exactly one invocation is emitted and no `--project` flag is added.
+- **AC13** — A command exiting `137` under a memory cap is reported with a memory-limit message naming the cap; the same exit code with no cap applied is reported as a plain failure.
+- **AC14** — `specclaw-update-status` with a stubbed PR lookup returning an open PR renders that change's line with the PR reference. With the lookup stubbed to fail, output matches the current tasks.md-only rendering and exit status stays 0. (NFR2, NFR5)
+- **AC15** — A change directory holding `proposal.md`, `tasks.md` with all tasks `[x]`, and an open PR does not render as "awaiting planning".
+- **AC16** — Existing suites `tests/run-parser-tests.sh`, `tests/run-memory-parallelism-tests.sh`, and `tests/run-synth-agent-tests.sh` all still pass, and `shellcheck` reports no new findings on changed `bin/` scripts.
+
+## Edge Cases
+
+1. **Log directory unwritable** — `mkdir -p <change_dir>/logs` fails → warn, fall back to `mktemp`, and if that also fails run inline exactly as today (NFR2).
+2. **Command string contains shell metacharacters** — `run-long` must preserve today's `eval` semantics (pipes, `&&`, env prefixes all keep working); wrapping must not re-quote a command into breakage. Round-trip a metacharacter-heavy command in tests.
+3. **Not a git repo, or repo with zero commits** — no HEAD SHA to stamp. Sidecar records an empty SHA and `--reuse` refuses to reuse it (fail closed on reuse, since correctness of skipping depends on the stamp).
+4. **Uncommitted working-tree changes** — HEAD SHA is unchanged, so a sidecar would be reused despite modified files. Sidecar must additionally record dirty-tree state and refuse reuse when the tree is dirty; otherwise `--reuse` would mask exactly the edit the operator is testing.
+5. **Concurrent runs writing the same log path** — two agents verifying the same change and phase. Log/sidecar names must include a discriminator (PID) so neither truncates the other's log.
+6. **Heartbeat when the command prints nothing** — log stays empty; heartbeat still emits with elapsed time and an empty-output note. Silence is exactly the case the watchdog kills, so it must still produce a line.
+7. **`heartbeat_seconds` set to 0 or a non-integer** — clamp to the default rather than dividing by zero or busy-looping. Mirrors the `per_agent_mb=0` guard already covered in `tests/run-memory-parallelism-tests.sh`.
+8. **`e2e_command` set but `verify.e2e` absent** — default `last` applies.
+9. **`verify.e2e` set to an unrecognised value** — warn and fall back to `last`; do not fail the run and do not silently skip.
+10. **`e2e_command` set, `test_command` empty** — `last` treats the missing fast tier as vacuously passing, then runs e2e.
+11. **`systemd-run` on PATH but unusable** — present but fails (no systemd session / permission denied). Detection must probe usability, not mere presence, then fall back uncapped with a warning.
+12. **Project name with spaces or shell metacharacters** in `verify.playwright.projects` — quote correctly in the emitted `--project=` flag.
+13. **Non-Playwright `e2e_command`** (Cypress, plain script) — `wrap` must not inject `--workers=1`; the memory cap may still apply.
+14. **`gh`/`az` present but unauthenticated, or PR lookup slow** — bounded timeout, warn once, omit PR state (NFR5).
+15. **Multiple PRs for one change, or a merged/closed PR** — render the most recently updated one and show its actual state; a merged PR must not read as open.
+16. **Interrupted `run-long`** — SIGINT/SIGTERM kills the child, writes an interrupted sidecar, leaves no orphan (NFR7).
+17. **`grep`/`head`/`sed` pipelines inside command substitution under `set -e`** — a no-match pipeline must not silently abort the script. Known trap from learning `[L2]` in `.specclaw/learnings.md`; append `|| true` on every such pipeline.
+
+## Dependencies
+
+- Existing: `bash` 4+, coreutils, `git`. Optional: `systemd-run` (memory cap), `gh` (GitHub PR state), `az` (Azure DevOps PR state) — all three optional by NFR2.
+- Existing scripts touched: `bin/specclaw-verify`, `bin/specclaw-build`, `bin/specclaw-browser-lock`, `bin/specclaw-update-status`, `templates/config.yaml`, `skills/verify/SKILL.md`.
+- CI: new test script must be registered in `.github/workflows/ci.yml` alongside the existing two suites.
+- Version bump required in `plugins/specclaw/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, kept in sync (enforced by the `json` CI job).
+- No dependency on the host health-monitor thresholds in `claude-multi-channel-discord` — specclaw must behave well under the current ones.
+
+## Notes
+
+**Resolved from the proposal's open questions:**
+
+- **Q1 (heartbeat)** → `verify.heartbeat_seconds`, default `60`. `run-long` applies to *all* test/lint/build commands unconditionally rather than above a duration threshold: a threshold needs a duration estimate specclaw does not have, and since nothing is emitted before the first interval, fast commands are unaffected anyway. Simpler and more predictable (guardrail Rule 2).
+- **Q2 (memory cap)** → `verify.playwright.max_memory_mb`, default `4096`, not derived from `build.memory.per_agent_mb`. Locked at approval.
+- **Q3 (sidecar staleness)** → HEAD-commit stamping, plus the dirty-tree refusal from edge case 4. Locked at approval.
+- **Q4 (`verify.e2e` default)** → `last`. Locked at approval.
+- **Q5 (project enumeration)** → neither option. Parsing `playwright.config.*` (TS/JS) is not statically tractable and `npx playwright test --list` costs a process spawn per verify and needs a working install. Instead the operator declares `verify.playwright.projects` explicitly (FR12), empty by default. Zero new failure modes; costs one config line in the projects that need serialization.
+- **Q6 (single change)** → confirmed, with the four parts as independently-committable waves.
+
+**Deliberately out of scope:** non-idempotent Playwright fixtures in a consumer project (fixed, non-randomized entity names leaving orphaned rows → HTTP 409 conflicts on re-run) belong to that project, not specclaw. Fixing FR1–FR6 removes most of the mid-test kills that create those orphans.

--- a/.specclaw/changes/long-running-test-orchestration/status.md
+++ b/.specclaw/changes/long-running-test-orchestration/status.md
@@ -13,7 +13,7 @@
 | Design | ✅ Done | 4 seams, 10 key decisions, grounding sources cited |
 | Tasks | ✅ Done | 12 tasks in 5 waves (4 root causes + release) |
 | Build | ✅ Done | All 5 waves committed 2026-07-24/25; T1–T12 |
-| Verify | ⚪ Pending | |
+| Verify | ⚠️ Partial |  |
 
 ## Task Progress
 

--- a/.specclaw/changes/long-running-test-orchestration/status.md
+++ b/.specclaw/changes/long-running-test-orchestration/status.md
@@ -13,7 +13,7 @@
 | Design | ✅ Done | 4 seams, 10 key decisions, grounding sources cited |
 | Tasks | ✅ Done | 12 tasks in 5 waves (4 root causes + release) |
 | Build | ✅ Done | All 5 waves committed 2026-07-24/25; T1–T12 |
-| Verify | ⚠️ Partial |  |
+| Verify | ✅ Passed |  |
 
 ## Task Progress
 

--- a/.specclaw/changes/long-running-test-orchestration/status.md
+++ b/.specclaw/changes/long-running-test-orchestration/status.md
@@ -1,0 +1,40 @@
+# Status: Long-running test orchestration
+
+**Change:** long-running-test-orchestration
+**Started:** 2026-07-24
+**Last Updated:** 2026-07-24
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | ✅ Approved | Approved 2026-07-24; Q2/Q3/Q4/Q6 resolved at approval |
+| Spec | ✅ Done | 14 FR, 7 NFR, 16 AC, 17 edge cases |
+| Design | ✅ Done | 4 seams, 10 key decisions, grounding sources cited |
+| Tasks | ✅ Done | 12 tasks in 5 waves (4 root causes + release) |
+| Build | ✅ Done | All 5 waves committed 2026-07-24/25; T1–T12 |
+| Verify | ⚪ Pending | |
+
+## Task Progress
+
+**Completed:** 12 / 12
+**Failed:** 0
+
+## Test Status
+
+`run-long-orchestration-tests.sh` — **261 passed, 0 failed** (registered in the CI `test` job by T12).
+`run-memory-parallelism-tests.sh` — 16 passed, 0 failed.
+`run-parser-tests.sh` — 30 passed, 11 failed **locally only**: `jq` is not installed on this
+machine and 11 cases shell out to it (`jq: command not found`). Identical failures reproduce at
+`origin/main`, so this is an environment gap, not a regression. CI installs `jq` first.
+`shellcheck` is likewise unavailable locally, so T12's "no new findings" check runs in CI only.
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+
+## Issues
+
+- ℹ️ Evidence in `proposal.md` / `spec.md` / `design.md` was sanitized before the GitHub Issue was filed (2026-07-25): the consumer project, its repo/channel names, PR numbers, spec filenames and verbatim operator quotes were generalized. `specclaw-gh-sync` rebuilds the issue body from `proposal.md` on every `update`, and `.specclaw/changes/` is git-tracked in a public repo, so the source files — not just the issue — had to be scrubbed. Failure modes, counts and durations are preserved.
+**GitHub Issue:** #47

--- a/.specclaw/changes/long-running-test-orchestration/tasks.md
+++ b/.specclaw/changes/long-running-test-orchestration/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Long-running test orchestration
+
+**Change:** long-running-test-orchestration
+**Created:** 2026-07-24
+**Total Tasks:** 12
+
+## Summary
+
+Four independently-committable waves, one per root cause, ordered so each wave leaves the repo green and useful on its own. Wave 1 (detached exec + heartbeat + sidecar) removes the teardown loop and is the highest-value slice. Wave 2 adds the slow-test tier. Wave 3 bounds Playwright's fan-out and memory. Wave 4 fixes status staleness. Wave 5 is docs, CI registration, and the version bump.
+
+Waves 2, 3 and 4 depend on Wave 1 only where they execute commands through `run-long`; Wave 4 is fully independent and may be built in parallel with 2–3 if convenient.
+
+## Tasks
+
+### Wave 1 — Detached execution with heartbeat (root cause 1)
+
+- [x] `T1` — Create `specclaw-run-long`: detached exec, heartbeat, capped tail, HEAD-stamped sidecar
+  - Files: `plugins/specclaw/bin/specclaw-run-long`
+  - Estimate: large
+  - Kind: impl
+  - Notes: FR1–FR5. Keep `eval` for the child (edge case 2 — pipes/`&&`/env prefixes must keep working). Heartbeats to **stderr**, capped tail to **stdout**, full log to disk. Sidecar is flat `key=value` (no jq, NFR3) with `exit`/`duration_s`/`log`/`head`/`dirty`/`cmd`/`interrupted`. Log name carries a PID discriminator (edge case 5). `--reuse` requires matching HEAD **and** a clean tree, and refuses when there is no HEAD (edge cases 3, 4). `trap` INT/TERM kills the child process *group* and writes an interrupted sidecar (NFR7). Clamp a 0/non-integer heartbeat to the default (edge case 7). Fall back to `mktemp`, then to inline execution, if the log dir is unwritable (edge case 1, NFR2).
+
+- [x] `T2` — Route `specclaw-verify`'s `run_capped()` through `run-long`
+  - Files: `plugins/specclaw/bin/specclaw-verify`
+  - Estimate: medium
+  - Kind: refactor
+  - Depends: T1
+  - Notes: FR6. `bin/specclaw-verify:63-81` is the seam. Captured output and exit codes must be unchanged — the existing 100-line cap and `... (truncated, N total lines)` marker are preserved by `run-long`, so the payload stays byte-identical (AC6). Pass `--phase` per command (test/lint/build) and `--log-dir <change_dir>/logs`.
+
+- [x] `T3` — Route `specclaw-build cmd_finalize` test/lint/build through `run-long`
+  - Files: `plugins/specclaw/bin/specclaw-build`
+  - Estimate: small
+  - Kind: refactor
+  - Depends: T1
+  - Notes: FR6. Three `if ! eval "$X" >&2 2>&1` blocks at `bin/specclaw-build:337-361`. Keep the existing `errors+=(...)` messages verbatim so failure reporting does not shift.
+
+- [x] `T4` — Regression tests for Wave 1
+  - Files: `plugins/specclaw/tests/run-long-orchestration-tests.sh`
+  - Estimate: medium
+  - Kind: test
+  - Depends: T1
+  - Notes: AC1–AC5 plus edge cases 1–7 and 16. Bash + coreutils only (NFR3); follow the structure of `tests/run-memory-parallelism-tests.sh` (temp workdir, EXIT-trap cleanup, `pass`/`fail` counters, spawned-PID tracking). AC5 needs a side-effecting command (append to a counter file) to prove non-execution on reuse. AC3 uses `--heartbeat 1` against a 3s command, and asserts a sub-interval command emits zero heartbeat lines.
+
+### Wave 2 — Slow-test tier and e2e ordering (root cause 2)
+
+- [x] `T5` — Add `build.e2e_command`, `verify.e2e`, `verify.heartbeat_seconds` to the config template
+  - Files: `plugins/specclaw/templates/config.yaml`
+  - Estimate: small
+  - Kind: config
+  - Notes: FR7. `e2e_command: ""` beside `test_command`; `verify.e2e: last` with the `skip | last | always` values commented; `verify.heartbeat_seconds: 60`. Comments must state that `test_command` is the fast tier and that absent keys mean unchanged behaviour.
+
+- [x] `T6` — Implement e2e policy + `e2e_state` in `specclaw-verify`, and exit-137 classification
+  - Files: `plugins/specclaw/bin/specclaw-verify`, `plugins/specclaw/skills/verify/SKILL.md`
+  - Estimate: medium
+  - Kind: impl
+  - Depends: T2, T5
+  - Notes: FR8, FR9, FR13. Order lint → build → test, then e2e per policy. Payload gains `e2e_output`, `e2e_state` (`passed|failed|skipped_policy|skipped_gate_failure|not_configured`) and `e2e_memory_limited`. Enumerated state, not an empty-output sentinel — a skip must be structurally un-mistakable for a pass. Unrecognised policy → warn, fall back to `last` (edge case 9); empty `test_command` under `last` is vacuously passing (edge case 10). SKILL.md must tell the verify agent to report a skip as a skip.
+
+- [x] `T7` — Tests for the e2e tier
+  - Files: `plugins/specclaw/tests/run-long-orchestration-tests.sh`
+  - Estimate: medium
+  - Kind: test
+  - Depends: T6
+  - Notes: AC6–AC9 plus edge cases 8–10. AC6 is the backward-compatibility proof: same fixture with no `e2e_command` must produce byte-identical `collect` output to v0.5.9 — capture the v0.5.9 baseline before T6 lands.
+
+### Wave 3 — Bounded Playwright invocation (root cause 3)
+
+- [x] `T8` — Add `wrap` to `specclaw-browser-lock` + the two new playwright config keys
+  - Files: `plugins/specclaw/bin/specclaw-browser-lock`, `plugins/specclaw/templates/config.yaml`
+  - Estimate: large
+  - Kind: impl
+  - Notes: FR10–FR12. `wrap` **prints** the transformed command, never executes it (NFR6). Order: `--workers=1` only for Playwright commands and only when `--workers` is absent (AC10, edge case 13) → one `--project=<quoted>` invocation per `verify.playwright.projects` entry joined with `&&`, single invocation when empty (AC12, edge case 12) → `systemd-run --user --scope -q -p MemoryMax=<N>M` prefix. **Probe** systemd-run usability (run a trivial scope once, cache the result) rather than trusting `command -v` (edge case 11). Exit `0` = capped, `10` = emitted uncapped + warn (NFR2). New keys: `max_memory_mb: 4096`, `projects: []`.
+
+- [x] `T9` — Wire the e2e path through `wrap` and report memory kills
+  - Files: `plugins/specclaw/bin/specclaw-verify`, `plugins/specclaw/skills/verify/SKILL.md`
+  - Estimate: small
+  - Kind: impl
+  - Depends: T6, T8
+  - Notes: FR13. acquire slot → `wrap` the e2e command → `run-long` it → release slot (release must happen even on failure). Use `wrap`'s exit code to set `e2e_memory_limited`, so an exit `137` under a cap is reported as *memory limit exceeded, cap NM* and the same code without a cap stays a plain failure (AC13).
+
+- [x] `T10` — Tests for `wrap`
+  - Files: `plugins/specclaw/tests/run-long-orchestration-tests.sh`
+  - Estimate: medium
+  - Kind: test
+  - Depends: T8
+  - Notes: AC10–AC13 plus edge cases 12–13. Pure string assertions. Cover systemd-run present via a stub on `PATH` and absent via `PATH` removal; assert the exit-code convention both ways.
+
+### Wave 4 — PR-aware status (root cause 4)
+
+- [x] `T11` — Add PR state to `specclaw-update-status`, with tests
+  - Files: `plugins/specclaw/bin/specclaw-update-status`, `plugins/specclaw/tests/run-long-orchestration-tests.sh`
+  - Estimate: medium
+  - Kind: impl
+  - Notes: FR14, AC14–AC15. `pr_state_for <change>` resolves the branch as `<git.branch_prefix><change_name>`, tries `gh` then Azure, memoises per run, wraps every call in `timeout 5` and `|| true` (NFR5 and learning `[L2]` — a no-match `grep\|head\|sed` in command substitution under `set -e` aborts the script). Newest PR by `updatedAt`, real state rendered — a merged PR must not read as open (edge case 15). The `"proposal ready, awaiting planning"` branch at `bin/specclaw-update-status:48-51` is reachable only with no `tasks.md` **and** no PR. `SPECCLAW_STATUS_NO_PR=1` disables the block and is the seam the byte-identical-output test uses. Tests stub the lookup for both success and failure paths.
+
+### Wave 5 — Docs, CI, release
+
+- [x] `T12` — Register the new suite in CI, document the five new keys, bump the version
+  - Files: `.github/workflows/ci.yml`, `README.md`, `plugins/specclaw/CLAUDE.md`, `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  - Estimate: small
+  - Kind: docs
+  - Depends: T4, T7, T10, T11
+  - Notes: AC16. Add `run-long-orchestration-tests.sh` to the `test` job beside the existing two suites — an unregistered suite silently never runs. Add `specclaw-run-long` to the Scripts table in `plugins/specclaw/CLAUDE.md`. Bump `plugin.json` and `marketplace.json` to the same version (the `json` CI job asserts they match). Confirm `shellcheck` shows no new findings on the changed bins.
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed

--- a/.specclaw/changes/long-running-test-orchestration/verify-report.md
+++ b/.specclaw/changes/long-running-test-orchestration/verify-report.md
@@ -1,0 +1,52 @@
+# Verify Report: long-running-test-orchestration
+
+**Verdict:** PARTIAL
+**Date:** 2026-07-25
+
+## Summary
+
+The implementation covers all 16 acceptance criteria structurally. 261 of 261 tests in the new `run-long-orchestration-tests.sh` suite pass; the existing memory-parallelism suite (16/16) is unaffected. The core paths for AC1–AC15 were confirmed both by code reading and by targeted live-shell verification (AC6 byte-identical golden, AC13 cap-detection logic, AC15 rendering). Two items could not be fully verified in this environment: `shellcheck` is absent locally (AC16 "no new shellcheck findings" sub-criterion), and the "existing suites still pass" portion of AC16 is partially degraded by a pre-existing `jq: command not found` failure in `run-parser-tests.sh` that also exists on `origin/main`. CI (`ci.yml`) registers the new suite and runs `shellcheck` on every push, which is the appropriate gating mechanism for those two gaps.
+
+## Acceptance Criteria
+
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| AC1 — `run-long` exits 3, tail holds `hi`, log on disk | MET | `run-long-orchestration-tests.sh` Case 1–2; code path `specclaw-run-long:291` |
+| AC2 — 500 lines → 100-line tail + truncation marker, 500 on disk | MET | Case 3–4; `specclaw-run-long:280-287` |
+| AC3 — heartbeat_seconds=1 → ≥2 heartbeat lines; sub-interval → none | MET | Case 5–6; `specclaw-run-long:237-254` |
+| AC4 — `.result` sidecar on pass and fail with all required keys | MET | Cases 8–9; `specclaw-run-long:268-276`; sidecar key set confirmed (`exit`, `duration_s`, `log`, `head`, `dirty`, `cmd`, `interrupted`) |
+| AC5 — `--reuse` hits on matching clean HEAD, misses after commit | MET | Cases 10–13; dirty-tree, empty-HEAD, and cached-dirty paths each have a separate case with a side-effecting counter file |
+| AC6 — no e2e keys → payload byte-identical to v0.5.9 | MET | Case 28 (golden comparison); confirmed live: `yaml_has_key` returns false for both `e2e_command` and `e2e` on the baseline fixture; `e2e_json` emitted only under `e2e_configured=true` (`specclaw-verify:420`) |
+| AC7 — `last` + failing lint skips e2e, names the gate | MET | Case 30; `specclaw-verify:354-362`; `e2e_state=skipped_gate_failure`, failing gate named in `e2e_output` |
+| AC8 — `skip` never runs e2e, cannot read as a pass | MET | Case 29; `e2e_state=skipped_policy`, `e2e_output` contains "This is NOT a pass"; all five skip states carry an explicit not-a-pass annotation in their output strings (`specclaw-verify:347-348`, 350-351, 362`) |
+| AC9 — `always` runs e2e even when lint failed | MET | Case 31; marker file written despite `lint_passed=false`; `e2e_state=passed` in payload |
+| AC10 — `wrap` appends `--workers=1`; existing `--workers` preserved | MET | Cases 43 (both `--workers=2` and space-separated `--workers 4` forms); `specclaw-browser-lock:324` |
+| AC11 — `systemd-run` present → `MemoryMax=4096M`; absent/unusable → unwrapped + warning | MET | Cases 41–42; both "missing from PATH" and "present-but-failing" paths tested separately; `systemd_run_usable()` probes with a live invocation (`specclaw-browser-lock:219-227`) |
+| AC12 — projects fan-out; absent/empty → single invocation, no `--project` | MET | Cases 45–47 (inline flow and block sequence forms); empty list case confirmed |
+| AC13 — exit 137 under cap → memory-limit message with cap value; same code without cap → plain failure | MET | Cases 37–38; cap detection at `specclaw-verify:374,379-380` (`wrap_rc -eq 0` AND `MemoryMax=` in wrapped string); uncapped path (wrap_rc=10) leaves `e2e_cap` empty so exit 137 is a plain failure |
+| AC14 — stubbed open PR renders in line; stubbed failing lookup → unchanged output, exit 0 | MET | Cases 19–20; failing stub confirmed byte-identical to `SPECCLAW_STATUS_NO_PR=1` baseline |
+| AC15 — all-[x] tasks + open PR never renders as "awaiting planning" | MET | Case 22; delta (tasks + PR) and epsilon (proposal-only + PR) both confirmed active, not pending; live run confirmed the STATUS.md text |
+| AC16 — existing suites pass; shellcheck no new findings | UNVERIFIED | New suite registered in `ci.yml:21`; parser suite has pre-existing 11 failures due to `jq: command not found` on this machine (identical on `origin/main` — not a regression); `shellcheck` not installed locally |
+
+## Test Results
+
+| Suite | Result |
+|-------|--------|
+| `tests/run-long-orchestration-tests.sh` | 261 passed, 0 failed |
+| `tests/run-memory-parallelism-tests.sh` | 16 passed, 0 failed |
+| `tests/run-parser-tests.sh` | 30 passed, 11 failed — `jq: command not found`; identical failure count on `origin/main`; not a regression from this branch |
+| `shellcheck plugins/specclaw/bin/specclaw-*` | Cannot run — `shellcheck` not installed on this machine; runs in CI (`ci.yml:29`) |
+
+## Findings
+
+1. **`e2e_configured` detection is narrow** (`specclaw-verify:299`): the gate fires on `e2e_command` or `e2e` keys anywhere in the file, not scoped to `build.` / `verify.`. A config with an unrelated comment containing "e2e_command:" would falsely set `e2e_configured=true`. In practice the config format does not produce this, and the test suite confirms the baseline case (AC6). Low risk, not a regression from spec intent.
+
+2. **`failed` count shows "| 0 failed"** when `failed=0` in `specclaw-update-status:121`. The string `${failed:+| $failed failed}` expands to `| 0 failed` because `"0"` is a non-empty string in bash. The test in Case 22 accounts for this ("**delta** — 2/2 tasks (100%) | 0 failed | PR #11 open") so the output is correct-by-spec. Slightly noisy but consistent with what the tests assert; not a bug per the spec.
+
+3. **`specclaw-gh-sync` change is in scope** (modified in the diff). The change adds a sentinel write to `status.md` when GitHub Issues are disabled. This is outside the spec for `long-running-test-orchestration` and carries no tests in this suite. No AC is at risk, but it is an untracked scope addition.
+
+## Unverified in this environment
+
+- **`shellcheck` findings on changed `bin/` scripts** — `shellcheck` is not installed locally. The CI `shellcheck` job runs on every push with `shellcheck plugins/specclaw/bin/specclaw-* || true` (note: `|| true` means CI does not block on findings; findings are advisory only).
+- **Real Playwright / systemd run** — No browser installed; all Playwright and `systemd-run` paths are covered by stubs per NFR6.
+- **`run-parser-tests.sh` baseline** — 11 tests fail due to `jq` absent on this machine; failure is pre-existing on `origin/main` and not caused by this branch.

--- a/.specclaw/changes/long-running-test-orchestration/verify-report.md
+++ b/.specclaw/changes/long-running-test-orchestration/verify-report.md
@@ -1,11 +1,11 @@
 # Verify Report: long-running-test-orchestration
 
-**Verdict:** PARTIAL
+**Verdict:** PASS
 **Date:** 2026-07-25
 
 ## Summary
 
-The implementation covers all 16 acceptance criteria structurally. 261 of 261 tests in the new `run-long-orchestration-tests.sh` suite pass; the existing memory-parallelism suite (16/16) is unaffected. The core paths for AC1–AC15 were confirmed both by code reading and by targeted live-shell verification (AC6 byte-identical golden, AC13 cap-detection logic, AC15 rendering). Two items could not be fully verified in this environment: `shellcheck` is absent locally (AC16 "no new shellcheck findings" sub-criterion), and the "existing suites still pass" portion of AC16 is partially degraded by a pre-existing `jq: command not found` failure in `run-parser-tests.sh` that also exists on `origin/main`. CI (`ci.yml`) registers the new suite and runs `shellcheck` on every push, which is the appropriate gating mechanism for those two gaps.
+The implementation covers all 16 acceptance criteria structurally. 261 of 261 tests in the new `run-long-orchestration-tests.sh` suite pass; the existing memory-parallelism suite (16/16) is unaffected. The core paths for AC1–AC15 were confirmed both by code reading and by targeted live-shell verification (AC6 byte-identical golden, AC13 cap-detection logic, AC15 rendering). AC16 was initially UNVERIFIED because neither `shellcheck` nor `jq` is installed on the build host; it was closed against CI instead. The first PR CI run turned out to expose **22 new shellcheck findings** on the changed bins (21 SC2317 in `specclaw-run-long`, 1 SC2064 in `specclaw-verify`) — so the sub-criterion was genuinely failing, not merely unobservable. Both codes are artefacts of shellcheck not modelling trap invocation and were suppressed with rationale in `15eca0d`. Diffing CI run 30152305952 against main's 30059040240 now shows **0 new findings** on all five changed bins, and the parser suite passes in CI. Verdict raised to PASS.
 
 ## Acceptance Criteria
 
@@ -26,7 +26,7 @@ The implementation covers all 16 acceptance criteria structurally. 261 of 261 te
 | AC13 — exit 137 under cap → memory-limit message with cap value; same code without cap → plain failure | MET | Cases 37–38; cap detection at `specclaw-verify:374,379-380` (`wrap_rc -eq 0` AND `MemoryMax=` in wrapped string); uncapped path (wrap_rc=10) leaves `e2e_cap` empty so exit 137 is a plain failure |
 | AC14 — stubbed open PR renders in line; stubbed failing lookup → unchanged output, exit 0 | MET | Cases 19–20; failing stub confirmed byte-identical to `SPECCLAW_STATUS_NO_PR=1` baseline |
 | AC15 — all-[x] tasks + open PR never renders as "awaiting planning" | MET | Case 22; delta (tasks + PR) and epsilon (proposal-only + PR) both confirmed active, not pending; live run confirmed the STATUS.md text |
-| AC16 — existing suites pass; shellcheck no new findings | UNVERIFIED | New suite registered in `ci.yml:21`; parser suite has pre-existing 11 failures due to `jq: command not found` on this machine (identical on `origin/main` — not a regression); `shellcheck` not installed locally |
+| AC16 — existing suites pass; shellcheck no new findings | MET | New suite registered in `ci.yml:21`. Verified in CI, not locally: parser suite passes in CI run 30152305952 (its 11 local failures are `jq: command not found`, identical on `origin/main`). Shellcheck findings on the changed bins diffed between CI run 30152305952 (head) and 30059040240 (main): **0 new**. The 22 findings the first PR run exposed were fixed in `15eca0d`. |
 
 ## Test Results
 
@@ -47,6 +47,6 @@ The implementation covers all 16 acceptance criteria structurally. 261 of 261 te
 
 ## Unverified in this environment
 
-- **`shellcheck` findings on changed `bin/` scripts** — `shellcheck` is not installed locally. The CI `shellcheck` job runs on every push with `shellcheck plugins/specclaw/bin/specclaw-* || true` (note: `|| true` means CI does not block on findings; findings are advisory only).
+- **`shellcheck` findings on changed `bin/` scripts** — resolved in CI rather than locally; shellcheck is still not installed on this host. Note the CI job runs `shellcheck plugins/specclaw/bin/specclaw-* || true`, so it reports `pass` regardless of findings: a green check is **not** evidence of a clean lint. The finding counts had to be read out of the job log and diffed against main by hand. Worth making that job fail on new findings, or the AC has no automatic gate.
 - **Real Playwright / systemd run** — No browser installed; all Playwright and `systemd-run` paths are covered by stubs per NFR6.
 - **`run-parser-tests.sh` baseline** — 11 tests fail due to `jq` absent on this machine; failure is pre-existing on `origin/main` and not caused by this branch.

--- a/.specclaw/config.yaml
+++ b/.specclaw/config.yaml
@@ -43,6 +43,12 @@ build:
     fable_max_fraction: 0.2                     # cap Fable share of tasks per build
     cache: true                                 # persist synthesized specs under changes/<change>/agents/
 
+# Workflow gates
+workflow:
+  strict: true
+  code_review: true                # Spawn the code-reviewer agent on /specclaw:verify
+  code_review_block: false         # Do not hard-block /specclaw:pr on CHANGES_REQUESTED yet
+
 # Notifications
 notifications:
   enabled: true

--- a/.specclaw/learnings.md
+++ b/.specclaw/learnings.md
@@ -110,3 +110,48 @@ yaml_get in specclaw-build-context does not strip inline YAML comments — commi
 Port yaml_val's comment-stripping into yaml_get (or reuse yaml_val) in a lifecycle-bug-fixes follow-up change.
 
 ---
+
+## [L8] design_gap — specclaw-browser-lock cmd_acquire writes $$ — the PID of ...
+
+**When:** 2026-07-25 05:37 UTC
+**Category:** design_gap
+**Priority:** high
+**Status:** pending
+
+### Detail
+specclaw-browser-lock cmd_acquire writes $$ — the PID of the short-lived browser-lock process itself — into the slot file, so slot_live() always sees a dead PID: 'status' reports 0/N while a slot is demonstrably held, and a concurrent acquire reclaims a live slot as stale. verify.playwright.max_browsers therefore does not gate concurrency for any subprocess caller (only for a caller that sources the script). Pre-existing since v0.5.9, found while wiring T9.
+
+### Action
+Follow-up change: record the caller's PID (or a heartbeat/flock) instead of $$, and add a concurrency test that two sequential acquires cannot both win the same slot
+
+---
+
+## [L9] design_gap — yaml_val strips a trailing single quote unconditionally a...
+
+**When:** 2026-07-25 05:37 UTC
+**Category:** design_gap
+**Priority:** medium
+**Status:** pending
+
+### Detail
+yaml_val strips a trailing single quote unconditionally after stripping double quotes, so any config value ending in ' — e.g. test_command: "sh -c 'npm test'" — is read back truncated and dies with 'unexpected EOF while looking for matching'. Pattern is duplicated across 6+ bin scripts.
+
+### Action
+Fix the quote-stripping to be paired-only, in one shared helper; add a parser test with a nested-quote command
+
+---
+
+## [L10] design_gap — specclaw-verify-context never forwards e2e evidence to th...
+
+**When:** 2026-07-25 05:37 UTC
+**Category:** design_gap
+**Priority:** medium
+**Status:** pending
+
+### Detail
+specclaw-verify-context never forwards e2e evidence to the verify agent: it maps only test_output/lint_output/build_output, and references/agent-prompts.md has no {{e2e_output}} placeholder. FR9's guarantee currently depends on the agent voluntarily re-reading collect output.
+
+### Action
+Add an {{e2e_output}}/e2e_state slot to specclaw-verify-context and agent-prompts.md — neither file is in this change's file map, so either extend T12 or open a follow-up
+
+---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,17 @@ Both files must stay in sync. Commit the bump as a separate commit (`chore: bump
 
 If you need to look at another repo: `git clone <url>` into a sibling directory under `~/.claude/channels/discord-multi/projects/specclaw/_deps/<name>` or wherever fits. Don't pollute this working tree with unrelated code.
 
+# Interactive progress reporting (REQUIRED)
+
+The operator cannot see your terminal. During any multi-step task (specclaw build, verify, refactor), post a brief `mcp__mcd__reply` update at every milestone — do not go silent until the end:
+
+- When you start a task/wave: one line saying what you're doing and rough ETA.
+- When a task, wave, or subagent batch completes: one line with the result (e.g. "T2 done — run_capped routed via run-long, tests green. Starting T3.").
+- Before any stretch likely to take >5 minutes without tool output (large synthesis, long test run): say so first ("Long verify run starting, ~10 min, will report back").
+- On errors or unexpected findings: report immediately, don't batch for the summary.
+
+One short line per update. This is not optional — silence longer than ~5 minutes during active work is a bug.
+
 # Discord conventions
 
 Inbound messages arrive wrapped in `<channel source="discord" ...>BODY</channel>` envelopes — BODY is what the operator typed. Respond by calling `mcp__mcd__reply` with `{ text, reply_to? }`. Do NOT call `mcp__discord__reply`. Don't print transcript text outside the reply tool — Discord users only see what `mcp__mcd__reply` emits. Keep replies brief; for long output, post the highlights and offer to dig in.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ Set `workflow.code_review: true` to enable an automated code review step inside 
 
 Set `workflow.code_review_block: true` to hard-block `/specclaw:pr` when the review verdict is `CHANGES_REQUESTED`. Defaults to `false` so existing projects are unaffected.
 
+### Long-Running Test Suites
+
+Suites that take minutes used to look like hangs: no output while they ran, so a session could tear itself down mid-run and then re-run the whole thing from scratch. `specclaw-run-long` now executes every configured test/lint/build/e2e command detached — heartbeats go to stderr, a capped tail to stdout, and the full log plus a HEAD-stamped sidecar to `<change>/logs/`. Because the sidecar records the commit and tree state, a re-verify at the same clean HEAD reuses the previous result instead of paying for it twice.
+
+Browser suites get their own tier, so a slow e2e run never blocks the fast feedback loop:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `build.e2e_command` | `""` | Slow tier (browser/e2e), run separately from `test_command`. Empty → no e2e tier. |
+| `verify.e2e` | `last` | When the slow tier runs: `skip`, `last` (only after lint/build/test pass), or `always`. |
+| `verify.heartbeat_seconds` | `60` | Liveness heartbeat interval for long commands. |
+| `verify.playwright.max_memory_mb` | `4096` | Memory ceiling per e2e invocation, applied via `systemd-run --scope`. |
+| `verify.playwright.projects` | `[]` | Playwright project names to run one-per-invocation, sequentially. Empty → a single invocation. |
+
+Every key is optional and absent keys mean unchanged behaviour. Playwright commands are pinned to `--workers=1` unless you set `--workers` yourself, and are capped at `max_memory_mb` when `systemd-run` is usable (probed, not assumed — an unusable one runs the command uncapped and says so). A run killed at the cap is reported as *memory limit exceeded*, never as an ordinary test failure. Skips are reported as skips: verify's payload carries an explicit `e2e_state` of `passed`, `failed`, `skipped_policy`, `skipped_gate_failure`, or `not_configured`, so a suite that never ran can't be read as a green one.
+
 ### Evidence-Grounded Agent Payloads
 
 Agent prompts follow published prompt-engineering guidance from Anthropic and OpenAI: coding agents are instructed to investigate before answering (never speculate about unopened code) and to write general-purpose solutions (tests verify correctness, they don't define it); verify and review agents must quote the exact spec/code/output lines a verdict rests on — unquotable claims are dropped; payloads put longform context first and the task last; loop fix agents carry reversibility rules (no force-push, no `--no-verify`, no destructive shortcuts to green a gate).

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -44,7 +44,8 @@ All executable scripts live in `bin/`. Key ones:
 | `specclaw-build-context` | Build coding agent payload (includes context.md; `--failure-record`/`--reflection` for loop remediation) |
 | `specclaw-loop` | Autonomous loop controller: `init` / `gates` / `decide` / `guard-tests` / `log-turn` / `escalate` / `ci-poll` / `done` |
 | `specclaw-update-context` | Output LLM prompt to rewrite context.md post-merge |
-| `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard |
+| `specclaw-run-long` | Run a long command detached: heartbeats to stderr, capped tail to stdout, full log + HEAD-stamped sidecar on disk; `--reuse` skips a re-run when HEAD matches and the tree is clean |
+| `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard (resolves open/merged PR state per change) |
 | `specclaw-gh-sync` | GitHub Issues sync |
 | `specclaw-pr` | Create GitHub PR (enforces test policy, triggers context update) |
 | `specclaw-validate-change` | Check phase prerequisites |

--- a/plugins/specclaw/bin/specclaw-browser-lock
+++ b/plugins/specclaw/bin/specclaw-browser-lock
@@ -18,7 +18,7 @@ POLL_INTERVAL_SECONDS=0.5
 
 usage() {
   cat <<'EOF'
-Usage: specclaw-browser-lock <specclaw_dir> <acquire|release <slot_id>|status>
+Usage: specclaw-browser-lock <specclaw_dir> <acquire|release <slot_id>|status|wrap <cmd>>
 
 Subcommands:
   acquire              Claim a free slot (blocks/polls until one is free or a
@@ -27,8 +27,15 @@ Subcommands:
                        exits 0 (fail-open).
   release <slot_id>    Free the named slot. Idempotent.
   status               Print `held/max` (live-PID slots vs max_browsers).
+  wrap <cmd>           Print (never execute) a memory-bounded form of <cmd>:
+                       `--workers=1` for Playwright commands that don't set it,
+                       one `--project=` invocation per verify.playwright.projects
+                       entry joined with `&&`, each prefixed with a
+                       `systemd-run --scope -p MemoryMax=<N>M` cap.
+                       Exit 0 = capped, 10 = emitted uncapped (warned).
 
 N (max slots) = verify.playwright.max_browsers in config.yaml (default 2).
+Memory cap    = verify.playwright.max_memory_mb in config.yaml (default 4096).
 
 Options:
   -h, --help   Show this help message
@@ -116,6 +123,109 @@ read_max_browsers() {
   echo "$n"
 }
 
+# Normalize a raw yaml scalar: strip an inline ` #` comment (leading whitespace
+# required, so a `#` inside a value survives), trim, then unwrap one layer of
+# matching quotes.
+clean_scalar() {
+  local v="$1"
+  if [[ "$v" =~ ^(.*[^[:space:]])?[[:space:]]+#.*$ ]]; then
+    v="${BASH_REMATCH[1]}"
+  fi
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  if [[ ${#v} -ge 2 ]]; then
+    case "$v" in
+      \"*\") v="${v#\"}"; v="${v%\"}" ;;
+      \'*\') v="${v#\'}"; v="${v%\'}" ;;
+    esac
+  fi
+  printf '%s' "$v"
+}
+
+# Print the body lines of the verify.playwright: block (yaml_val handles one
+# nesting level only, so the two-level-deep block is scanned out directly).
+# Block ends at the first line indented less than its keys.
+playwright_block() {
+  local config="$1"
+  [[ -f "$config" ]] || return 0
+  awk '
+    /^[a-zA-Z_]/                { inv = ($0 ~ /^verify:/); inp = 0 }
+    inv && /^  playwright:/     { inp = 1; next }
+    inp && /^    /              { print; next }
+    inp                         { inp = 0 }
+  ' "$config"
+}
+
+# Resolve verify.playwright.max_memory_mb (default 4096).
+read_max_memory_mb() {
+  local mb=""
+  mb="$(playwright_block "$1" | sed -n 's/^    max_memory_mb:[[:space:]]*//p' | head -1)" || true
+  mb="$(clean_scalar "$mb")"
+  [[ "$mb" =~ ^[0-9]+$ ]] && [[ "$mb" -ge 1 ]] || mb=4096
+  echo "$mb"
+}
+
+# Print verify.playwright.projects entries, one per line (no output = empty).
+# Supports both yaml list forms:
+#   inline flow:     projects: [desktop, "my project"]
+#   block sequence:  projects:
+#                      - desktop
+read_projects() {
+  local block inline body item
+  block="$(playwright_block "$1")" || true
+  [[ -n "$block" ]] || return 0
+
+  inline="$(printf '%s\n' "$block" | sed -n 's/^    projects:[[:space:]]*//p' | head -1)" || true
+  inline="$(clean_scalar "$inline")"
+  case "$inline" in
+    \[*\]*)
+      body="${inline#*[}"; body="${body%]*}"
+      local IFS=','
+      for item in $body; do
+        item="$(clean_scalar "$item")"
+        [[ -n "$item" ]] && printf '%s\n' "$item"
+      done
+      return 0
+      ;;
+  esac
+
+  printf '%s\n' "$block" | awk '
+    /^    projects:[[:space:]]*$/ { inblk = 1; next }
+    inblk {
+      if ($0 ~ /^[[:space:]]*-[[:space:]]*/) { sub(/^[[:space:]]*-[[:space:]]*/, ""); print; next }
+      if ($0 ~ /^[[:space:]]*#/ || $0 ~ /^[[:space:]]*$/) { next }
+      inblk = 0
+    }
+  ' | while IFS= read -r item; do
+        item="$(clean_scalar "$item")"
+        [[ -n "$item" ]] && printf '%s\n' "$item"
+      done || true
+}
+
+# Single-quote a string so a shell re-parses it as one literal word.
+shell_quote() {
+  local s="$1"
+  s="${s//\'/\'\\\'\'}"
+  printf "'%s'" "$s"
+}
+
+# Is `systemd-run --user --scope` actually usable here? Probed once and cached
+# for the process: `command -v` succeeds in containers where the call fails, and
+# a false-positive cap silently does nothing (edge case 11). Bounded by
+# `timeout` so a wedged systemd/dbus can never stall a build (NFR2).
+SYSTEMD_RUN_USABLE=""
+systemd_run_usable() {
+  if [[ -z "$SYSTEMD_RUN_USABLE" ]]; then
+    if command -v systemd-run >/dev/null 2>&1 &&
+       timeout 5 systemd-run --user --scope -q true >/dev/null 2>&1; then
+      SYSTEMD_RUN_USABLE=yes
+    else
+      SYSTEMD_RUN_USABLE=no
+    fi
+  fi
+  [[ "$SYSTEMD_RUN_USABLE" == "yes" ]]
+}
+
 # Is a slot occupied by a live process? slot_live <slot_dir>
 # Returns 0 (live) only if the pid file holds a PID that `kill -0` accepts.
 slot_live() {
@@ -197,6 +307,61 @@ cmd_status() {
   echo "${held}/${n}"
 }
 
+# ─── wrap ───────────────────────────────────────────────────────────────────
+
+# Print a memory-bounded form of the given command. Prints only — execution is
+# the caller's job (specclaw-run-long), which keeps every transformation a pure
+# string assertion in tests (NFR6).
+# Exit 0 = a memory cap was applied, 10 = emitted uncapped (warned) (NFR2).
+cmd_wrap() {
+  local specclaw_dir="$1" cmd="$2"
+  [[ -n "$cmd" ]] || { warn "wrap requires a command string"; return 1; }
+  local config="$specclaw_dir/config.yaml"
+
+  # 1. Playwright worker cap: only for Playwright commands (a Cypress or plain
+  #    script must not grow a --workers flag), and only when the command does
+  #    not already choose a worker count.
+  if [[ "$cmd" == *playwright* ]] && [[ "$cmd" != *--workers* ]]; then
+    cmd="$cmd --workers=1"
+  fi
+
+  # 2. Project fan-out: one invocation per configured project, run in sequence.
+  #    Empty list → a single invocation, project selection left to the project's
+  #    own playwright config.
+  local -a invocations=()
+  local project
+  while IFS= read -r project; do
+    [[ -n "$project" ]] || continue
+    invocations+=( "$cmd --project=$(printf '%q' "$project")" )
+  done < <(read_projects "$config")
+  [[ ${#invocations[@]} -gt 0 ]] || invocations=( "$cmd" )
+
+  # 3. Memory cap: put each invocation in its own bounded transient scope. The
+  #    invocation goes through `bash -c` because a command string may carry env
+  #    prefixes, pipes or `&&` (edge case 2) — `systemd-run <string>` execs a
+  #    binary, so `CI=1 npx …` would fail and `a | b` would leave `b` outside
+  #    the cap. Quoting, not rewriting, so the command itself is unchanged.
+  local mb capped=yes
+  mb="$(read_max_memory_mb "$config")"
+  systemd_run_usable || {
+    capped=no
+    warn "browser-lock: systemd-run unusable — emitting command uncapped (MemoryMax=${mb}M not applied)"
+  }
+
+  local out="" inv
+  for inv in "${invocations[@]}"; do
+    [[ -z "$out" ]] || out="$out && "
+    if [[ "$capped" == "yes" ]]; then
+      out="${out}systemd-run --user --scope -q -p MemoryMax=${mb}M bash -c $(shell_quote "$inv")"
+    else
+      out="$out$inv"
+    fi
+  done
+  printf '%s\n' "$out"
+
+  [[ "$capped" == "yes" ]] || return 10
+}
+
 # ─── Main dispatch ────────────────────────────────────────────────────────────
 
 [[ $# -gt 0 ]] || { usage; exit 1; }
@@ -215,5 +380,6 @@ case "$subcmd" in
   acquire) cmd_acquire "$specclaw_dir" ;;
   release) cmd_release "$specclaw_dir" "${1:-}" ;;
   status)  cmd_status "$specclaw_dir" ;;
+  wrap)    cmd_wrap "$specclaw_dir" "$*" ;;
   *)       warn "Unknown subcommand: $subcmd (try --help)"; usage; exit 1 ;;
 esac

--- a/plugins/specclaw/bin/specclaw-build
+++ b/plugins/specclaw/bin/specclaw-build
@@ -316,6 +316,23 @@ cmd_commit() {
 
 # ─── finalize ─────────────────────────────────────────────────────────────────
 
+# Run a configured check command through specclaw-run-long so a long suite stays
+# observable while running (heartbeats on stderr) and contributes only a capped
+# tail to the transcript, with the full log kept on disk (FR6).
+# All output lands on stderr, exactly as the previous inline eval did — stdout
+# stays reserved for finalize's summary JSON. Returns the command's exit code.
+# Fail-open (NFR2): if run-long is not resolvable, run inline as before.
+run_long_check() {
+  local phase="$1" log_dir="$2" cmd="$3"
+  local runner="$SCRIPT_DIR/specclaw-run-long"
+  if [[ -x "$runner" ]]; then
+    "$runner" --log-dir "$log_dir" --phase "$phase" -- "$cmd" >&2
+  else
+    warn "specclaw-run-long not found at $runner — running $phase command inline"
+    eval "$cmd" >&2 2>&1
+  fi
+}
+
 cmd_finalize() {
   [[ $# -ge 2 ]] || die "finalize requires: <specclaw_dir> <change_name>"
   local specclaw_dir="$1" change_name="$2"
@@ -334,10 +351,13 @@ cmd_finalize() {
   local tests_passed=true lint_passed=true build_passed=true merged=false
   local errors=()
 
+  # Full logs live beside the change; run-long falls back to mktemp if unwritable.
+  local log_dir="$specclaw_dir/changes/$change_name/logs"
+
   # Run test command
   if [[ -n "$test_command" ]]; then
     echo "Running tests: $test_command" >&2
-    if ! eval "$test_command" >&2 2>&1; then
+    if ! run_long_check test "$log_dir" "$test_command"; then
       tests_passed=false
       errors+=("Test command failed: $test_command")
     fi
@@ -346,7 +366,7 @@ cmd_finalize() {
   # Run lint command
   if [[ -n "$lint_command" ]]; then
     echo "Running lint: $lint_command" >&2
-    if ! eval "$lint_command" >&2 2>&1; then
+    if ! run_long_check lint "$log_dir" "$lint_command"; then
       lint_passed=false
       errors+=("Lint command failed: $lint_command")
     fi
@@ -355,7 +375,7 @@ cmd_finalize() {
   # Run build command
   if [[ -n "$build_command" ]]; then
     echo "Running build: $build_command" >&2
-    if ! eval "$build_command" >&2 2>&1; then
+    if ! run_long_check build "$log_dir" "$build_command"; then
       build_passed=false
       errors+=("Build command failed: $build_command")
     fi

--- a/plugins/specclaw/bin/specclaw-build
+++ b/plugins/specclaw/bin/specclaw-build
@@ -329,7 +329,9 @@ run_long_check() {
     "$runner" --log-dir "$log_dir" --phase "$phase" -- "$cmd" >&2
   else
     warn "specclaw-run-long not found at $runner — running $phase command inline"
-    eval "$cmd" >&2 2>&1
+    # `1>&2` alone: stdout joins stderr, and stderr is already there. The older
+    # `>&2 2>&1` spelling had the same effect but reads like a stream swap.
+    eval "$cmd" 1>&2
   fi
 }
 

--- a/plugins/specclaw/bin/specclaw-gh-sync
+++ b/plugins/specclaw/bin/specclaw-gh-sync
@@ -645,7 +645,12 @@ cmd_create() {
   local has_issues
   has_issues="$(repo_has_issues)"
   if [[ "$has_issues" == "false" ]]; then
-    warn "GitHub Issues are disabled for $REPO — skipping issue creation (no tracking issue recorded)."
+    warn "GitHub Issues are disabled for $REPO — skipping issue creation."
+    # Write sentinel so specclaw-validate-change knows sync was attempted
+    local status_file="$specclaw_dir/changes/$change_name/status.md"
+    if [[ -f "$status_file" ]] && ! grep -q "GitHub Issue" "$status_file" 2>/dev/null; then
+      echo "**GitHub Issue:** N/A (Issues disabled on $REPO)" >> "$status_file"
+    fi
     exit 0
   fi
 

--- a/plugins/specclaw/bin/specclaw-run-long
+++ b/plugins/specclaw/bin/specclaw-run-long
@@ -139,7 +139,12 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   # commits yet, so the empty stamp correctly disables --reuse (edge case 3).
   current_head="$(git rev-parse --verify --quiet HEAD || true)"
   if [[ -n "$current_head" ]]; then
-    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    # Untracked files count as dirty: a brand-new, not-yet-`git add`ed test file
+    # changes what the suite would do, but `git diff` (with or without --cached)
+    # is blind to it. Missing that means --reuse serves a stale pass for a suite
+    # that never ran the new file — the one failure mode reuse must never have.
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null ||
+       [[ -n "$(git ls-files --others --exclude-standard 2>/dev/null || true)" ]]; then
       current_dirty="true"
     fi
   fi
@@ -155,6 +160,7 @@ if [[ -n "$prior_sidecar" ]]; then
   cached_dirty="$(sidecar_val "$prior_sidecar" dirty)"
   cached_exit="$(sidecar_val "$prior_sidecar" exit)"
   cached_log="$(sidecar_val "$prior_sidecar" log)"
+  cached_cmd="$(sidecar_val "$prior_sidecar" cmd)"
 
   # Refuse reuse when there is no HEAD (edge case 3): HEAD stamp is empty.
   if [[ -z "$cached_head" ]] || [[ -z "$current_head" ]]; then
@@ -164,6 +170,12 @@ if [[ -n "$prior_sidecar" ]]; then
     warn "--reuse: working tree is dirty — refusing to reuse to avoid masking uncommitted edits"
   elif [[ "$cached_dirty" == "true" ]]; then
     warn "--reuse: cached result was recorded with a dirty tree — refusing to reuse"
+  # Refuse reuse when the sidecar was written for a different command. The
+  # sidecar is found by slug, and the slug is truncated to SLUG_MAX chars — two
+  # long commands sharing a prefix collide, so the stored `cmd` is the only
+  # thing that actually proves identity.
+  elif [[ "$cached_cmd" != "$cmd" ]]; then
+    warn "--reuse: cached sidecar was written for a different command — re-executing"
   # Refuse reuse when HEAD doesn't match.
   elif [[ "$cached_head" != "$current_head" ]]; then
     warn "--reuse: cached HEAD ${cached_head:0:8} != current ${current_head:0:8} — re-executing"
@@ -195,6 +207,12 @@ start_time="$SECONDS"
 # Called from trap — shellcheck does not see trap-based invocations as calls.
 # shellcheck disable=SC2329
 _cleanup_interrupt() {
+  # A signal arriving between `&` and `child_pid="$!"` would otherwise see an
+  # empty PID and leave the child running unsupervised. `jobs -p` still knows
+  # about it in that window.
+  if [[ -z "$child_pid" ]]; then
+    child_pid="$(jobs -p | tail -1 || true)"
+  fi
   if [[ -n "$child_pid" ]]; then
     # Kill entire process group to avoid orphans.
     kill -- -"$child_pid" 2>/dev/null || true

--- a/plugins/specclaw/bin/specclaw-run-long
+++ b/plugins/specclaw/bin/specclaw-run-long
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# specclaw-run-long — Detached command execution with heartbeat, capped tail,
+# and HEAD-stamped sidecar for long-running test/lint/build commands.
+# Part of the specclaw skill. Bash + coreutils only (no jq, no python, NFR3).
+#
+# Stream discipline: heartbeats → stderr (liveness); 100-line tail → stdout
+# (captured payload); full log → disk (truth). Getting this wrong breaks AC6.
+#
+# Fail-open: unwritable log dir → mktemp fallback → inline execution (NFR2).
+set -euo pipefail
+
+# Default heartbeat interval in seconds (clamped from 0/non-integer, edge case 7).
+DEFAULT_HEARTBEAT=60
+# Maximum tail lines (matches run_capped() in specclaw-verify).
+TAIL_LINES=100
+# Slug max length for log filename.
+SLUG_MAX=40
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-run-long [--log-dir DIR] [--phase NAME] [--heartbeat N] [--reuse] -- <command string>
+
+Runs a command detached, writing combined stdout+stderr to a log file.
+Emits heartbeats to stderr every N seconds. On completion prints the last
+100 lines of the log to stdout plus the log path. Writes a result sidecar.
+
+Options:
+  --log-dir DIR    Directory for log and sidecar files (default: mktemp dir)
+  --phase NAME     Phase label used in the log filename (default: run)
+  --heartbeat N    Heartbeat interval in seconds (default: 60; 0 clamps to default)
+  --reuse          Return cached sidecar if HEAD matches and tree is clean
+
+Stream discipline:
+  stderr: heartbeat progress lines (for agent/watchdog liveness)
+  stdout: 100-line tail + log path (captured payload for verify report)
+  disk:   full log (complete truth)
+
+  -h, --help   Show this help message
+EOF
+}
+
+warn() { echo "WARN [run-long]: $*" >&2; }
+
+# Read a key=value sidecar file; echo the value for a given key.
+# Values may contain '=' (e.g. log paths), so only split on the first '='.
+sidecar_val() {
+  local file="$1" key="$2"
+  [[ -r "$file" ]] || return 0
+  # Use parameter expansion on the line to split at the first '=' only.
+  while IFS= read -r line; do
+    local k="${line%%=*}"
+    if [[ "$k" == "$key" ]]; then
+      echo "${line#*=}"
+      return 0
+    fi
+  done < "$file"
+  return 0
+}
+
+# Newest sidecar for this phase+command, ignoring the PID discriminator.
+# Log names carry a PID (edge case 5), so reuse must not look for its own.
+newest_sidecar() {
+  local candidate="" newest=""
+  for candidate in "${log_dir}/${phase}-${slug}"-*.result; do
+    [[ -f "$candidate" ]] || continue
+    if [[ -z "$newest" ]] || [[ "$candidate" -nt "$newest" ]]; then
+      newest="$candidate"
+    fi
+  done
+  echo "$newest"
+}
+
+# ─── Argument parsing ──────────────────────────────────────────────────────────
+
+log_dir=""
+phase="run"
+heartbeat="$DEFAULT_HEARTBEAT"
+reuse=false
+cmd=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --log-dir)  [[ $# -ge 2 ]] || { warn "--log-dir requires an argument"; exit 1; }
+                log_dir="$2"; shift 2 ;;
+    --phase)    [[ $# -ge 2 ]] || { warn "--phase requires an argument"; exit 1; }
+                phase="$2"; shift 2 ;;
+    --heartbeat)[[ $# -ge 2 ]] || { warn "--heartbeat requires an argument"; exit 1; }
+                heartbeat="$2"; shift 2 ;;
+    --reuse)    reuse=true; shift ;;
+    --)         shift; cmd="$*"; break ;;
+    *)          warn "Unknown option: $1 (try --help)"; exit 1 ;;
+  esac
+done
+
+[[ -n "$cmd" ]] || { warn "No command provided after --"; usage; exit 1; }
+
+# Clamp heartbeat to default if 0 or non-integer (edge case 7).
+if ! [[ "$heartbeat" =~ ^[0-9]+$ ]] || [[ "$heartbeat" -eq 0 ]]; then
+  warn "heartbeat '${heartbeat}' is not a positive integer — clamping to ${DEFAULT_HEARTBEAT}s"
+  heartbeat="$DEFAULT_HEARTBEAT"
+fi
+
+# ─── Log directory resolution (NFR2 fail-open) ────────────────────────────────
+
+if [[ -n "$log_dir" ]]; then
+  if ! mkdir -p "$log_dir" 2>/dev/null; then
+    warn "cannot create log dir '${log_dir}' — falling back to mktemp"
+    log_dir=""
+  fi
+fi
+
+if [[ -z "$log_dir" ]]; then
+  if ! log_dir="$(mktemp -d 2>/dev/null)"; then
+    warn "mktemp also failed — running inline (no log, no sidecar)"
+    eval "$cmd"
+    exit $?
+  fi
+fi
+
+# ─── Log path construction ─────────────────────────────────────────────────────
+
+# Slug: sanitize command to [a-z0-9-], truncate to SLUG_MAX chars.
+slug="$(echo "$cmd" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | tr -s '-' | sed 's/^-//;s/-$//' | cut -c1-"${SLUG_MAX}")"
+[[ -n "$slug" ]] || slug="cmd"
+
+log_base="${log_dir}/${phase}-${slug}-$$"
+log_file="${log_base}.log"
+sidecar="${log_base}.result"
+
+# ─── HEAD and dirty-tree detection ────────────────────────────────────────────
+
+current_head=""
+current_dirty="false"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  # --verify --quiet: prints nothing (not the literal "HEAD") when there are no
+  # commits yet, so the empty stamp correctly disables --reuse (edge case 3).
+  current_head="$(git rev-parse --verify --quiet HEAD || true)"
+  if [[ -n "$current_head" ]]; then
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+      current_dirty="true"
+    fi
+  fi
+fi
+
+# ─── Reuse path (FR5, edge cases 3 & 4) ──────────────────────────────────────
+
+prior_sidecar=""
+"$reuse" && prior_sidecar="$(newest_sidecar)"
+
+if [[ -n "$prior_sidecar" ]]; then
+  cached_head="$(sidecar_val "$prior_sidecar" head)"
+  cached_dirty="$(sidecar_val "$prior_sidecar" dirty)"
+  cached_exit="$(sidecar_val "$prior_sidecar" exit)"
+  cached_log="$(sidecar_val "$prior_sidecar" log)"
+
+  # Refuse reuse when there is no HEAD (edge case 3): HEAD stamp is empty.
+  if [[ -z "$cached_head" ]] || [[ -z "$current_head" ]]; then
+    warn "--reuse: no HEAD available — refusing to reuse (fail closed)"
+  # Refuse reuse when the tree is dirty (edge case 4).
+  elif [[ "$current_dirty" == "true" ]]; then
+    warn "--reuse: working tree is dirty — refusing to reuse to avoid masking uncommitted edits"
+  elif [[ "$cached_dirty" == "true" ]]; then
+    warn "--reuse: cached result was recorded with a dirty tree — refusing to reuse"
+  # Refuse reuse when HEAD doesn't match.
+  elif [[ "$cached_head" != "$current_head" ]]; then
+    warn "--reuse: cached HEAD ${cached_head:0:8} != current ${current_head:0:8} — re-executing"
+  else
+    # All checks pass: serve the cached result.
+    echo "[run-long] reuse: sidecar HEAD matches current HEAD (${current_head:0:8}), clean tree — skipping execution" >&2
+    # Print the stored tail from the log file if it still exists.
+    if [[ -f "$cached_log" ]]; then
+      local_total="$(wc -l < "$cached_log" 2>/dev/null || echo 0)"
+      if [[ "$local_total" -gt "$TAIL_LINES" ]]; then
+        tail -"${TAIL_LINES}" "$cached_log"
+        echo "... (truncated, ${local_total} total lines)"
+      else
+        cat "$cached_log"
+      fi
+    fi
+    echo "log: ${cached_log:-$sidecar}"
+    [[ "$cached_exit" =~ ^[0-9]+$ ]] || cached_exit=1
+    exit "$cached_exit"
+  fi
+fi
+
+# ─── Child setup and trap ─────────────────────────────────────────────────────
+
+child_pid=""
+start_time="$SECONDS"
+
+# Write an interrupted sidecar and kill the child process group (NFR7, edge case 16).
+# Called from trap — shellcheck does not see trap-based invocations as calls.
+# shellcheck disable=SC2329
+_cleanup_interrupt() {
+  if [[ -n "$child_pid" ]]; then
+    # Kill entire process group to avoid orphans.
+    kill -- -"$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+  fi
+  local elapsed=$(( SECONDS - start_time ))
+  {
+    echo "exit=1"
+    echo "duration_s=${elapsed}"
+    echo "log=${log_file}"
+    echo "head=${current_head}"
+    echo "dirty=${current_dirty}"
+    echo "cmd=${cmd}"
+    echo "interrupted=true"
+  } > "$sidecar"
+  exit 1
+}
+
+trap '_cleanup_interrupt' INT
+trap '_cleanup_interrupt' TERM
+
+# ─── Execute detached ─────────────────────────────────────────────────────────
+
+# Use eval to preserve pipes, &&, env prefixes (edge case 2, design decision 2).
+# set -m enables job control so the child gets its own process group, allowing
+# the trap to kill the whole group cleanly (NFR7).
+set -m
+eval "$cmd" >"$log_file" 2>&1 &
+child_pid="$!"
+
+# ─── Heartbeat loop ───────────────────────────────────────────────────────────
+
+next_heartbeat="$heartbeat"
+
+while kill -0 "$child_pid" 2>/dev/null; do
+  sleep 1
+  elapsed=$(( SECONDS - start_time ))
+  if [[ "$elapsed" -ge "$next_heartbeat" ]]; then
+    # Count log lines (|| true per learning [L2]: no-match pipeline aborts set -e).
+    log_lines="$(wc -l < "$log_file" 2>/dev/null || echo 0)"
+    # Get last non-empty line (|| true per learning [L2]).
+    last_line="$(grep -v '^[[:space:]]*$' "$log_file" 2>/dev/null | tail -1 || true)"
+    if [[ -z "$last_line" ]]; then
+      last_line="(no output yet)"
+    fi
+    # Truncate last line to keep the heartbeat terse (NFR4).
+    if [[ "${#last_line}" -gt 120 ]]; then
+      last_line="${last_line:0:117}..."
+    fi
+    echo "[run-long] ${elapsed}s elapsed | ${log_lines} log lines | last: ${last_line}" >&2
+    next_heartbeat=$(( elapsed + heartbeat ))
+  fi
+done
+
+# ─── Harvest exit code ────────────────────────────────────────────────────────
+
+rc=0
+wait "$child_pid" 2>/dev/null || rc=$?
+set +m
+
+end_time="$SECONDS"
+duration=$(( end_time - start_time ))
+
+# ─── Write sidecar (always, pass or fail — FR4) ───────────────────────────────
+
+{
+  echo "exit=${rc}"
+  echo "duration_s=${duration}"
+  echo "log=${log_file}"
+  echo "head=${current_head}"
+  echo "dirty=${current_dirty}"
+  echo "cmd=${cmd}"
+  echo "interrupted=false"
+} > "$sidecar"
+
+# ─── Print capped tail to stdout (FR3) ────────────────────────────────────────
+
+total="$(wc -l < "$log_file" 2>/dev/null || echo 0)"
+
+if [[ "$total" -gt "$TAIL_LINES" ]]; then
+  tail -"${TAIL_LINES}" "$log_file"
+  echo "... (truncated, ${total} total lines)"
+else
+  cat "$log_file"
+fi
+
+echo "log: ${log_file}"
+
+exit "$rc"

--- a/plugins/specclaw/bin/specclaw-run-long
+++ b/plugins/specclaw/bin/specclaw-run-long
@@ -153,7 +153,7 @@ fi
 # ─── Reuse path (FR5, edge cases 3 & 4) ──────────────────────────────────────
 
 prior_sidecar=""
-"$reuse" && prior_sidecar="$(newest_sidecar)"
+[[ "$reuse" == "true" ]] && prior_sidecar="$(newest_sidecar)"
 
 if [[ -n "$prior_sidecar" ]]; then
   cached_head="$(sidecar_val "$prior_sidecar" head)"

--- a/plugins/specclaw/bin/specclaw-run-long
+++ b/plugins/specclaw/bin/specclaw-run-long
@@ -204,8 +204,11 @@ child_pid=""
 start_time="$SECONDS"
 
 # Write an interrupted sidecar and kill the child process group (NFR7, edge case 16).
-# Called from trap — shellcheck does not see trap-based invocations as calls.
-# shellcheck disable=SC2329
+# Called from trap — shellcheck does not see trap-based invocations as calls, so it
+# reports the function as never called (SC2329) and every line in its body as
+# unreachable (SC2317). Both are artefacts of that blind spot; the body is covered
+# by the interrupt test cases.
+# shellcheck disable=SC2329,SC2317
 _cleanup_interrupt() {
   # A signal arriving between `&` and `child_pid="$!"` would otherwise see an
   # empty PID and leave the child running unsupervised. `jobs -p` still knows

--- a/plugins/specclaw/bin/specclaw-run-long
+++ b/plugins/specclaw/bin/specclaw-run-long
@@ -222,7 +222,12 @@ trap '_cleanup_interrupt' TERM
 # set -m enables job control so the child gets its own process group, allowing
 # the trap to kill the whole group cleanly (NFR7).
 set -m
-eval "$cmd" >"$log_file" 2>&1 &
+# `set +e` inside the subshell: the background job inherits errexit, which would
+# terminate it with status 1 instead of the child's real status for a *simple*
+# command (`npm test`, `npx playwright test`). That collapse would make the
+# exit-137 memory-kill classification (FR13) impossible. AND-lists are exempt
+# from errexit, which is why the bug only shows on the common case.
+( set +e; eval "$cmd" ) >"$log_file" 2>&1 &
 child_pid="$!"
 
 # ─── Heartbeat loop ───────────────────────────────────────────────────────────

--- a/plugins/specclaw/bin/specclaw-update-status
+++ b/plugins/specclaw/bin/specclaw-update-status
@@ -12,6 +12,80 @@ STATUS_FILE="$SPECCLAW_DIR/STATUS.md"
 # Read project name from config
 PROJECT_NAME=$(grep 'name:' "$SPECCLAW_DIR/config.yaml" | head -1 | sed 's/.*name: *"\(.*\)"/\1/')
 
+# ─── PR state (FR14) ─────────────────────────────────────────────────────────
+# A change that is already in review must never render as "awaiting planning".
+# Fail-open by contract (NFR2): a missing, unauthenticated, offline, or slow
+# `gh`/`az` yields an empty state, never an error — with no PR discoverable the
+# dashboard is byte-identical to the pre-FR14 rendering (NFR1).
+# `SPECCLAW_STATUS_NO_PR=1` skips the whole block.
+
+PR_LOOKUP=1
+[ "${SPECCLAW_STATUS_NO_PR:-0}" = "1" ] && PR_LOOKUP=0
+declare -A PR_STATE_CACHE=()
+
+# Read `<section>.<key>` from config.yaml — section-scoped, inline-comment and
+# quote stripped. Trimmed-down twin of `yaml_val` in specclaw-build.
+cfg_val() {
+  local section="$1" key="$2" v
+  v=$(sed -n "/^${section}:/,/^[a-zA-Z_]/{s/^[[:space:]][[:space:]]*${key}:[[:space:]]*//p;}" \
+    "$SPECCLAW_DIR/config.yaml" 2>/dev/null | head -1 || true)
+  if [[ "$v" =~ ([[:space:]]+#) ]]; then v="${v%%"${BASH_REMATCH[1]}"*}"; fi
+  v="${v%"${v##*[![:space:]]}"}"
+  v="${v#\"}"; v="${v%\"}"; v="${v#\'}"; v="${v%\'}"
+  printf '%s' "$v"
+}
+
+# Branch names must match what specclaw actually pushes: <branch_prefix><change>.
+BRANCH_PREFIX="$(cfg_val git branch_prefix)"
+BRANCH_PREFIX="${BRANCH_PREFIX:-specclaw/}"
+
+# Bounded invocation (NFR5) — a network call must never stall status generation.
+pr_bounded() {
+  if command -v timeout >/dev/null 2>&1; then timeout 5 "$@"; else "$@"; fi
+}
+
+# One `<updatedAt> <number> <state>` row per PR on the branch, or nothing.
+# GitHub via `gh` first, then Azure DevOps via `az`; both optional.
+pr_rows() {
+  local branch="$1" rows=""
+  if command -v gh >/dev/null 2>&1; then
+    rows=$(pr_bounded gh pr list --head "$branch" --state all --limit 20 \
+      --json number,state,updatedAt \
+      --template '{{range .}}{{.updatedAt}} {{.number}} {{.state}}{{"\n"}}{{end}}' 2>/dev/null || true)
+  fi
+  if [ -z "$rows" ] && command -v az >/dev/null 2>&1; then
+    rows=$(pr_bounded az repos pr list --source-branch "refs/heads/$branch" --status all \
+      --query '[].[creationDate,pullRequestId,status]' -o tsv 2>/dev/null || true)
+  fi
+  printf '%s' "$rows"
+}
+
+# pr_state_for <change> — `PR #123 open` for the most recently updated PR on the
+# change's branch, rendering its real state (edge case 15: a merged PR reads as
+# merged, never as open). Empty when nothing is discoverable. Memoised per run.
+pr_state_for() {
+  local change="$1" branch newest state rendered=""
+  [ "$PR_LOOKUP" = "1" ] || return 0
+  if [ -n "${PR_STATE_CACHE[$change]+set}" ]; then
+    printf '%s' "${PR_STATE_CACHE[$change]}"
+    return 0
+  fi
+  branch="${BRANCH_PREFIX}${change}"
+  # ISO-8601 timestamps sort lexically, so `sort -r | head -1` is the newest PR.
+  # `|| true`: a no-match grep in this pipeline must not abort the script ([L2]).
+  newest=$(pr_rows "$branch" | tr '\t' ' ' | grep -v '^[[:space:]]*$' | sort -r | head -1 || true)
+  if [ -n "$newest" ]; then
+    # shellcheck disable=SC2086  # deliberate split of the "<ts> <num> <state>" row
+    set -- $newest
+    if [ "$#" -ge 3 ]; then
+      state=$(printf '%s' "$3" | tr '[:upper:]' '[:lower:]')
+      rendered="PR #$2 $state"
+    fi
+  fi
+  PR_STATE_CACHE["$change"]="$rendered"
+  printf '%s' "$rendered"
+}
+
 ACTIVE_COUNT=0
 COMPLETED_COUNT=0
 ACTIVE_LINES=""
@@ -24,6 +98,7 @@ for change_dir in "$CHANGES_DIR"/*/; do
   [ "$(basename "$change_dir")" = "archive" ] && continue
 
   change_name=$(basename "$change_dir")
+  pr_state="$(pr_state_for "$change_name")"
 
   if [ -f "$change_dir/tasks.md" ]; then
     total=$(grep -c '^\- \[' "$change_dir/tasks.md" 2>/dev/null || true)
@@ -43,7 +118,11 @@ for change_dir in "$CHANGES_DIR"/*/; do
     [ "$failed" -gt 0 ] && status_emoji="⚠️"
     [ "$done" -eq "$total" ] && [ "$total" -gt 0 ] && status_emoji="✅"
 
-    ACTIVE_LINES="${ACTIVE_LINES}\n- $status_emoji **$change_name** — $done/$total tasks ($pct%) ${failed:+| $failed failed}"
+    ACTIVE_LINES="${ACTIVE_LINES}\n- $status_emoji **$change_name** — $done/$total tasks ($pct%) ${failed:+| $failed failed}${pr_state:+ | $pr_state}"
+    ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
+  elif [ -n "$pr_state" ]; then
+    # Unplanned but already in review — in flight, not "awaiting planning" (AC15).
+    ACTIVE_LINES="${ACTIVE_LINES}\n- 🔀 **$change_name** — $pr_state"
     ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
   elif [ -f "$change_dir/proposal.md" ]; then
     PENDING_LINES="${PENDING_LINES}\n- 📋 **$change_name** — proposal ready, awaiting planning"

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -15,6 +15,16 @@ elif command -v specclaw-run-long >/dev/null 2>&1; then
   RUN_LONG="$(command -v specclaw-run-long)"
 fi
 
+# Resolve specclaw-browser-lock (browser-slot semaphore + memory-cap command
+# wrapper). Empty when unresolvable — the e2e command then runs unwrapped,
+# uncapped and without a slot, exactly as before the e2e tier existed (NFR2).
+BROWSER_LOCK=""
+if [ -x "${SCRIPT_DIR}/specclaw-browser-lock" ]; then
+  BROWSER_LOCK="${SCRIPT_DIR}/specclaw-browser-lock"
+elif command -v specclaw-browser-lock >/dev/null 2>&1; then
+  BROWSER_LOCK="$(command -v specclaw-browser-lock)"
+fi
+
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 usage() {
@@ -139,6 +149,38 @@ run_capped() {
   fi
   rm -f "$tmpfile"
   return "$rc"
+}
+
+# Browser slot currently held by the e2e tier. Tracked in globals so the slot is
+# released from a trap too: a leaked slot would starve the pool for every later
+# run, so release must happen on failure and on interruption, not just on the
+# happy path.
+E2E_SLOT=""
+E2E_SLOT_DIR=""
+
+# Claim a browser slot for the e2e command. Fail-open: acquire prints `none` and
+# exits 0 when the pool is unusable or times out, and we then proceed slotless
+# rather than blocking the run (NFR2).
+e2e_acquire_slot() {
+  local specclaw_dir="$1" slot=""
+  slot=$("$BROWSER_LOCK" "$specclaw_dir" acquire) || slot=""
+  case "$slot" in
+    ""|none) return 0 ;;
+  esac
+  E2E_SLOT="$slot"
+  E2E_SLOT_DIR="$specclaw_dir"
+  trap 'e2e_release_slot' EXIT
+  trap 'e2e_release_slot; exit 130' INT
+  trap 'e2e_release_slot; exit 143' TERM
+}
+
+# Release the held slot. Idempotent, so the trap and the normal path can both
+# call it, and never fatal — a failed release must not mask the e2e result.
+e2e_release_slot() {
+  [ -n "$E2E_SLOT" ] || return 0
+  local slot="$E2E_SLOT"
+  E2E_SLOT=""
+  "$BROWSER_LOCK" "$E2E_SLOT_DIR" release "$slot" || true
 }
 
 # ─── Subcommand: collect ──────────────────────────────────────────────────────
@@ -319,17 +361,43 @@ cmd_collect() {
         e2e_state="skipped_gate_failure"
         e2e_output="SKIPPED — verify.e2e=last and an earlier gate failed (${failed_gates}); e2e command was never executed. This is NOT a pass."
       else
+        # Bounded invocation (FR10, FR12): hold a browser slot for the run, let
+        # browser-lock decide how the command is constrained (--workers=1,
+        # sequential --project fan-out, MemoryMax scope), and execute the string
+        # it prints. Each script keeps one job — browser-lock constrains, run-long
+        # (via run_capped) executes and observes.
+        local e2e_run_cmd="$e2e_cmd" e2e_cap=""
+        if [ -n "$BROWSER_LOCK" ]; then
+          e2e_acquire_slot "$specclaw_dir"
+          local wrapped="" wrap_rc=0
+          wrapped=$("$BROWSER_LOCK" "$specclaw_dir" wrap "$e2e_cmd") || wrap_rc=$?
+          if [ -n "$wrapped" ] && { [ "$wrap_rc" -eq 0 ] || [ "$wrap_rc" -eq 10 ]; }; then
+            e2e_run_cmd="$wrapped"
+            # wrap exit 0 = a memory cap was applied, 10 = emitted uncapped. Only
+            # the capped case may attribute an exit 137 to the cap (FR13), and the
+            # cap it actually carries is the one named in the report.
+            if [ "$wrap_rc" -eq 0 ] && [[ "$wrapped" =~ MemoryMax=([0-9]+M) ]]; then
+              e2e_cap="cap ${BASH_REMATCH[1]}"
+            fi
+          else
+            warn "browser-lock wrap failed (exit ${wrap_rc}) — running the e2e command unwrapped and uncapped"
+          fi
+        fi
+
         local e2e_rc=0
-        run_capped e2e_output "$e2e_cmd" e2e "$log_dir" || e2e_rc=$?
+        run_capped e2e_output "$e2e_run_cmd" e2e "$log_dir" || e2e_rc=$?
+        e2e_release_slot
         if [ "$e2e_rc" -eq 0 ]; then
           e2e_state="passed"
         else
           e2e_state="failed"
-          # Exit 137 = SIGKILL, i.e. the memory limit was exceeded (FR13). Never
-          # report it as a generic or flaky test failure.
-          if [ "$e2e_rc" -eq 137 ]; then
+          # Exit 137 = SIGKILL. Only a run that actually carried a memory cap can
+          # be reported as a memory-limit breach, and then it never reads as a
+          # generic or flaky test failure (FR13). The same code with no cap
+          # applied stays a plain failure (AC13).
+          if [ "$e2e_rc" -eq 137 ] && [ -n "$e2e_cap" ]; then
             e2e_memory_limited=true
-            e2e_output="MEMORY LIMIT EXCEEDED — e2e command was killed with SIGKILL (exit 137), not a test assertion failure.
+            e2e_output="MEMORY LIMIT EXCEEDED — e2e command exceeded its memory limit (${e2e_cap}) and was killed with SIGKILL (exit 137), not a test assertion failure.
 ${e2e_output}"
           fi
         fi

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -5,6 +5,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Resolve specclaw-run-long (long-running command executor: heartbeats to stderr,
+# full log to disk). Empty when unresolvable — run_capped then executes inline
+# exactly as before, so a missing helper never blocks a verify run (NFR2).
+RUN_LONG=""
+if [ -x "${SCRIPT_DIR}/specclaw-run-long" ]; then
+  RUN_LONG="${SCRIPT_DIR}/specclaw-run-long"
+elif command -v specclaw-run-long >/dev/null 2>&1; then
+  RUN_LONG="$(command -v specclaw-run-long)"
+fi
+
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 usage() {
@@ -60,17 +70,54 @@ yaml_val() {
 }
 
 # Run a command, capture output (capped at 100 lines), return exit code
-# Usage: run_capped <varname_output> <command_string>
+# Usage: run_capped <varname_output> <command_string> [phase] [log_dir]
 # Sets: <varname_output> to captured output, returns command exit code
+#
+# Execution goes through specclaw-run-long when available, so a multi-minute
+# suite emits heartbeats to stderr and keeps its full log on disk. The captured
+# payload is still re-capped here from the log file with the same head -100 +
+# truncation marker as the inline path, so callers see byte-identical output.
 run_capped() {
   local -n _out_ref="$1"
   local cmd="$2"
+  local phase="${3:-run}"
+  local log_dir="${4:-}"
+  local rc=0
+  local total
+
+  if [ -n "$RUN_LONG" ]; then
+    local rl_args=(--phase "$phase")
+    [ -n "$log_dir" ] && rl_args+=(--log-dir "$log_dir")
+    local rl_out=""
+    rl_out=$("$RUN_LONG" "${rl_args[@]}" -- "$cmd") || rc=$?
+    # run-long's last stdout line is "log: <path>"; the full log lives there.
+    local log_path
+    log_path=$(printf '%s\n' "$rl_out" | tail -1 | sed -n 's/^log: //p')
+    if [ -n "$log_path" ] && [ -f "$log_path" ]; then
+      _out_ref=$(head -100 "$log_path")
+      total=$(wc -l < "$log_path")
+      if [ "$total" -gt 100 ]; then
+        _out_ref="${_out_ref}
+... (truncated, ${total} total lines)"
+      fi
+    else
+      # run-long could not create a log (its own inline fallback) — its stdout
+      # is the raw, uncapped command output, so apply the cap here.
+      _out_ref=$(printf '%s\n' "$rl_out" | head -100)
+      total=$(printf '%s\n' "$rl_out" | wc -l)
+      if [ "$total" -gt 100 ]; then
+        _out_ref="${_out_ref}
+... (truncated, ${total} total lines)"
+      fi
+    fi
+    return "$rc"
+  fi
+
+  # specclaw-run-long unavailable — execute inline as before (NFR2 fail-open).
   local tmpfile
   tmpfile=$(mktemp)
-  local rc=0
   eval "$cmd" >"$tmpfile" 2>&1 || rc=$?
   _out_ref=$(head -100 "$tmpfile")
-  local total
   total=$(wc -l < "$tmpfile")
   if [ "$total" -gt 100 ]; then
     _out_ref="${_out_ref}
@@ -195,20 +242,22 @@ cmd_collect() {
   local test_output="" lint_output="" build_output=""
   local tests_passed=true lint_passed=true build_passed=true
 
+  local log_dir="${change_dir}/logs"
+
   if [ -n "$test_cmd" ]; then
-    if ! run_capped test_output "$test_cmd"; then
+    if ! run_capped test_output "$test_cmd" test "$log_dir"; then
       tests_passed=false
     fi
   fi
 
   if [ -n "$lint_cmd" ]; then
-    if ! run_capped lint_output "$lint_cmd"; then
+    if ! run_capped lint_output "$lint_cmd" lint "$log_dir"; then
       lint_passed=false
     fi
   fi
 
   if [ -n "$build_cmd" ]; then
-    if ! run_capped build_output "$build_cmd"; then
+    if ! run_capped build_output "$build_cmd" build "$log_dir"; then
       build_passed=false
     fi
   fi

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -69,6 +69,19 @@ yaml_val() {
   printf '%s' "$val"
 }
 
+# True when a simple scalar key is literally present in config.yaml.
+# yaml_val cannot tell "key absent" from "key present but empty", and that
+# distinction is what keeps the payload byte-identical to v0.5.9 when none of
+# the new e2e keys exist (NFR1).
+yaml_has_key() {
+  local file="$1" field="$2"
+  grep -qE "^[[:space:]]*${field}:" "$file" 2>/dev/null
+}
+
+# Heartbeat interval (seconds) handed to specclaw-run-long as --heartbeat.
+# Empty = do not pass the flag, so run-long applies its own default.
+HEARTBEAT_SECONDS=""
+
 # Run a command, capture output (capped at 100 lines), return exit code
 # Usage: run_capped <varname_output> <command_string> [phase] [log_dir]
 # Sets: <varname_output> to captured output, returns command exit code
@@ -88,6 +101,7 @@ run_capped() {
   if [ -n "$RUN_LONG" ]; then
     local rl_args=(--phase "$phase")
     [ -n "$log_dir" ] && rl_args+=(--log-dir "$log_dir")
+    [ -n "$HEARTBEAT_SECONDS" ] && rl_args+=(--heartbeat "$HEARTBEAT_SECONDS")
     local rl_out=""
     rl_out=$("$RUN_LONG" "${rl_args[@]}" -- "$cmd") || rc=$?
     # run-long's last stdout line is "log: <path>"; the full log lives there.
@@ -229,26 +243,38 @@ cmd_collect() {
   done
 
   # 4. Read config for commands
-  local test_cmd="" lint_cmd="" build_cmd=""
+  local test_cmd="" lint_cmd="" build_cmd="" e2e_cmd="" e2e_policy=""
+  # e2e_configured: any of the new e2e keys is literally present. When none are,
+  # the e2e payload fields are omitted entirely so output matches v0.5.9 (NFR1/AC6).
+  local e2e_configured=false
   if [ -f "$config_file" ]; then
     test_cmd=$(yaml_val "$config_file" "build.test_command")
     lint_cmd=$(yaml_val "$config_file" "build.lint_command")
     build_cmd=$(yaml_val "$config_file" "build.build_command")
+    e2e_cmd=$(yaml_val "$config_file" "build.e2e_command")
+    e2e_policy=$(yaml_val "$config_file" "verify.e2e")
+    HEARTBEAT_SECONDS=$(yaml_val "$config_file" "verify.heartbeat_seconds")
+    if yaml_has_key "$config_file" "e2e_command" || yaml_has_key "$config_file" "e2e"; then
+      e2e_configured=true
+    fi
   else
     warn "config.yaml not found at ${config_file}, skipping commands"
   fi
 
-  # 5. Run commands
+  # Resolve the e2e policy (FR8). Absent → "last" (edge case 8);
+  # unrecognised → warn and fall back to "last", never a silent skip (edge case 9).
+  case "$e2e_policy" in
+    skip|last|always) ;;
+    "") e2e_policy="last" ;;
+    *)  warn "verify.e2e: unrecognised value '${e2e_policy}' — falling back to 'last'"
+        e2e_policy="last" ;;
+  esac
+
+  # 5. Run commands — fast gates in lint → build → test order, then e2e per policy (FR8).
   local test_output="" lint_output="" build_output=""
   local tests_passed=true lint_passed=true build_passed=true
 
   local log_dir="${change_dir}/logs"
-
-  if [ -n "$test_cmd" ]; then
-    if ! run_capped test_output "$test_cmd" test "$log_dir"; then
-      tests_passed=false
-    fi
-  fi
 
   if [ -n "$lint_cmd" ]; then
     if ! run_capped lint_output "$lint_cmd" lint "$log_dir"; then
@@ -262,6 +288,55 @@ cmd_collect() {
     fi
   fi
 
+  if [ -n "$test_cmd" ]; then
+    if ! run_capped test_output "$test_cmd" test "$log_dir"; then
+      tests_passed=false
+    fi
+  fi
+
+  # 5b. E2E tier (FR8, FR9, FR13).
+  # e2e_state is an enumerated string, never an empty-output sentinel: a skip is
+  # structurally un-mistakable for a pass, and every non-passed state carries a
+  # human-readable reason in e2e_output.
+  local e2e_output="" e2e_state="not_configured" e2e_memory_limited=false
+  if [ "$e2e_configured" = true ]; then
+    if [ -z "$e2e_cmd" ]; then
+      e2e_state="not_configured"
+      e2e_output="NOT CONFIGURED — build.e2e_command is empty; there is no e2e tier to run. This is NOT a pass."
+    elif [ "$e2e_policy" = "skip" ]; then
+      e2e_state="skipped_policy"
+      e2e_output="SKIPPED BY POLICY — verify.e2e=skip; e2e command was never executed. This is NOT a pass."
+    else
+      # Under "last", an unset fast-tier command is vacuously passing (edge case 10):
+      # *_passed stay true when their command is empty, so e2e still runs.
+      local failed_gates=""
+      if [ "$e2e_policy" = "last" ]; then
+        [ "$lint_passed" = true ]  || failed_gates="${failed_gates}${failed_gates:+, }lint"
+        [ "$build_passed" = true ] || failed_gates="${failed_gates}${failed_gates:+, }build"
+        [ "$tests_passed" = true ] || failed_gates="${failed_gates}${failed_gates:+, }test"
+      fi
+      if [ -n "$failed_gates" ]; then
+        e2e_state="skipped_gate_failure"
+        e2e_output="SKIPPED — verify.e2e=last and an earlier gate failed (${failed_gates}); e2e command was never executed. This is NOT a pass."
+      else
+        local e2e_rc=0
+        run_capped e2e_output "$e2e_cmd" e2e "$log_dir" || e2e_rc=$?
+        if [ "$e2e_rc" -eq 0 ]; then
+          e2e_state="passed"
+        else
+          e2e_state="failed"
+          # Exit 137 = SIGKILL, i.e. the memory limit was exceeded (FR13). Never
+          # report it as a generic or flaky test failure.
+          if [ "$e2e_rc" -eq 137 ]; then
+            e2e_memory_limited=true
+            e2e_output="MEMORY LIMIT EXCEEDED — e2e command was killed with SIGKILL (exit 137), not a test assertion failure.
+${e2e_output}"
+          fi
+        fi
+      fi
+    fi
+  fi
+
   # 6. Build AC JSON array
   local ac_json=""
   for ac in "${ac_lines[@]}"; do
@@ -271,6 +346,16 @@ cmd_collect() {
   done
 
   # 7. Output JSON
+  # The e2e block is appended only when the new keys are configured, so a config
+  # without them reproduces the v0.5.9 payload byte-for-byte (NFR1, AC6).
+  local e2e_json=""
+  if [ "$e2e_configured" = true ]; then
+    e2e_json=",
+  \"e2e_output\": \"$(json_escape "$e2e_output")\",
+  \"e2e_state\": \"${e2e_state}\",
+  \"e2e_memory_limited\": ${e2e_memory_limited}"
+  fi
+
   local output
   output=$(cat <<ENDJSON
 {
@@ -284,7 +369,7 @@ cmd_collect() {
   "build_output": "$(json_escape "$build_output")",
   "tests_passed": ${tests_passed},
   "lint_passed": ${lint_passed},
-  "build_passed": ${build_passed}
+  "build_passed": ${build_passed}${e2e_json}
 }
 ENDJSON
 )

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -169,7 +169,17 @@ e2e_acquire_slot() {
   esac
   E2E_SLOT="$slot"
   E2E_SLOT_DIR="$specclaw_dir"
-  trap 'e2e_release_slot' EXIT
+  # Chain rather than clobber: a caller may already hold an EXIT trap (temp-file
+  # cleanup is the obvious one), and silently dropping it would leak whatever it
+  # was there to clean. `trap -p` prints a re-runnable `trap -- '<body>' EXIT`,
+  # so appending it keeps the prior handler intact.
+  local prior_exit=""
+  prior_exit="$(trap -p EXIT)"
+  if [ -n "$prior_exit" ]; then
+    trap "e2e_release_slot; ${prior_exit}" EXIT
+  else
+    trap 'e2e_release_slot' EXIT
+  fi
   trap 'e2e_release_slot; exit 130' INT
   trap 'e2e_release_slot; exit 143' TERM
 }
@@ -181,6 +191,59 @@ e2e_release_slot() {
   local slot="$E2E_SLOT"
   E2E_SLOT=""
   "$BROWSER_LOCK" "$E2E_SLOT_DIR" release "$slot" || true
+}
+
+# Run the e2e command and classify the outcome: take a browser slot, let
+# browser-lock constrain the command (--workers=1, sequential --project fan-out,
+# MemoryMax scope), execute the string it prints, release the slot, then decide
+# whether a non-zero exit was a memory-limit breach or an ordinary failure.
+#
+# Each script keeps one job — browser-lock constrains, run-long (via run_capped)
+# executes and observes, this classifies.
+#
+# Usage: e2e_run <out_var> <state_var> <memlimited_var> <specclaw_dir> <cmd> <log_dir>
+e2e_run() {
+  local -n _run_out="$1" _run_state="$2" _run_mem="$3"
+  local specclaw_dir="$4" e2e_cmd="$5" log_dir="$6"
+
+  # Bounded invocation (FR10, FR12).
+  local e2e_run_cmd="$e2e_cmd" e2e_cap=""
+  if [ -n "$BROWSER_LOCK" ]; then
+    e2e_acquire_slot "$specclaw_dir"
+    local wrapped="" wrap_rc=0
+    wrapped=$("$BROWSER_LOCK" "$specclaw_dir" wrap "$e2e_cmd") || wrap_rc=$?
+    if [ -n "$wrapped" ] && { [ "$wrap_rc" -eq 0 ] || [ "$wrap_rc" -eq 10 ]; }; then
+      e2e_run_cmd="$wrapped"
+      # wrap exit 0 = a memory cap was applied, 10 = emitted uncapped. Only the
+      # capped case may attribute an exit 137 to the cap (FR13), and the cap it
+      # actually carries is the one named in the report.
+      if [ "$wrap_rc" -eq 0 ] && [[ "$wrapped" =~ MemoryMax=([0-9]+M) ]]; then
+        e2e_cap="cap ${BASH_REMATCH[1]}"
+      fi
+    else
+      warn "browser-lock wrap failed (exit ${wrap_rc}) — running the e2e command unwrapped and uncapped"
+    fi
+  fi
+
+  local out="" rc=0
+  run_capped out "$e2e_run_cmd" e2e "$log_dir" || rc=$?
+  e2e_release_slot
+
+  if [ "$rc" -eq 0 ]; then
+    _run_state="passed"
+  else
+    _run_state="failed"
+    # Exit 137 = SIGKILL. Only a run that actually carried a memory cap can be
+    # reported as a memory-limit breach, and then it never reads as a generic or
+    # flaky test failure (FR13). The same code with no cap applied stays a plain
+    # failure (AC13).
+    if [ "$rc" -eq 137 ] && [ -n "$e2e_cap" ]; then
+      _run_mem=true
+      out="MEMORY LIMIT EXCEEDED — e2e command exceeded its memory limit (${e2e_cap}) and was killed with SIGKILL (exit 137), not a test assertion failure.
+${out}"
+    fi
+  fi
+  _run_out="$out"
 }
 
 # ─── Subcommand: collect ──────────────────────────────────────────────────────
@@ -296,7 +359,12 @@ cmd_collect() {
     e2e_cmd=$(yaml_val "$config_file" "build.e2e_command")
     e2e_policy=$(yaml_val "$config_file" "verify.e2e")
     HEARTBEAT_SECONDS=$(yaml_val "$config_file" "verify.heartbeat_seconds")
-    if yaml_has_key "$config_file" "e2e_command" || yaml_has_key "$config_file" "e2e"; then
+    # Exactly two keys switch the e2e payload fields on: `build.e2e_command` and
+    # `verify.e2e`. The `e2e` pattern is anchored to a following space so a
+    # future `e2e_timeout:` cannot enable the block by accident — a bare `e2e:`
+    # with no value would also not match, which is the fail-closed direction.
+    if yaml_has_key "$config_file" "e2e_command" ||
+       grep -qE "^[[:space:]]*e2e:[[:space:]]" "$config_file" 2>/dev/null; then
       e2e_configured=true
     fi
   else
@@ -361,46 +429,8 @@ cmd_collect() {
         e2e_state="skipped_gate_failure"
         e2e_output="SKIPPED — verify.e2e=last and an earlier gate failed (${failed_gates}); e2e command was never executed. This is NOT a pass."
       else
-        # Bounded invocation (FR10, FR12): hold a browser slot for the run, let
-        # browser-lock decide how the command is constrained (--workers=1,
-        # sequential --project fan-out, MemoryMax scope), and execute the string
-        # it prints. Each script keeps one job — browser-lock constrains, run-long
-        # (via run_capped) executes and observes.
-        local e2e_run_cmd="$e2e_cmd" e2e_cap=""
-        if [ -n "$BROWSER_LOCK" ]; then
-          e2e_acquire_slot "$specclaw_dir"
-          local wrapped="" wrap_rc=0
-          wrapped=$("$BROWSER_LOCK" "$specclaw_dir" wrap "$e2e_cmd") || wrap_rc=$?
-          if [ -n "$wrapped" ] && { [ "$wrap_rc" -eq 0 ] || [ "$wrap_rc" -eq 10 ]; }; then
-            e2e_run_cmd="$wrapped"
-            # wrap exit 0 = a memory cap was applied, 10 = emitted uncapped. Only
-            # the capped case may attribute an exit 137 to the cap (FR13), and the
-            # cap it actually carries is the one named in the report.
-            if [ "$wrap_rc" -eq 0 ] && [[ "$wrapped" =~ MemoryMax=([0-9]+M) ]]; then
-              e2e_cap="cap ${BASH_REMATCH[1]}"
-            fi
-          else
-            warn "browser-lock wrap failed (exit ${wrap_rc}) — running the e2e command unwrapped and uncapped"
-          fi
-        fi
-
-        local e2e_rc=0
-        run_capped e2e_output "$e2e_run_cmd" e2e "$log_dir" || e2e_rc=$?
-        e2e_release_slot
-        if [ "$e2e_rc" -eq 0 ]; then
-          e2e_state="passed"
-        else
-          e2e_state="failed"
-          # Exit 137 = SIGKILL. Only a run that actually carried a memory cap can
-          # be reported as a memory-limit breach, and then it never reads as a
-          # generic or flaky test failure (FR13). The same code with no cap
-          # applied stays a plain failure (AC13).
-          if [ "$e2e_rc" -eq 137 ] && [ -n "$e2e_cap" ]; then
-            e2e_memory_limited=true
-            e2e_output="MEMORY LIMIT EXCEEDED — e2e command exceeded its memory limit (${e2e_cap}) and was killed with SIGKILL (exit 137), not a test assertion failure.
-${e2e_output}"
-          fi
-        fi
+        e2e_run e2e_output e2e_state e2e_memory_limited \
+          "$specclaw_dir" "$e2e_cmd" "$log_dir"
       fi
     fi
   fi

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -176,6 +176,10 @@ e2e_acquire_slot() {
   local prior_exit=""
   prior_exit="$(trap -p EXIT)"
   if [ -n "$prior_exit" ]; then
+    # SC2064 (expand-now) is the point: `$prior_exit` must be baked into the new
+    # handler at install time, since the variable is local and will be gone by
+    # the time EXIT fires.
+    # shellcheck disable=SC2064
     trap "e2e_release_slot; ${prior_exit}" EXIT
   else
     trap 'e2e_release_slot' EXIT

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -38,11 +38,13 @@ Gathers acceptance criteria from `spec.md`, current contents of changed files, a
 
 An absent `verify.e2e` means `last`; an unrecognised value warns on stderr and falls back to `last`.
 
+When the e2e command does run, `collect` brackets it: it takes a browser slot (`specclaw-browser-lock acquire`), passes the command through `specclaw-browser-lock wrap` — which adds `--workers=1` for Playwright, one sequential `--project=` invocation per `verify.playwright.projects` entry, and a `MemoryMax=<verify.playwright.max_memory_mb>M` scope when `systemd-run` is usable — runs the wrapped string, then releases the slot. The slot is released even when the command fails or the run is interrupted. When `systemd-run` is unusable, `wrap` warns and the command runs uncapped.
+
 When any of these keys is present, `collect` adds three fields to the payload:
 
 - **`e2e_output`** — the e2e command's capped output, or an explicit reason string when it did not run.
 - **`e2e_state`** — one of `passed`, `failed`, `skipped_policy`, `skipped_gate_failure`, `not_configured`.
-- **`e2e_memory_limited`** — `true` when the e2e command was killed with SIGKILL (exit `137`), i.e. it exceeded its memory limit.
+- **`e2e_memory_limited`** — `true` only when the e2e command exited `137` (SIGKILL) **while a memory cap was actually applied**. An exit `137` with no cap in force (`systemd-run` unusable, or no browser-lock) leaves this `false`, because the kill cannot be attributed to a specclaw cap.
 
 With none of the keys present, the payload is unchanged from before the e2e tier existed.
 
@@ -50,7 +52,8 @@ With none of the keys present, the payload is unchanged from before the e2e tier
 
 - `passed` is the *only* state that may be reported as e2e passing.
 - `skipped_policy`, `skipped_gate_failure` and `not_configured` mean **e2e evidence does not exist**. Say so explicitly in `verify-report.md` (e.g. "E2E: skipped — `verify.e2e=last`, lint gate failed; no e2e evidence"), and do not mark an acceptance criterion that depends on e2e evidence as met. If an AC can only be proven by the e2e suite, a skipped e2e makes that AC unverified, which caps the verdict at PARTIAL.
-- `e2e_memory_limited: true` must be reported as *the memory limit was exceeded*, never as a generic or flaky test failure.
+- `e2e_memory_limited: true` must be reported as **the memory limit was exceeded**, naming the cap that `e2e_output` quotes (e.g. "E2E: memory limit exceeded — killed by SIGKILL under cap 4096M"). Never call it a flaky, transient or generic test failure, and never suggest a re-run as the fix: raise `verify.playwright.max_memory_mb`, cut `verify.playwright.max_browsers`, or split `verify.playwright.projects`.
+- `e2e_memory_limited: false` with `e2e_state: failed` is an ordinary failure — report it from `e2e_output` on its own terms. An exit `137` here means the process was killed with no specclaw cap in force (host OOM killer or an external kill); say that, and do not name a cap.
 
 ## Step 2 — Build verify context
 

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -24,7 +24,33 @@ If it fails (tasks not all complete), report and stop.
 specclaw-verify collect .specclaw <change>
 ```
 
-Gathers acceptance criteria from `spec.md`, current contents of changed files, and configured test/lint/build command results.
+Gathers acceptance criteria from `spec.md`, current contents of changed files, and configured lint/build/test command results — run in that order — followed by the e2e tier when configured.
+
+### E2E tier (`build.e2e_command` + `verify.e2e`)
+
+`build.e2e_command` is the slow tier (browser/e2e); `build.test_command` stays the fast tier. `verify.e2e` decides when the slow tier runs:
+
+| Policy | Behaviour |
+|--------|-----------|
+| `last` (default) | Run e2e only after `lint_command`, `build_command` and `test_command` all pass. An unset fast-tier command is vacuously passing. |
+| `skip` | Never run e2e. |
+| `always` | Run e2e even when an earlier gate failed. |
+
+An absent `verify.e2e` means `last`; an unrecognised value warns on stderr and falls back to `last`.
+
+When any of these keys is present, `collect` adds three fields to the payload:
+
+- **`e2e_output`** — the e2e command's capped output, or an explicit reason string when it did not run.
+- **`e2e_state`** — one of `passed`, `failed`, `skipped_policy`, `skipped_gate_failure`, `not_configured`.
+- **`e2e_memory_limited`** — `true` when the e2e command was killed with SIGKILL (exit `137`), i.e. it exceeded its memory limit.
+
+With none of the keys present, the payload is unchanged from before the e2e tier existed.
+
+**Report a skip as a skip — never as a pass.** `e2e_state` is the authority, not `e2e_output`:
+
+- `passed` is the *only* state that may be reported as e2e passing.
+- `skipped_policy`, `skipped_gate_failure` and `not_configured` mean **e2e evidence does not exist**. Say so explicitly in `verify-report.md` (e.g. "E2E: skipped — `verify.e2e=last`, lint gate failed; no e2e evidence"), and do not mark an acceptance criterion that depends on e2e evidence as met. If an AC can only be proven by the e2e suite, a skipped e2e makes that AC unverified, which caps the verdict at PARTIAL.
+- `e2e_memory_limited: true` must be reported as *the memory limit was exceeded*, never as a generic or flaky test failure.
 
 ## Step 2 — Build verify context
 

--- a/plugins/specclaw/templates/config.yaml
+++ b/plugins/specclaw/templates/config.yaml
@@ -84,6 +84,10 @@ verify:
   heartbeat_seconds: 60            # Liveness heartbeat interval for long commands (stderr)
   playwright:
     max_browsers: 2                # Hard cap on concurrent Playwright/Chromium instances across all agents
+    max_memory_mb: 4096            # Memory ceiling (MB) per e2e invocation, applied via systemd-run --scope
+                                   # Absent → 4096. systemd-run unusable → command runs uncapped (warned).
+    projects: []                   # Playwright project names to run one-per-invocation, sequentially
+                                   # Absent or empty → a single invocation, no --project flag added.
 
 # Notifications
 notifications:

--- a/plugins/specclaw/templates/config.yaml
+++ b/plugins/specclaw/templates/config.yaml
@@ -44,7 +44,10 @@ context:
 
 # Build settings
 build:
-  test_command: ""                 # e.g., "npm test", "pytest"
+  test_command: ""                 # Fast tier: unit/integration. e.g., "npm test", "pytest"
+  e2e_command: ""                  # Slow tier: browser/e2e. e.g., "npx playwright test"
+                                   # Run separately from test_command, per verify.e2e below.
+                                   # Absent or empty → no e2e tier, behaviour unchanged.
   lint_command: ""                 # e.g., "npm run lint"
   build_command: ""                # e.g., "npm run build"
   parallel_tasks: 3               # Max concurrent agent spawns
@@ -73,6 +76,12 @@ build:
 
 # Verify settings
 verify:
+  # When the slow tier (build.e2e_command) runs. Absent → "last".
+  #   skip   — never run e2e during verify
+  #   last   — run e2e only after lint, build and test all pass
+  #   always — run e2e even when an earlier gate failed
+  e2e: last
+  heartbeat_seconds: 60            # Liveness heartbeat interval for long commands (stderr)
   playwright:
     max_browsers: 2                # Hard cap on concurrent Playwright/Chromium instances across all agents
 

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -343,6 +343,69 @@ assert_eq "edge4b cached-dirty sidecar re-executes" "2" "$(wc -l < "$ctr12" | tr
 assert_contains "edge4b cached-dirty refusal is reported" "recorded with a dirty tree" "$(cat "$err12")"
 echo
 
+echo "--- Case 12b (review): an untracked file counts as dirty and refuses reuse ---"
+# `git diff` and `git diff --cached` are both blind to untracked files, so a
+# brand-new not-yet-added test file would otherwise leave the tree looking clean
+# and serve a cached pass for a suite that never saw the new file.
+r12b="$WORK/repo-untracked"
+make_repo "$r12b"
+d12b="$WORK/untracked-logs"
+ctr12b="$WORK/counter-untracked"
+: > "$ctr12b"
+SIDE12B="sh -c 'echo z >> $ctr12b'"
+( cd "$r12b" && "$RUNLONG" --log-dir "$d12b" --phase ut -- "$SIDE12B" ) >/dev/null 2>&1
+assert_eq "review untracked: first run executes" "1" "$(wc -l < "$ctr12b" | tr -d ' ')"
+# Clean tree, matching HEAD -> the reuse would hit ...
+( cd "$r12b" && "$RUNLONG" --log-dir "$d12b" --phase ut --reuse -- "$SIDE12B" ) >/dev/null 2>&1
+assert_eq "review untracked: a genuinely clean tree still reuses" "1" \
+  "$(wc -l < "$ctr12b" | tr -d ' ')"
+# ... until an untracked file appears.
+echo "new test" > "$r12b/new_test.sh"
+err12b="$WORK/reuse-untracked.err"
+( cd "$r12b" && "$RUNLONG" --log-dir "$d12b" --phase ut --reuse -- "$SIDE12B" ) >/dev/null 2>"$err12b"
+assert_eq "review untracked: an untracked file re-executes" "2" "$(wc -l < "$ctr12b" | tr -d ' ')"
+assert_contains "review untracked: refusal is reported as a dirty tree" \
+  "working tree is dirty" "$(cat "$err12b")"
+# A .gitignore'd file is NOT dirt — --exclude-standard must hold, or reuse would
+# never hit in any repo with build output on disk.
+rm -f "$r12b/new_test.sh"
+echo "junk.log" > "$r12b/.gitignore"
+git -C "$r12b" add .gitignore
+git -C "$r12b" commit -qm "gitignore"
+echo noise > "$r12b/junk.log"
+( cd "$r12b" && "$RUNLONG" --log-dir "$d12b" --phase ut -- "$SIDE12B" ) >/dev/null 2>&1
+( cd "$r12b" && "$RUNLONG" --log-dir "$d12b" --phase ut --reuse -- "$SIDE12B" ) >/dev/null 2>&1
+assert_eq "review untracked: an ignored file is not dirt, reuse still hits" "3" \
+  "$(wc -l < "$ctr12b" | tr -d ' ')"
+echo
+
+echo "--- Case 12c (review): a slug collision does not serve another command's result ---"
+# The sidecar is located by slug, and the slug is truncated, so two long commands
+# sharing a prefix land on the same filename. Only the stored `cmd` proves identity.
+r12c="$WORK/repo-slugcollide"
+make_repo "$r12c"
+d12c="$WORK/slugcollide-logs"
+ctr12c="$WORK/counter-slugcollide"
+: > "$ctr12c"
+PREFIX="sh -c 'echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+CMD_A="$PREFIX >/dev/null; echo A >> $ctr12c'"
+CMD_B="$PREFIX >/dev/null; echo B >> $ctr12c'"
+( cd "$r12c" && "$RUNLONG" --log-dir "$d12c" --phase sc -- "$CMD_A" ) >/dev/null 2>&1
+assert_eq "review slug: command A ran once" "1" "$(wc -l < "$ctr12c" | tr -d ' ')"
+# Same phase, same truncated slug, same HEAD, clean tree — the only difference is
+# the command itself, which must be enough to force a re-run.
+err12c="$WORK/reuse-slugcollide.err"
+( cd "$r12c" && "$RUNLONG" --log-dir "$d12c" --phase sc --reuse -- "$CMD_B" ) >/dev/null 2>"$err12c"
+assert_eq "review slug: command B is not served A's cached result" "2" \
+  "$(wc -l < "$ctr12c" | tr -d ' ')"
+assert_eq "review slug: it was B that ran, not A again" "B" "$(tail -1 "$ctr12c")"
+assert_contains "review slug: the refusal names the command mismatch" \
+  "written for a different command" "$(cat "$err12c")"
+# The identical command still reuses — the guard must not break the happy path.
+( cd "$r12c" && "$RUNLONG" --log-dir "$d12c" --phase sc --reuse -- "$CMD_B" ) >/dev/null 2>&1
+assert_eq "review slug: an identical command still reuses" "2" "$(wc -l < "$ctr12c" | tr -d ' ')"
+echo
+
 echo "--- Case 13 (edge 3): repo with zero commits -> empty head stamp, reuse fails closed ---"
 r13="$WORK/repo-empty"
 make_repo "$r13" --empty

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+# run-long-orchestration-tests.sh — regression suite for Wave 1 of the
+# `long-running-test-orchestration` change: `bin/specclaw-run-long`.
+#
+# Locks in:
+#   specclaw-run-long (FR1–FR5):
+#     AC1: `sh -c 'echo hi; exit 3'` -> exit 3, `hi` in the tail, `hi` on disk.
+#     AC2: 500-line command -> 100-line tail + `... (truncated, 500 total lines)`
+#          marker on stdout, all 500 lines on disk.
+#     AC3: --heartbeat 1 against a 3s command -> >=2 heartbeat lines on STDERR;
+#          a sub-interval command emits none.
+#     AC4: sidecar always written (pass and fail) with exit/duration_s/log/head/
+#          dirty/cmd/interrupted, head = 40-char SHA.
+#     AC5: --reuse on matching HEAD + clean tree does NOT re-execute (proven by a
+#          side-effecting counter file); refuses after a new commit.
+#   Stream discipline (FR2/FR3, design "stderr = liveness, stdout = payload,
+#     disk = truth"): heartbeats never land on stdout.
+#   Edge cases:
+#     1: unwritable --log-dir -> mktemp fallback; mktemp failure too -> inline.
+#     2: eval semantics survive — pipes, `&&`, `VAR=x` env prefixes.
+#     3: repo with zero commits -> empty head stamp, --reuse fails closed.
+#     4: dirty tree -> --reuse refuses; a sidecar recorded dirty is never reused.
+#     5: log name carries a PID discriminator, so concurrent runs never collide.
+#     6: heartbeat still fires when the command prints nothing.
+#     7: --heartbeat 0 / non-integer clamps to the 60s default.
+#     16: SIGTERM kills the child process group, writes an `interrupted=true`
+#         sidecar, exits non-zero, leaves no orphan.
+#
+# Plain bash + coreutils — no jq/bats/npm (NFR3). Run from anywhere:
+#   bash plugins/specclaw/tests/run-long-orchestration-tests.sh
+# Exits non-zero if any case fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/../bin" && pwd)"
+
+RUNLONG="$BIN_DIR/specclaw-run-long"
+
+if [[ ! -f "$RUNLONG" ]]; then
+  echo "FATAL: missing bin script: $RUNLONG" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+# Track any background PIDs we spawn (run-long parents, sleepers) so nothing
+# outlives the suite — same guard as run-memory-parallelism-tests.sh.
+SLEEPERS=()
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below.
+cleanup() {
+  local p
+  for p in "${SLEEPERS[@]:-}"; do
+    [[ -n "$p" ]] && kill "$p" 2>/dev/null || true
+  done
+  # Belt and braces: reap the marker children used by the interrupt case.
+  pkill -f '^sleep 47' 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label (= '$actual')"
+  else
+    fail "$label (expected '$expected', got '$actual')"
+  fi
+}
+
+# assert_contains <label> <needle> <haystack>
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label (found '$needle')"
+  else
+    fail "$label (missing '$needle' in: $(printf '%s' "$haystack" | head -3 | tr '\n' '|'))"
+  fi
+}
+
+# assert_not_contains <label> <needle> <haystack>
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$label (absent '$needle')"
+  else
+    fail "$label (unexpectedly found '$needle')"
+  fi
+}
+
+# The captured payload minus the trailing `log: <path>` line. Needed for
+# negative assertions: the log path embeds a slug of the command itself, so
+# grepping raw stdout for an absent token would self-match via the filename.
+payload() { grep -v '^log: ' <<<"$1" || true; }
+
+# Read a key from a key=value sidecar (first '=' only), echo the value.
+sc() {
+  local file="$1" key="$2"
+  sed -n "s/^${key}=//p" "$file" 2>/dev/null | head -1 || true
+}
+
+# Newest .result sidecar in a directory.
+newest_result() {
+  ls -t "$1"/*.result 2>/dev/null | head -1 || true
+}
+
+# make_repo <dir> [--empty]
+# A self-contained git repo so HEAD/dirty stamping is deterministic.
+make_repo() {
+  local d="$1" empty="${2:-}"
+  mkdir -p "$d"
+  git -C "$d" init -q
+  git -C "$d" config user.email "test@specclaw.invalid"
+  git -C "$d" config user.name "specclaw tests"
+  git -C "$d" config commit.gpgsign false
+  [[ "$empty" == "--empty" ]] && return 0
+  echo one > "$d/file.txt"
+  git -C "$d" add file.txt
+  git -C "$d" commit -qm "init"
+}
+
+echo "=== specclaw long-running-test-orchestration (Wave 1) regression suite ==="
+echo "bin:  $BIN_DIR"
+echo "work: $WORK"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exit code, tail, and on-disk log
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 1 (AC1): exit code propagates; tail and disk log carry output ---"
+d1="$WORK/ac1"
+out="$("$RUNLONG" --log-dir "$d1" --phase t1 -- "sh -c 'echo hi; exit 3'" 2>"$d1.err")"; rc=$?
+assert_eq "AC1 exit code propagates" "3" "$rc"
+assert_contains "AC1 tail carries stdout" "hi" "$out"
+assert_contains "AC1 stdout announces the log path" "log: $d1/" "$out"
+log1="$(sed -n 's/^log: //p' <<<"$out" | head -1)"
+if [[ -f "$log1" ]]; then
+  pass "AC1 log file exists on disk ($log1)"
+  assert_eq "AC1 on-disk log content" "hi" "$(cat "$log1")"
+else
+  fail "AC1 log file exists on disk (got '$log1')"
+fi
+echo
+
+echo "--- Case 2 (AC1b): a passing command exits 0 ---"
+d2="$WORK/ac1b"
+out="$("$RUNLONG" --log-dir "$d2" --phase t2 -- "sh -c 'echo ok'" 2>/dev/null)"; rc=$?
+assert_eq "AC1b passing command exits 0" "0" "$rc"
+assert_contains "AC1b tail carries output" "ok" "$out"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Capped tail (FR3 / NFR4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 3 (AC2): 500 lines -> 100-line tail + truncation marker, 500 on disk ---"
+d3="$WORK/ac2"
+out="$("$RUNLONG" --log-dir "$d3" --phase t3 -- "seq 1 500" 2>/dev/null)"; rc=$?
+assert_eq "AC2 exit 0" "0" "$rc"
+# stdout = 100 tail lines + 1 truncation marker + 1 `log:` line.
+assert_eq "AC2 stdout is exactly 102 lines" "102" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+assert_eq "AC2 tail starts at line 401" "401" "$(printf '%s\n' "$out" | head -1)"
+assert_contains "AC2 truncation marker" "... (truncated, 500 total lines)" "$out"
+log3="$(sed -n 's/^log: //p' <<<"$out" | head -1)"
+assert_eq "AC2 on-disk log holds all 500 lines" "500" "$(wc -l < "$log3" | tr -d ' ')"
+assert_eq "AC2 on-disk log last line" "500" "$(tail -1 "$log3")"
+echo
+
+echo "--- Case 4 (AC2b): a sub-cap command is printed whole, with no marker ---"
+d4="$WORK/ac2b"
+out="$("$RUNLONG" --log-dir "$d4" --phase t4 -- "seq 1 5" 2>/dev/null)"
+assert_eq "AC2b stdout is 5 lines + log line" "6" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+assert_not_contains "AC2b no truncation marker" "truncated" "$out"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heartbeats (FR2, AC3, edge cases 6 & 7) — stderr only
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 5 (AC3 + edge 6): --heartbeat 1 on a 3s silent command ---"
+d5="$WORK/ac3"
+mkdir -p "$d5"
+out="$("$RUNLONG" --log-dir "$d5" --phase hb --heartbeat 1 -- "sleep 3" 2>"$d5/err")"; rc=$?
+assert_eq "AC3 exit 0" "0" "$rc"
+beats="$(grep -c 'elapsed' "$d5/err" 2>/dev/null || true)"
+if [[ "${beats:-0}" -ge 2 ]]; then
+  pass "AC3 at least 2 heartbeat lines on stderr (got $beats)"
+else
+  fail "AC3 at least 2 heartbeat lines on stderr (got ${beats:-0}: $(tr '\n' '|' < "$d5/err"))"
+fi
+assert_contains "AC3 heartbeat carries elapsed seconds and log line count" "log lines" "$(cat "$d5/err")"
+# Edge case 6: a silent command must still produce a heartbeat, with a note.
+assert_contains "edge6 silent command still heartbeats" "(no output yet)" "$(cat "$d5/err")"
+# Stream discipline: heartbeats must never pollute the captured payload.
+assert_not_contains "AC3 heartbeats stay off stdout" "[run-long]" "$out"
+echo
+
+echo "--- Case 6 (AC3b): a command shorter than one interval emits no heartbeat ---"
+d6="$WORK/ac3b"
+mkdir -p "$d6"
+"$RUNLONG" --log-dir "$d6" --phase hb2 -- "echo quick" >/dev/null 2>"$d6/err"
+assert_eq "AC3b zero heartbeat lines under one interval" "0" "$(grep -c 'elapsed' "$d6/err" 2>/dev/null || true)"
+echo
+
+echo "--- Case 7 (edge 7): --heartbeat 0 / non-integer clamps to the 60s default ---"
+d7="$WORK/edge7"
+mkdir -p "$d7"
+"$RUNLONG" --log-dir "$d7" --phase z --heartbeat 0 -- "echo x" >/dev/null 2>"$d7/zero.err"; rc=$?
+assert_eq "edge7 --heartbeat 0 still exits 0" "0" "$rc"
+assert_contains "edge7 --heartbeat 0 warns and clamps to 60" "clamping to 60s" "$(cat "$d7/zero.err")"
+"$RUNLONG" --log-dir "$d7" --phase z2 --heartbeat abc -- "sleep 2" >/dev/null 2>"$d7/nan.err"; rc=$?
+assert_eq "edge7 non-integer heartbeat still exits 0" "0" "$rc"
+assert_contains "edge7 non-integer heartbeat warns and clamps" "clamping to 60s" "$(cat "$d7/nan.err")"
+# Clamped to 60s, a 2s command must stay silent (no busy-loop, no 0-division).
+assert_eq "edge7 clamped interval emits no heartbeat for a 2s command" "0" \
+  "$(grep -c 'elapsed' "$d7/nan.err" 2>/dev/null || true)"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sidecar (FR4 / AC4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 8 (AC4): sidecar written on PASS with every required key ---"
+r8="$WORK/repo-ac4"
+make_repo "$r8"
+d8="$WORK/ac4-logs"
+( cd "$r8" && "$RUNLONG" --log-dir "$d8" --phase ok -- "sh -c 'echo fine'" ) >/dev/null 2>&1
+s8="$(newest_result "$d8")"
+if [[ -n "$s8" && -f "$s8" ]]; then
+  pass "AC4 sidecar exists after a pass ($(basename "$s8"))"
+  assert_eq "AC4 sidecar exit=0" "0" "$(sc "$s8" exit)"
+  assert_eq "AC4 sidecar cmd round-trips" "sh -c 'echo fine'" "$(sc "$s8" cmd)"
+  assert_eq "AC4 sidecar interrupted=false" "false" "$(sc "$s8" interrupted)"
+  assert_eq "AC4 sidecar dirty=false on a clean tree" "false" "$(sc "$s8" dirty)"
+  head8="$(sc "$s8" head)"
+  assert_eq "AC4 sidecar head is a 40-char SHA" "40" "${#head8}"
+  assert_eq "AC4 sidecar head equals repo HEAD" "$(git -C "$r8" rev-parse HEAD)" "$head8"
+  dur8="$(sc "$s8" duration_s)"
+  if [[ "$dur8" =~ ^[0-9]+$ ]]; then
+    pass "AC4 sidecar duration_s is an integer (= ${dur8})"
+  else
+    fail "AC4 sidecar duration_s is an integer (got '$dur8')"
+  fi
+  log8="$(sc "$s8" log)"
+  if [[ -f "$log8" ]]; then
+    pass "AC4 sidecar log path points at a real file"
+  else
+    fail "AC4 sidecar log path points at a real file (got '$log8')"
+  fi
+else
+  fail "AC4 sidecar exists after a pass (none found in $d8)"
+fi
+echo
+
+echo "--- Case 9 (AC4b): sidecar written on FAIL too, recording the exit code ---"
+d9="$WORK/ac4b-logs"
+( cd "$r8" && "$RUNLONG" --log-dir "$d9" --phase bad -- "sh -c 'echo boom >&2; exit 7'" ) >/dev/null 2>&1
+s9="$(newest_result "$d9")"
+if [[ -n "$s9" && -f "$s9" ]]; then
+  pass "AC4b sidecar exists after a failure"
+  assert_eq "AC4b sidecar records exit=7" "7" "$(sc "$s9" exit)"
+  assert_eq "AC4b stderr of the child landed in the log" "boom" "$(cat "$(sc "$s9" log)")"
+else
+  fail "AC4b sidecar exists after a failure (none found in $d9)"
+fi
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --reuse (FR5, AC5, edge cases 3 & 4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 10 (AC5): --reuse hits on matching HEAD + clean tree, misses after a commit ---"
+r10="$WORK/repo-reuse"
+make_repo "$r10"
+d10="$WORK/reuse-logs"
+ctr10="$WORK/counter-reuse"
+: > "$ctr10"
+SIDE="sh -c 'echo x >> $ctr10'"
+
+( cd "$r10" && "$RUNLONG" --log-dir "$d10" --phase re -- "$SIDE" ) >/dev/null 2>&1
+assert_eq "AC5 first run executes the side effect" "1" "$(wc -l < "$ctr10" | tr -d ' ')"
+
+err10="$WORK/reuse-hit.err"
+out10="$( cd "$r10" && "$RUNLONG" --log-dir "$d10" --phase re --reuse -- "$SIDE" 2>"$err10" )"; rc=$?
+assert_eq "AC5 reuse hit does NOT re-execute" "1" "$(wc -l < "$ctr10" | tr -d ' ')"
+assert_eq "AC5 reuse hit replays the cached exit code" "0" "$rc"
+assert_contains "AC5 reuse hit says so on stderr" "reuse: sidecar HEAD matches" "$(cat "$err10")"
+assert_contains "AC5 reuse hit still prints a log path on stdout" "log: " "$out10"
+
+# A new commit invalidates the stamp.
+echo two >> "$r10/file.txt"
+git -C "$r10" add file.txt
+git -C "$r10" commit -qm "second"
+err10b="$WORK/reuse-headmiss.err"
+( cd "$r10" && "$RUNLONG" --log-dir "$d10" --phase re --reuse -- "$SIDE" ) >/dev/null 2>"$err10b"
+assert_eq "AC5 new commit invalidates reuse (re-executed)" "2" "$(wc -l < "$ctr10" | tr -d ' ')"
+assert_contains "AC5 HEAD-mismatch is reported" "re-executing" "$(cat "$err10b")"
+echo
+
+echo "--- Case 11 (edge 4): a dirty tree refuses reuse ---"
+echo dirt >> "$r10/file.txt"
+err11="$WORK/reuse-dirty.err"
+( cd "$r10" && "$RUNLONG" --log-dir "$d10" --phase re --reuse -- "$SIDE" ) >/dev/null 2>"$err11"
+assert_eq "edge4 dirty tree re-executes" "3" "$(wc -l < "$ctr10" | tr -d ' ')"
+assert_contains "edge4 dirty tree is reported" "working tree is dirty" "$(cat "$err11")"
+git -C "$r10" checkout -q -- file.txt
+echo
+
+echo "--- Case 12 (edge 4b): a sidecar recorded on a dirty tree is never reused ---"
+r12="$WORK/repo-cacheddirty"
+make_repo "$r12"
+d12="$WORK/cacheddirty-logs"
+ctr12="$WORK/counter-cacheddirty"
+: > "$ctr12"
+SIDE12="sh -c 'echo y >> $ctr12'"
+# Record the sidecar while the tree is dirty ...
+echo dirt >> "$r12/file.txt"
+( cd "$r12" && "$RUNLONG" --log-dir "$d12" --phase cd -- "$SIDE12" ) >/dev/null 2>&1
+s12="$(newest_result "$d12")"
+assert_eq "edge4b sidecar records dirty=true" "true" "$(sc "$s12" dirty)"
+# ... then clean the tree: HEAD matches and the tree is clean, but the cached
+# result was measured against uncommitted edits, so it must not be served.
+git -C "$r12" checkout -q -- file.txt
+err12="$WORK/reuse-cacheddirty.err"
+( cd "$r12" && "$RUNLONG" --log-dir "$d12" --phase cd --reuse -- "$SIDE12" ) >/dev/null 2>"$err12"
+assert_eq "edge4b cached-dirty sidecar re-executes" "2" "$(wc -l < "$ctr12" | tr -d ' ')"
+assert_contains "edge4b cached-dirty refusal is reported" "recorded with a dirty tree" "$(cat "$err12")"
+echo
+
+echo "--- Case 13 (edge 3): repo with zero commits -> empty head stamp, reuse fails closed ---"
+r13="$WORK/repo-empty"
+make_repo "$r13" --empty
+d13="$WORK/empty-logs"
+ctr13="$WORK/counter-empty"
+: > "$ctr13"
+SIDE13="sh -c 'echo z >> $ctr13'"
+( cd "$r13" && "$RUNLONG" --log-dir "$d13" --phase eh -- "$SIDE13" ) >/dev/null 2>&1
+s13="$(newest_result "$d13")"
+assert_eq "edge3 sidecar exists for a commit-less repo" "0" "$(sc "$s13" exit)"
+assert_eq "edge3 head stamp is empty" "" "$(sc "$s13" head)"
+err13="$WORK/reuse-nohead.err"
+( cd "$r13" && "$RUNLONG" --log-dir "$d13" --phase eh --reuse -- "$SIDE13" ) >/dev/null 2>"$err13"
+assert_eq "edge3 no-HEAD reuse fails closed (re-executed)" "2" "$(wc -l < "$ctr13" | tr -d ' ')"
+assert_contains "edge3 no-HEAD refusal is reported" "no HEAD available" "$(cat "$err13")"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# eval semantics (edge case 2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 14 (edge 2): pipes, &&, and env prefixes survive eval ---"
+d14="$WORK/edge2"
+out="$("$RUNLONG" --log-dir "$d14" --phase pipe -- "printf 'aaa\nbbb\nccc\n' | grep bbb" 2>/dev/null)"; rc=$?
+assert_eq "edge2 pipeline exits 0" "0" "$rc"
+assert_contains "edge2 pipeline output preserved" "bbb" "$out"
+assert_not_contains "edge2 pipeline actually filtered" "aaa" "$(payload "$out")"
+
+out="$("$RUNLONG" --log-dir "$d14" --phase and -- "sh -c 'exit 0' && echo second-ran" 2>/dev/null)"; rc=$?
+assert_eq "edge2 && chain exits 0" "0" "$rc"
+assert_contains "edge2 && chain ran the right-hand side" "second-ran" "$out"
+
+out="$("$RUNLONG" --log-dir "$d14" --phase and2 -- "sh -c 'exit 4' && echo must-not-run" 2>/dev/null)"; rc=$?
+assert_eq "edge2 && short-circuit propagates the left exit code" "4" "$rc"
+assert_not_contains "edge2 && short-circuit skipped the right-hand side" "must-not-run" "$(payload "$out")"
+
+out="$("$RUNLONG" --log-dir "$d14" --phase env -- 'FOO=bar sh -c "echo got=\$FOO"' 2>/dev/null)"; rc=$?
+assert_eq "edge2 env-prefix exits 0" "0" "$rc"
+assert_contains "edge2 env prefix reached the child" "got=bar" "$out"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Log-dir fail-open (edge case 1 / NFR2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 15 (edge 1): unwritable --log-dir falls back to mktemp ---"
+blocker="$WORK/not-a-dir"
+: > "$blocker"           # a regular file: mkdir -p below it fails even as root
+err15="$WORK/edge1.err"
+out="$("$RUNLONG" --log-dir "$blocker/logs" --phase fb -- "echo fellback" 2>"$err15")"; rc=$?
+assert_eq "edge1 fallback still exits 0" "0" "$rc"
+assert_contains "edge1 warns about the unwritable log dir" "falling back to mktemp" "$(cat "$err15")"
+assert_contains "edge1 output still captured" "fellback" "$out"
+log15="$(sed -n 's/^log: //p' <<<"$out" | head -1)"
+assert_not_contains "edge1 log did NOT land under the rejected dir" "$blocker" "$log15"
+if [[ -n "$log15" && -f "$log15" ]]; then
+  pass "edge1 fallback log exists ($log15)"
+  rm -rf "$(dirname "$log15")"
+else
+  fail "edge1 fallback log exists (got '$log15')"
+fi
+echo
+
+echo "--- Case 16 (edge 1b): mktemp failure too -> inline execution, no log/sidecar ---"
+err16="$WORK/edge1b.err"
+out="$(TMPDIR="$blocker" "$RUNLONG" --log-dir "$blocker/logs" --phase inline -- "echo ran-inline" 2>"$err16")"; rc=$?
+assert_eq "edge1b inline execution exits with the command's code" "0" "$rc"
+assert_contains "edge1b warns that it is running inline" "running inline" "$(cat "$err16")"
+assert_contains "edge1b command still ran" "ran-inline" "$out"
+assert_not_contains "edge1b no log path claimed" "log: " "$out"
+rc=0; TMPDIR="$blocker" "$RUNLONG" --log-dir "$blocker/logs" -- "sh -c 'exit 5'" >/dev/null 2>&1 || rc=$?
+assert_eq "edge1b inline execution still propagates a failure" "5" "$rc"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PID discriminator (edge case 5)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 17 (edge 5): concurrent runs of the same command do not collide ---"
+d17="$WORK/edge5"
+mkdir -p "$d17"
+CMD17="sh -c 'sleep 1; echo done'"
+"$RUNLONG" --log-dir "$d17" --phase cc -- "$CMD17" >/dev/null 2>&1 &
+a=$!; SLEEPERS+=("$a")
+"$RUNLONG" --log-dir "$d17" --phase cc -- "$CMD17" >/dev/null 2>&1 &
+b=$!; SLEEPERS+=("$b")
+wait "$a"; wait "$b"
+logs17="$(ls "$d17"/cc-*.log 2>/dev/null | wc -l | tr -d ' ')"
+res17="$(ls "$d17"/cc-*.result 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq "edge5 two concurrent runs wrote two distinct logs" "2" "$logs17"
+assert_eq "edge5 two concurrent runs wrote two distinct sidecars" "2" "$res17"
+assert_contains "edge5 log name carries the PID discriminator" "-${a}.log" "$(ls "$d17"/cc-*.log | tr '\n' ' ')"
+# Neither truncated the other: both logs hold the full output.
+bad17=0
+for f in "$d17"/cc-*.log; do
+  [[ "$(cat "$f")" == "done" ]] || bad17=$((bad17 + 1))
+done
+assert_eq "edge5 neither run truncated the other's log" "0" "$bad17"
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Interrupt handling (NFR7 / edge case 16)
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "--- Case 18 (edge 16): SIGTERM kills the child group, writes interrupted sidecar ---"
+d18="$WORK/edge16"
+mkdir -p "$d18"
+# NOTE: the child marker is `sleep 47`, matched with an anchored pattern
+# (`^sleep 47`) so the harness's own argv never self-matches.
+"$RUNLONG" --log-dir "$d18" --phase intr --heartbeat 1 -- "sleep 47" >/dev/null 2>&1 &
+rl=$!; SLEEPERS+=("$rl")
+# Wait for the detached child to actually be running before signalling.
+spawned=0
+for _ in $(seq 1 60); do
+  if pgrep -f '^sleep 47' >/dev/null 2>&1; then spawned=1; break; fi
+  sleep 0.1
+done
+assert_eq "edge16 child was spawned before the signal" "1" "$spawned"
+kill -TERM "$rl" 2>/dev/null || true
+rc=0; wait "$rl" || rc=$?
+assert_eq "edge16 interrupted run exits non-zero" "1" "$rc"
+s18="$(newest_result "$d18")"
+if [[ -n "$s18" && -f "$s18" ]]; then
+  pass "edge16 sidecar written on interrupt ($(basename "$s18"))"
+  assert_eq "edge16 sidecar marks interrupted=true" "true" "$(sc "$s18" interrupted)"
+  assert_eq "edge16 sidecar records a non-zero exit" "1" "$(sc "$s18" exit)"
+  assert_contains "edge16 sidecar keeps the command string" "sleep 47" "$(sc "$s18" cmd)"
+else
+  fail "edge16 sidecar written on interrupt (none found in $d18)"
+fi
+# No orphan: the child must be gone shortly after the parent's trap runs.
+orphan=1
+for _ in $(seq 1 30); do
+  if ! pgrep -f '^sleep 47' >/dev/null 2>&1; then orphan=0; break; fi
+  sleep 0.1
+done
+assert_eq "edge16 no orphaned child process survives" "0" "$orphan"
+echo
+
+echo "=================================================="
+echo "$PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -472,6 +472,209 @@ done
 assert_eq "edge16 no orphaned child process survives" "0" "$orphan"
 echo
 
+# ─────────────────────────────────────────────────────────────────────────────
+# PR-aware status — bin/specclaw-update-status (FR14)
+#
+# Locks in:
+#   AC14: a stubbed `gh` returning an open PR renders that change's line with
+#         the PR reference; a stubbed *failing* lookup leaves STATUS.md
+#         byte-identical to the SPECCLAW_STATUS_NO_PR=1 baseline, exit 0.
+#   AC15: proposal.md + all-[x] tasks.md + an open PR never renders as
+#         "awaiting planning"; a proposal-only change with a PR is reported as
+#         in flight rather than pending.
+#   Edge 15: several PRs on one branch -> newest by `updatedAt`, real state
+#         rendered (a merged PR must not read as open).
+#   NFR1: `SPECCLAW_STATUS_NO_PR=1` skips the lookup entirely (the stub is
+#         never even invoked) — the seam the unchanged-output test uses.
+#   NFR5: a hanging lookup is timeout-bounded, not a hang.
+#   NFR2: branch resolves as <git.branch_prefix><change>; `gh` absent falls back
+#         to `az`; both absent degrades to the pre-FR14 rendering.
+# ─────────────────────────────────────────────────────────────────────────────
+
+UPDATESTATUS="$BIN_DIR/specclaw-update-status"
+if [[ ! -f "$UPDATESTATUS" ]]; then
+  echo "FATAL: missing bin script: $UPDATESTATUS" >&2
+  exit 2
+fi
+
+# make_status_project <dir> [branch_prefix]
+# A minimal `.specclaw/` tree: config.yaml (with an inline comment on the
+# prefix, as templates/config.yaml ships it) plus an empty changes/ dir.
+make_status_project() {
+  local d="$1" prefix="${2:-specclaw/}"
+  mkdir -p "$d/.specclaw/changes"
+  printf 'version: 1\nproject:\n  name: "statusproj"\ngit:\n  strategy: "branch-per-change"\n  branch_prefix: "%s"      # Prefix for feature branches\n' \
+    "$prefix" > "$d/.specclaw/config.yaml"
+}
+
+# add_change <project_dir> <name> [--proposal-only]
+# Default shape is a fully-built change: proposal.md + tasks.md with all [x].
+add_change() {
+  local d="$1" name="$2" mode="${3:-}"
+  mkdir -p "$d/.specclaw/changes/$name"
+  printf '# Proposal\n' > "$d/.specclaw/changes/$name/proposal.md"
+  [[ "$mode" == "--proposal-only" ]] && return 0
+  printf -- '- [x] T1 one\n- [x] T2 two\n' > "$d/.specclaw/changes/$name/tasks.md"
+}
+
+# stub_bin <dir> <name> <body> — an executable stub on a PATH shim directory.
+stub_bin() {
+  local dir="$1" name="$2" body="$3"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" > "$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+# STATUS.md minus the volatile `Last Updated` line, for byte-comparison.
+status_body() { grep -v '^\*\*Last Updated:' "$1" || true; }
+
+echo "--- Case 19 (AC14): a stubbed open PR renders in the change's line ---"
+p19="$WORK/st-ac14"
+make_status_project "$p19"
+add_change "$p19" alpha
+stub_bin "$p19/stub" gh 'echo "2026-07-24T09:00:00Z 123 OPEN"'
+out="$(PATH="$p19/stub:$PATH" "$UPDATESTATUS" "$p19/.specclaw" 2>&1)"; rc=$?
+assert_eq "AC14 update-status exits 0 with a PR found" "0" "$rc"
+assert_contains "AC14 update-status reports the file it wrote" "OK: Updated" "$out"
+st19="$(cat "$p19/.specclaw/STATUS.md")"
+assert_contains "AC14 STATUS.md carries the PR reference" "PR #123 open" "$st19"
+assert_contains "AC14 the tasks.md rendering is preserved alongside it" \
+  "**alpha** — 2/2 tasks (100%)" "$st19"
+echo
+
+echo "--- Case 20 (AC14b): a failing lookup leaves output unchanged, exit 0 ---"
+p20="$WORK/st-ac14b"
+make_status_project "$p20"
+add_change "$p20" beta
+# Baseline: the PR block disabled entirely.
+SPECCLAW_STATUS_NO_PR=1 "$UPDATESTATUS" "$p20/.specclaw" >/dev/null 2>&1
+cp "$p20/.specclaw/STATUS.md" "$p20/baseline.md"
+stub_bin "$p20/stub" gh 'echo "gh: could not determine repo" >&2; exit 1'
+out="$(PATH="$p20/stub:$PATH" "$UPDATESTATUS" "$p20/.specclaw" 2>&1)"; rc=$?
+assert_eq "AC14b a failing PR lookup still exits 0" "0" "$rc"
+assert_eq "AC14b output is byte-identical to the no-PR baseline" \
+  "$(status_body "$p20/baseline.md")" "$(status_body "$p20/.specclaw/STATUS.md")"
+assert_not_contains "AC14b no PR text is invented on failure" "PR #" \
+  "$(cat "$p20/.specclaw/STATUS.md")"
+assert_not_contains "AC14b the lookup's stderr is not leaked into STATUS.md" \
+  "could not determine repo" "$(cat "$p20/.specclaw/STATUS.md")"
+echo
+
+echo "--- Case 21 (edge 15): newest PR by updatedAt wins; merged never reads as open ---"
+p21="$WORK/st-edge15"
+make_status_project "$p21"
+add_change "$p21" gamma
+stub_bin "$p21/stub" gh 'printf "2026-07-20T10:00:00Z 100 OPEN\n2026-07-24T11:00:00Z 456 MERGED\n"'
+PATH="$p21/stub:$PATH" "$UPDATESTATUS" "$p21/.specclaw" >/dev/null 2>&1; rc=$?
+assert_eq "edge15 multi-PR lookup exits 0" "0" "$rc"
+st21="$(cat "$p21/.specclaw/STATUS.md")"
+assert_contains "edge15 newest PR is the one rendered, with its real state" "PR #456 merged" "$st21"
+assert_not_contains "edge15 a merged PR never reads as open" "open" "$st21"
+assert_not_contains "edge15 the older PR is not rendered" "PR #100" "$st21"
+echo
+
+echo "--- Case 22 (AC15): an open PR means in flight, never 'awaiting planning' ---"
+p22="$WORK/st-ac15"
+make_status_project "$p22"
+add_change "$p22" delta                    # planned: proposal + all-[x] tasks
+add_change "$p22" epsilon --proposal-only  # unplanned, but PR'd
+stub_bin "$p22/stub" gh 'case "$*" in
+  *delta*)   echo "2026-07-24T09:00:00Z 11 OPEN" ;;
+  *epsilon*) echo "2026-07-24T10:00:00Z 12 OPEN" ;;
+esac'
+PATH="$p22/stub:$PATH" "$UPDATESTATUS" "$p22/.specclaw" >/dev/null 2>&1; rc=$?
+assert_eq "AC15 update-status exits 0" "0" "$rc"
+st22="$(cat "$p22/.specclaw/STATUS.md")"
+assert_not_contains "AC15 no PR'd change is reported as awaiting planning" \
+  "awaiting planning" "$st22"
+assert_contains "AC15 the completed change keeps its task rendering + PR state" \
+  "**delta** — 2/2 tasks (100%) | 0 failed | PR #11 open" "$st22"
+assert_contains "AC15 a proposal-only change with a PR renders as in flight" \
+  "**epsilon** — PR #12 open" "$st22"
+assert_contains "AC15 both PR'd changes count as active" "**Active:** 2" "$st22"
+echo
+
+echo "--- Case 23 (NFR1): SPECCLAW_STATUS_NO_PR=1 skips the lookup entirely ---"
+p23="$WORK/st-nfr1"
+make_status_project "$p23"
+add_change "$p23" zeta
+mark23="$p23/gh-was-called"
+stub_bin "$p23/stub" gh "echo called >> '$mark23'; echo \"2026-07-24T09:00:00Z 99 OPEN\""
+out="$(SPECCLAW_STATUS_NO_PR=1 PATH="$p23/stub:$PATH" "$UPDATESTATUS" "$p23/.specclaw" 2>&1)"; rc=$?
+assert_eq "NFR1 disabled PR block still exits 0" "0" "$rc"
+if [[ -f "$mark23" ]]; then
+  fail "NFR1 the lookup is never invoked when disabled (stub ran)"
+else
+  pass "NFR1 the lookup is never invoked when disabled"
+fi
+assert_not_contains "NFR1 no PR text with the block disabled" "PR #" \
+  "$(cat "$p23/.specclaw/STATUS.md")"
+# Same fixture, block enabled: proves the seam is what suppressed it.
+PATH="$p23/stub:$PATH" "$UPDATESTATUS" "$p23/.specclaw" >/dev/null 2>&1
+assert_contains "NFR1 the same fixture does render a PR when enabled" "PR #99 open" \
+  "$(cat "$p23/.specclaw/STATUS.md")"
+echo
+
+echo "--- Case 24 (NFR5): a hanging lookup is timeout-bounded, not a hang ---"
+p24="$WORK/st-nfr5"
+make_status_project "$p24"
+add_change "$p24" eta
+# `exec` so the stub *is* the sleeping process: a real slow `gh` is one process,
+# and `timeout` must be able to reap it without the caller waiting on a child.
+stub_bin "$p24/stub" gh 'exec sleep 30'
+t24=$SECONDS
+PATH="$p24/stub:$PATH" "$UPDATESTATUS" "$p24/.specclaw" >/dev/null 2>&1; rc=$?
+el24=$((SECONDS - t24))
+assert_eq "NFR5 a hanging lookup still exits 0" "0" "$rc"
+if [[ "$el24" -lt 15 ]]; then
+  pass "NFR5 status generation stayed bounded (${el24}s < 15s)"
+else
+  fail "NFR5 status generation stayed bounded (took ${el24}s)"
+fi
+assert_not_contains "NFR5 a timed-out lookup contributes no PR text" "PR #" \
+  "$(cat "$p24/.specclaw/STATUS.md")"
+echo
+
+echo "--- Case 25 (NFR2): the branch is <git.branch_prefix><change> ---"
+p25="$WORK/st-branch"
+make_status_project "$p25" "wip/"
+add_change "$p25" theta
+argv25="$p25/gh-argv"
+stub_bin "$p25/stub" gh "printf '%s\\n' \"\$*\" >> '$argv25'; echo \"2026-07-24T09:00:00Z 5 OPEN\""
+PATH="$p25/stub:$PATH" "$UPDATESTATUS" "$p25/.specclaw" >/dev/null 2>&1
+assert_contains "NFR2 configured branch_prefix is used for the lookup" \
+  "--head wip/theta" "$(cat "$argv25" 2>/dev/null || true)"
+assert_contains "NFR2 the lookup asks for every state, so merged PRs are visible" \
+  "--state all" "$(cat "$argv25" 2>/dev/null || true)"
+assert_eq "NFR2 one change costs exactly one lookup (memoised per run)" "1" \
+  "$(wc -l < "$argv25" | tr -d ' ')"
+echo
+
+echo "--- Case 26 (NFR2): gh absent -> az fallback; both absent -> unchanged ---"
+p26="$WORK/st-az"
+make_status_project "$p26"
+add_change "$p26" iota
+# A shim PATH with no `gh` at all — only the binaries update-status itself needs.
+shim26="$p26/shim"
+mkdir -p "$shim26"
+for b in bash cat sed grep head sort tr date basename timeout; do
+  ln -sf "$(command -v "$b")" "$shim26/$b"
+done
+SPECCLAW_STATUS_NO_PR=1 PATH="$shim26" "$UPDATESTATUS" "$p26/.specclaw" >/dev/null 2>&1
+cp "$p26/.specclaw/STATUS.md" "$p26/baseline.md"
+# Both lookups absent: degrade to the pre-FR14 rendering (NFR2).
+PATH="$shim26" "$UPDATESTATUS" "$p26/.specclaw" >/dev/null 2>&1; rc=$?
+assert_eq "NFR2 no gh and no az still exits 0" "0" "$rc"
+assert_eq "NFR2 no lookup available -> output unchanged" \
+  "$(status_body "$p26/baseline.md")" "$(status_body "$p26/.specclaw/STATUS.md")"
+# Now Azure DevOps answers instead (tab-separated, as `az ... -o tsv` emits).
+stub_bin "$shim26" az 'printf "2026-07-24T08:00:00Z\t77\tactive\n"'
+PATH="$shim26" "$UPDATESTATUS" "$p26/.specclaw" >/dev/null 2>&1; rc=$?
+assert_eq "NFR2 az fallback exits 0" "0" "$rc"
+assert_contains "NFR2 az fallback renders the PR with its ADO state" "PR #77 active" \
+  "$(cat "$p26/.specclaw/STATUS.md")"
+echo
+
 echo "=================================================="
 echo "$PASS passed, $FAIL failed"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -25,6 +25,16 @@
 #     7: --heartbeat 0 / non-integer clamps to the 60s default.
 #     16: SIGTERM kills the child process group, writes an `interrupted=true`
 #         sidecar, exits non-zero, leaves no orphan.
+#   specclaw-browser-lock wrap (FR10–FR12):
+#     AC10: `--workers=1` appended for Playwright commands, an existing
+#           `--workers` preserved and never duplicated.
+#     AC11: MemoryMax defaults to 4096M and honours an explicit value; an
+#           unusable `systemd-run` emits the command uncapped with one WARN.
+#     AC12: `verify.playwright.projects` (both yaml list forms) fans out into
+#           one `&&`-joined `--project=` invocation each; absent/empty -> one.
+#     Edge 11: `systemd-run` absent from PATH *and* present-but-failing.
+#     Edge 12: project names with spaces / `&` survive as single argv entries.
+#     Edge 13: non-Playwright commands never gain `--workers`.
 #
 # Plain bash + coreutils — no jq/bats/npm (NFR3). Run from anywhere:
 #   bash plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -1098,6 +1108,443 @@ if [[ "${beats40:-0}" -ge 2 ]]; then
 else
   fail "a 1s heartbeat produces liveness lines on verify's stderr (got ${beats40:-0})"
 fi
+echo
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bounded Playwright invocation — bin/specclaw-browser-lock wrap (FR10–FR12)
+#
+# `wrap` PRINTS a transformed command and never executes it, so every case below
+# is a pure string assertion plus the exit-code convention (0 = capped,
+# 10 = emitted uncapped, 1 = no command). Locks in:
+#   AC10: `--workers=1` appended for Playwright commands; an existing
+#         `--workers=N` is preserved, never duplicated.
+#   AC11: MemoryMax defaults to 4096M (key absent / garbage / no config file at
+#         all) and honours an explicit value; `systemd-run` unusable -> the
+#         unwrapped command on stdout, one WARN on stderr, exit 10.
+#   AC12: `verify.playwright.projects` in both yaml forms (inline flow and block
+#         sequence) -> one `&&`-joined invocation per project carrying
+#         `--project=<name>`; absent/empty -> exactly one invocation, no
+#         `--project` flag.
+#   Edge cases:
+#     2:  shell metacharacters (pipes, `&&`, `VAR=x` env prefixes) survive the
+#         wrap verbatim and stay inside the capped `bash -c`.
+#     11: `systemd-run` missing from PATH *and* present-but-failing both fall
+#         back uncapped — usability is probed, not inferred from presence.
+#     12: project names with spaces or `&` survive as single argv entries
+#         (proved by re-parsing the emitted string against a recording stub).
+#   Scoping: only `verify.playwright` is read — a `build.playwright` block is
+#         ignored.
+#   Regression: `status` / `acquire` / `release` / unknown-subcommand dispatch is
+#         unchanged by the new subcommand.
+#
+# `systemd-run` is stubbed in both directions (CAP_STUB / NOCAP_STUB above) plus
+# a shim PATH with no `systemd-run` at all, so no case depends on a working
+# cgroup session (NFR6).
+# ─────────────────────────────────────────────────────────────────────────────
+
+LOCK="$BIN_DIR/specclaw-browser-lock"
+if [[ ! -f "$LOCK" ]]; then
+  echo "FATAL: missing bin script: $LOCK" >&2
+  exit 2
+fi
+
+# make_pw_project <name> [config heredoc on stdin] — a `.specclaw` dir under
+# $WORK/<name>. With no stdin content, no config.yaml is written at all (the
+# "no config file" default path). Echoes the .specclaw path.
+make_pw_project() {
+  local d="$WORK/$1"
+  mkdir -p "$d/.specclaw"
+  if [[ ! -t 0 ]]; then
+    cat > "$d/.specclaw/config.yaml.tmp"
+    if [[ -s "$d/.specclaw/config.yaml.tmp" ]]; then
+      mv "$d/.specclaw/config.yaml.tmp" "$d/.specclaw/config.yaml"
+    else
+      rm -f "$d/.specclaw/config.yaml.tmp"
+    fi
+  fi
+  printf '%s' "$d/.specclaw"
+}
+
+# wrap_with <stub_dir> <specclaw_dir> <errfile> <cmd…> — `wrap` with <stub_dir>
+# shadowing systemd-run. Echoes the emitted command string; sets WRAP_RC.
+WRAP_RC=0
+wrap_with() {
+  local stub="$1" dir="$2" err="$3"; shift 3
+  local o
+  o="$(PATH="$stub:$PATH" "$LOCK" "$dir" wrap "$@" 2>"$err")"; WRAP_RC=$?
+  printf '%s' "$o"
+}
+
+# Occurrences of <needle> in <haystack>, as a count.
+count_of() { grep -o -- "$1" <<<"$2" | wc -l | tr -d ' '; }
+
+# A recording `npx` so the emitted string can be re-parsed and its argv
+# inspected — the only way to prove a project name survived as ONE word.
+WRAP_ARGV_STUB="$WORK/stub-wrap-argv"
+stub_bin "$WRAP_ARGV_STUB" npx 'for a in "$@"; do printf "ARG[%s]\n" "$a"; done'
+
+# A PATH with no `systemd-run` on it at all (edge case 11, first half): only the
+# binaries `wrap` itself needs. Distinct from NOCAP_STUB, which *has* the binary
+# but fails when run.
+NOSYSD_SHIM="$WORK/shim-nosystemd"
+mkdir -p "$NOSYSD_SHIM"
+for b in bash awk sed head cat tr ls; do
+  ln -sf "$(command -v "$b")" "$NOSYSD_SHIM/$b"
+done
+
+echo "--- Case 41 (AC11): MemoryMax defaults to 4096M; an explicit value is honoured ---"
+d41="$(make_pw_project wrap-cap-default </dev/null)"
+out="$(wrap_with "$CAP_STUB" "$d41" "$WORK/w41.err" 'npx playwright test')"
+assert_eq "AC11 a capped wrap exits 0" "0" "$WRAP_RC"
+assert_eq "AC11 no config file at all -> the 4096M default, one capped invocation" \
+  "systemd-run --user --scope -q -p MemoryMax=4096M bash -c 'npx playwright test --workers=1'" \
+  "$out"
+assert_eq "AC11 a capped wrap emits nothing on stderr" "" "$(cat "$WORK/w41.err")"
+
+d41b="$(make_pw_project wrap-cap-nokey <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_browsers: 2
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d41b" "$WORK/w41b.err" 'npx playwright test')"
+assert_contains "AC11 a playwright block without max_memory_mb still caps at 4096M" \
+  "MemoryMax=4096M" "$out"
+
+d41c="$(make_pw_project wrap-cap-explicit <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 2048
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d41c" "$WORK/w41c.err" 'npx playwright test')"
+assert_contains "AC11 an explicit max_memory_mb is used" "MemoryMax=2048M" "$out"
+assert_not_contains "AC11 the default does not leak alongside an explicit value" \
+  "4096M" "$out"
+
+# Garbage and zero must clamp to the default rather than emit `MemoryMax=M` or
+# `MemoryMax=0M` (an unbounded/instantly-fatal scope).
+d41d="$(make_pw_project wrap-cap-garbage <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: "lots"
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d41d" "$WORK/w41d.err" 'npx playwright test')"
+assert_contains "AC11 a non-numeric max_memory_mb clamps to 4096M" "MemoryMax=4096M" "$out"
+assert_not_contains "AC11 a non-numeric cap is never emitted verbatim" "MemoryMax=lots" "$out"
+
+d41e="$(make_pw_project wrap-cap-zero <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 0
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d41e" "$WORK/w41e.err" 'npx playwright test')"
+assert_contains "AC11 max_memory_mb: 0 clamps to 4096M" "MemoryMax=4096M" "$out"
+assert_not_contains "AC11 a zero cap is never emitted" "MemoryMax=0M" "$out"
+
+# Trailing inline comments are config.yaml's shipped style (templates/config.yaml).
+d41f="$(make_pw_project wrap-cap-comment <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 8192   # cap for the e2e tier
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d41f" "$WORK/w41f.err" 'npx playwright test')"
+assert_contains "AC11 an inline comment is stripped from max_memory_mb" "MemoryMax=8192M" "$out"
+assert_not_contains "AC11 the comment text never reaches the command" "cap for the e2e" "$out"
+echo
+
+echo "--- Case 42 (AC11b + edge 11): systemd-run absent AND unusable both fall back ---"
+d42="$(make_pw_project wrap-uncapped <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 2048
+EOF
+)"
+# (a) present on PATH but failing — usability is probed, not assumed.
+err42a="$WORK/w42a.err"
+out="$(PATH="$NOCAP_STUB:$PATH" "$LOCK" "$d42" wrap 'npx playwright test' 2>"$err42a")"; rc=$?
+assert_eq "edge11 a present-but-failing systemd-run exits 10 (emitted uncapped)" "10" "$rc"
+assert_eq "edge11 the emitted string is the plain transformed command" \
+  "npx playwright test --workers=1" "$out"
+assert_not_contains "edge11 no systemd-run prefix is emitted when it is unusable" \
+  "systemd-run" "$out"
+assert_not_contains "edge11 no MemoryMax is claimed when nothing was capped" "MemoryMax=2048M" "$out"
+assert_contains "edge11 the fallback warns on stderr" "systemd-run unusable" "$(cat "$err42a")"
+assert_contains "edge11 the warning names the cap that was NOT applied" "MemoryMax=2048M not applied" \
+  "$(cat "$err42a")"
+assert_eq "edge11 exactly one WARN line is emitted" "1" \
+  "$(grep -c '^WARN: ' "$err42a" 2>/dev/null || true)"
+# (b) not on PATH at all — same fallback, same exit code.
+err42b="$WORK/w42b.err"
+out="$(PATH="$NOSYSD_SHIM" "$LOCK" "$d42" wrap 'npx playwright test' 2>"$err42b")"; rc=$?
+assert_eq "edge11 systemd-run missing from PATH also exits 10" "10" "$rc"
+assert_eq "edge11 missing systemd-run emits the plain command too" \
+  "npx playwright test --workers=1" "$out"
+assert_contains "edge11 the missing-binary path warns identically" "systemd-run unusable" \
+  "$(cat "$err42b")"
+echo
+
+echo "--- Case 43 (AC10): --workers=1 is appended, an existing --workers is preserved ---"
+d43="$(make_pw_project wrap-workers </dev/null)"
+out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test')"
+assert_contains "AC10 a playwright command gains --workers=1" "--workers=1" "$out"
+assert_eq "AC10 exactly one --workers flag is emitted" "1" "$(count_of '--workers' "$out")"
+
+out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test --workers=2')"
+assert_contains "AC10 an existing --workers=2 is preserved" "--workers=2" "$out"
+assert_not_contains "AC10 --workers=1 is not forced over an explicit value" "--workers=1" "$out"
+assert_eq "AC10 an explicit --workers is never duplicated" "1" "$(count_of '--workers' "$out")"
+
+# The space-separated form is a --workers choice too and must not be doubled.
+out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test --workers 4')"
+assert_contains "AC10 the space-separated --workers 4 form is preserved" "--workers 4" "$out"
+assert_eq "AC10 the space-separated form is not duplicated either" "1" \
+  "$(count_of '--workers' "$out")"
+echo
+
+echo "--- Case 44 (edge 13): a non-Playwright command gets no --workers, but is still capped ---"
+d44="$(make_pw_project wrap-cypress </dev/null)"
+out="$(wrap_with "$CAP_STUB" "$d44" "$WORK/w44.err" 'npx cypress run')"
+assert_eq "edge13 a cypress command still exits 0 (capped)" "0" "$WRAP_RC"
+assert_eq "edge13 cypress is capped but untouched otherwise" \
+  "systemd-run --user --scope -q -p MemoryMax=4096M bash -c 'npx cypress run'" "$out"
+assert_not_contains "edge13 no --workers is injected into a non-playwright command" \
+  "--workers" "$out"
+out="$(wrap_with "$CAP_STUB" "$d44" "$WORK/w44.err" 'bash scripts/e2e.sh')"
+assert_not_contains "edge13 a plain script gets no --workers either" "--workers" "$out"
+assert_contains "edge13 a plain script is still memory-capped" "MemoryMax=4096M" "$out"
+echo
+
+echo "--- Case 45 (AC12): inline-flow projects -> one &&-joined invocation each ---"
+d45="$(make_pw_project wrap-proj-inline <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 2048
+    projects: [desktop, mobile]
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d45" "$WORK/w45.err" 'npx playwright test')"
+assert_eq "AC12 a project fan-out still exits 0" "0" "$WRAP_RC"
+assert_eq "AC12 inline-flow projects emit both invocations, joined with && , in order" \
+  "systemd-run --user --scope -q -p MemoryMax=2048M bash -c 'npx playwright test --workers=1 --project=desktop' && systemd-run --user --scope -q -p MemoryMax=2048M bash -c 'npx playwright test --workers=1 --project=mobile'" \
+  "$out"
+assert_eq "AC12 two projects mean exactly one && join" "1" "$(count_of '&&' "$out")"
+assert_eq "AC12 each project gets its own capped scope" "2" "$(count_of 'MemoryMax=2048M' "$out")"
+assert_eq "AC12 --workers=1 is applied once per invocation, not once overall" "2" \
+  "$(count_of '--workers=1' "$out")"
+echo
+
+echo "--- Case 46 (AC12b): block-sequence projects behave identically ---"
+d46="$(make_pw_project wrap-proj-block <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 2048
+    projects:
+      - desktop
+      - mobile
+EOF
+)"
+out46="$(wrap_with "$CAP_STUB" "$d46" "$WORK/w46.err" 'npx playwright test')"
+assert_eq "AC12b the block-sequence form exits 0" "0" "$WRAP_RC"
+assert_contains "AC12b block sequence yields --project=desktop" "--project=desktop" "$out46"
+assert_contains "AC12b block sequence yields --project=mobile" "--project=mobile" "$out46"
+assert_eq "AC12b block sequence joins with a single &&" "1" "$(count_of '&&' "$out46")"
+# The two yaml spellings are the same configuration, so they must wrap the same.
+out45="$(wrap_with "$CAP_STUB" "$d45" "$WORK/w46b.err" 'npx playwright test')"
+assert_eq "AC12b both yaml list forms produce the identical command" "$out45" "$out46"
+echo
+
+echo "--- Case 47 (AC12c): absent or empty projects -> exactly one plain invocation ---"
+d47="$(make_pw_project wrap-proj-absent <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_memory_mb: 2048
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d47" "$WORK/w47.err" 'npx playwright test')"
+assert_eq "AC12c an absent projects key emits a single invocation, no --project" \
+  "systemd-run --user --scope -q -p MemoryMax=2048M bash -c 'npx playwright test --workers=1'" \
+  "$out"
+assert_not_contains "AC12c no --project flag is invented" "--project" "$out"
+assert_eq "AC12c a single invocation carries no && join" "0" "$(count_of '&&' "$out")"
+
+d47b="$(make_pw_project wrap-proj-empty <<'EOF'
+version: 1
+verify:
+  playwright:
+    projects: []
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d47b" "$WORK/w47b.err" 'npx playwright test')"
+assert_eq "AC12c an explicitly empty list behaves as absent" \
+  "systemd-run --user --scope -q -p MemoryMax=4096M bash -c 'npx playwright test --workers=1'" \
+  "$out"
+assert_not_contains "AC12c an empty list adds no --project" "--project" "$out"
+echo
+
+echo "--- Case 48 (edge 12): project names with spaces / & survive as single argv entries ---"
+d48="$(make_pw_project wrap-proj-quoting <<'EOF'
+version: 1
+verify:
+  playwright:
+    projects: ["my project", "smoke & regression"]
+EOF
+)"
+# Capped: re-parse the emitted string with a recording `npx` on PATH. Only one
+# ARG[] line per project proves the name did not split into separate words, and
+# that the `&` did not background the invocation.
+out="$(wrap_with "$CAP_STUB" "$d48" "$WORK/w48.err" 'npx playwright test')"
+assert_eq "edge12 a quoted-name fan-out exits 0" "0" "$WRAP_RC"
+argv48="$(PATH="$WRAP_ARGV_STUB:$CAP_STUB:$PATH" bash -c "$out" 2>&1)"
+assert_contains "edge12 a project name with a space arrives as ONE argv entry" \
+  "ARG[--project=my project]" "$argv48"
+assert_contains "edge12 a project name containing & arrives as ONE argv entry" \
+  "ARG[--project=smoke & regression]" "$argv48"
+assert_eq "edge12 both invocations ran, 4 argv entries each" "8" \
+  "$(count_of 'ARG\[' "$argv48")"
+# Uncapped: the same names must survive the no-systemd-run path too.
+out="$(PATH="$NOCAP_STUB:$PATH" "$LOCK" "$d48" wrap 'npx playwright test' 2>/dev/null)"; rc=$?
+assert_eq "edge12 the uncapped fan-out exits 10" "10" "$rc"
+argv48b="$(PATH="$WRAP_ARGV_STUB:$NOCAP_STUB:$PATH" bash -c "$out" 2>&1)"
+assert_contains "edge12 spaces survive the uncapped path as one argv entry" \
+  "ARG[--project=my project]" "$argv48b"
+assert_contains "edge12 & survives the uncapped path as one argv entry" \
+  "ARG[--project=smoke & regression]" "$argv48b"
+assert_eq "edge12 the uncapped fan-out also ran both invocations" "8" \
+  "$(count_of 'ARG\[' "$argv48b")"
+echo
+
+echo "--- Case 49 (edge 2): pipes, &&, and env prefixes survive the wrap ---"
+d49="$(make_pw_project wrap-metachars </dev/null)"
+META='CI=1 npx cypress run | tee /dev/null && echo chained'
+out="$(wrap_with "$CAP_STUB" "$d49" "$WORK/w49.err" "$META")"
+assert_eq "edge2 a metacharacter-heavy command still caps (exit 0)" "0" "$WRAP_RC"
+# The whole compound goes inside ONE `bash -c`, so the pipeline's right-hand side
+# is inside the cap rather than escaping it (design rationale for `bash -c`).
+assert_eq "edge2 the compound command is wrapped verbatim inside one bash -c" \
+  "systemd-run --user --scope -q -p MemoryMax=4096M bash -c 'CI=1 npx cypress run | tee /dev/null && echo chained'" \
+  "$out"
+assert_eq "edge2 only one bash -c is emitted (nothing escapes the scope)" "1" \
+  "$(count_of 'bash -c' "$out")"
+# Semantics, not just the string: re-run it and check the env prefix and the
+# `&&` right-hand side both took effect.
+ran49="$(PATH="$WRAP_ARGV_STUB:$CAP_STUB:$PATH" bash -c "$out" 2>&1)"
+assert_contains "edge2 the piped-through output survived" "ARG[cypress]" "$ran49"
+assert_contains "edge2 the && right-hand side still ran" "chained" "$ran49"
+# Env prefix reaching the child, proved through the wrap.
+out="$(wrap_with "$CAP_STUB" "$d49" "$WORK/w49b.err" 'FOO=bar sh -c "echo got=\$FOO"')"
+assert_contains "edge2 an env prefix is preserved in the emitted string" "FOO=bar" "$out"
+assert_eq "edge2 the env prefix reaches the child when the wrapped string runs" "got=bar" \
+  "$(PATH="$CAP_STUB:$PATH" bash -c "$out" 2>&1)"
+# Uncapped path: nothing is re-quoted, the command comes back byte-identical.
+out="$(PATH="$NOCAP_STUB:$PATH" "$LOCK" "$d49" wrap "$META" 2>/dev/null)"
+assert_eq "edge2 the uncapped path returns the command byte-identical" "$META" "$out"
+echo
+
+echo "--- Case 50: only verify.playwright is read; a build.playwright block is ignored ---"
+d50="$(make_pw_project wrap-scoping <<'EOF'
+version: 1
+build:
+  playwright:
+    max_memory_mb: 999
+    projects: [ghost]
+verify:
+  playwright:
+    max_memory_mb: 2048
+    projects: [desktop]
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d50" "$WORK/w50.err" 'npx playwright test')"
+assert_contains "scoping the verify.playwright cap wins" "MemoryMax=2048M" "$out"
+assert_not_contains "scoping a build.playwright cap is ignored" "MemoryMax=999M" "$out"
+assert_contains "scoping the verify.playwright project is used" "--project=desktop" "$out"
+assert_not_contains "scoping a build.playwright project is ignored" "ghost" "$out"
+# The same keys under build: alone must leave the defaults untouched.
+d50b="$(make_pw_project wrap-scoping-buildonly <<'EOF'
+version: 1
+build:
+  playwright:
+    max_memory_mb: 999
+    projects: [ghost]
+EOF
+)"
+out="$(wrap_with "$CAP_STUB" "$d50b" "$WORK/w50b.err" 'npx playwright test')"
+assert_eq "scoping build.playwright alone leaves the 4096M default and no fan-out" \
+  "systemd-run --user --scope -q -p MemoryMax=4096M bash -c 'npx playwright test --workers=1'" \
+  "$out"
+echo
+
+echo "--- Case 51: wrap with no command warns and exits 1 ---"
+d51="$(make_pw_project wrap-nocmd </dev/null)"
+err51="$WORK/w51.err"
+out="$(PATH="$CAP_STUB:$PATH" "$LOCK" "$d51" wrap 2>"$err51")"; rc=$?
+assert_eq "a missing command exits 1" "1" "$rc"
+assert_eq "a missing command emits nothing on stdout" "" "$out"
+assert_contains "a missing command says what it needs" "wrap requires a command string" \
+  "$(cat "$err51")"
+# An all-whitespace command is just as unusable as an absent one.
+out="$(PATH="$CAP_STUB:$PATH" "$LOCK" "$d51" wrap "" 2>"$err51")"; rc=$?
+assert_eq "an empty command string exits 1 too" "1" "$rc"
+assert_eq "an empty command string emits nothing on stdout" "" "$out"
+echo
+
+echo "--- Case 52: status / acquire / release / unknown dispatch is unchanged ---"
+d52="$(make_pw_project wrap-subcmds <<'EOF'
+version: 1
+verify:
+  playwright:
+    max_browsers: 3
+    max_memory_mb: 2048
+    projects: [desktop]
+EOF
+)"
+assert_eq "status still prints held/max with the configured max_browsers" "0/3" \
+  "$("$LOCK" "$d52" status)"
+slot52="$("$LOCK" "$d52" acquire 2>"$WORK/w52.err")"; rc=$?
+assert_eq "acquire still exits 0" "0" "$rc"
+assert_eq "acquire still prints the lowest free slot id" "slot-1" "$slot52"
+if [[ -d "$d52/.locks/playwright/slot-1" ]]; then
+  pass "acquire still creates the slot directory"
+else
+  fail "acquire still creates the slot directory"
+fi
+"$LOCK" "$d52" release "$slot52"; rc=$?
+assert_eq "release still exits 0" "0" "$rc"
+if [[ -d "$d52/.locks/playwright/slot-1" ]]; then
+  fail "release still removes the slot directory"
+else
+  pass "release still removes the slot directory"
+fi
+"$LOCK" "$d52" release "$slot52"; rc=$?
+assert_eq "release is still idempotent" "0" "$rc"
+# A slot pinned by a live PID is still counted as held.
+sleep 43 & p52=$!; SLEEPERS+=("$p52")
+mkdir -p "$d52/.locks/playwright/slot-2"
+echo "$p52" > "$d52/.locks/playwright/slot-2/pid"
+assert_eq "status still counts a live-PID slot as held" "1/3" "$("$LOCK" "$d52" status)"
+kill "$p52" 2>/dev/null || true
+"$LOCK" "$d52" release slot-2 2>/dev/null || true
+# The new subcommand did not shift the dispatch: an unknown one still fails.
+err52="$WORK/w52-unknown.err"
+"$LOCK" "$d52" bogus >/dev/null 2>"$err52"; rc=$?
+assert_eq "an unknown subcommand still exits 1" "1" "$rc"
+assert_contains "an unknown subcommand still warns by name" "Unknown subcommand: bogus" \
+  "$(cat "$err52")"
+"$LOCK" --help >/dev/null 2>&1; rc=$?
+assert_eq "--help still exits 0" "0" "$rc"
+assert_contains "--help documents the wrap subcommand" "wrap <cmd>" "$("$LOCK" --help)"
 echo
 
 echo "=================================================="

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -1241,6 +1241,15 @@ wrap_with() {
 # Occurrences of <needle> in <haystack>, as a count.
 count_of() { grep -o -- "$1" <<<"$2" | wc -l | tr -d ' '; }
 
+# `wrap` emits one `bash -c '<cmd>'` invocation per Playwright project (or exactly
+# one when no projects are configured), so "one --workers per invocation" is the
+# fixture-independent invariant. Asserting a literal "1" instead would silently
+# pass a fan-out that duplicated the flag within a single invocation.
+assert_one_workers_per_invocation() {
+  local label="$1" out="$2"
+  assert_eq "$label" "$(count_of 'bash -c' "$out")" "$(count_of '\--workers' "$out")"
+}
+
 # A recording `npx` so the emitted string can be re-parsed and its argv
 # inspected — the only way to prove a project name survived as ONE word.
 WRAP_ARGV_STUB="$WORK/stub-wrap-argv"
@@ -1360,18 +1369,17 @@ echo "--- Case 43 (AC10): --workers=1 is appended, an existing --workers is pres
 d43="$(make_pw_project wrap-workers </dev/null)"
 out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test')"
 assert_contains "AC10 a playwright command gains --workers=1" "--workers=1" "$out"
-assert_eq "AC10 exactly one --workers flag is emitted" "1" "$(count_of '--workers' "$out")"
+assert_one_workers_per_invocation "AC10 exactly one --workers flag per invocation" "$out"
 
 out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test --workers=2')"
 assert_contains "AC10 an existing --workers=2 is preserved" "--workers=2" "$out"
 assert_not_contains "AC10 --workers=1 is not forced over an explicit value" "--workers=1" "$out"
-assert_eq "AC10 an explicit --workers is never duplicated" "1" "$(count_of '--workers' "$out")"
+assert_one_workers_per_invocation "AC10 an explicit --workers is never duplicated" "$out"
 
 # The space-separated form is a --workers choice too and must not be doubled.
 out="$(wrap_with "$CAP_STUB" "$d43" "$WORK/w43.err" 'npx playwright test --workers 4')"
 assert_contains "AC10 the space-separated --workers 4 form is preserved" "--workers 4" "$out"
-assert_eq "AC10 the space-separated form is not duplicated either" "1" \
-  "$(count_of '--workers' "$out")"
+assert_one_workers_per_invocation "AC10 the space-separated form is not duplicated either" "$out"
 echo
 
 echo "--- Case 44 (edge 13): a non-Playwright command gets no --workers, but is still capped ---"
@@ -1404,7 +1412,8 @@ assert_eq "AC12 inline-flow projects emit both invocations, joined with && , in 
 assert_eq "AC12 two projects mean exactly one && join" "1" "$(count_of '&&' "$out")"
 assert_eq "AC12 each project gets its own capped scope" "2" "$(count_of 'MemoryMax=2048M' "$out")"
 assert_eq "AC12 --workers=1 is applied once per invocation, not once overall" "2" \
-  "$(count_of '--workers=1' "$out")"
+  "$(count_of '\--workers=1' "$out")"
+assert_one_workers_per_invocation "AC12 the fan-out keeps one --workers per invocation" "$out"
 echo
 
 echo "--- Case 46 (AC12b): block-sequence projects behave identically ---"

--- a/plugins/specclaw/tests/run-long-orchestration-tests.sh
+++ b/plugins/specclaw/tests/run-long-orchestration-tests.sh
@@ -675,6 +675,431 @@ assert_contains "NFR2 az fallback renders the PR with its ADO state" "PR #77 act
   "$(cat "$p26/.specclaw/STATUS.md")"
 echo
 
+# ─────────────────────────────────────────────────────────────────────────────
+# E2E tier — bin/specclaw-verify collect (FR7–FR9, FR13)
+#
+# Locks in:
+#   Gate order: lint -> build -> test, then e2e per policy.
+#   AC6/NFR1: a config carrying none of the new keys produces a payload
+#         byte-identical to v0.5.9 (golden captured from 451301d) — no `e2e_*`
+#         keys at all, not even empty ones.
+#   AC7: `last` + a failing lint never runs e2e; the payload names the gate.
+#   AC8: `skip` never runs e2e and says so; no state reads as a pass.
+#   AC9: `always` runs e2e even when lint failed.
+#   AC13: exit 137 *under a cap* -> e2e_memory_limited=true and the message
+#         names the cap; exit 137 with no cap applied (wrap exit 10) -> a plain
+#         failure with e2e_memory_limited=false.
+#   Every e2e_state value: passed | failed | skipped_policy |
+#         skipped_gate_failure | not_configured.
+#   verify.heartbeat_seconds reaches run-long as `--heartbeat`.
+#   Browser slot released even when the e2e command fails.
+#   Edge cases:
+#     8:  e2e_command set, verify.e2e absent -> default `last`.
+#     9:  unrecognised verify.e2e -> warn on stderr, fall back to `last`.
+#     10: e2e_command set, test_command empty -> vacuously passing, e2e runs.
+#
+# `systemd-run` is stubbed in both directions so neither path depends on a
+# working cgroup/systemd session on the host (NFR6).
+# ─────────────────────────────────────────────────────────────────────────────
+
+VERIFY="$BIN_DIR/specclaw-verify"
+if [[ ! -f "$VERIFY" ]]; then
+  echo "FATAL: missing bin script: $VERIFY" >&2
+  exit 2
+fi
+
+# make_verify_project <root> — a minimal `.specclaw/` tree for `verify collect`:
+# spec.md with one AC and tasks.md naming one (deliberately absent) file. The
+# change is always `vc`. config.yaml is written per case so the key set under
+# test is exact — that is what makes the AC6 byte-comparison meaningful.
+make_verify_project() {
+  local root="$1"
+  mkdir -p "$root/.specclaw/changes/vc"
+  printf '# Spec\n\n- **AC1** — first criterion.\n' > "$root/.specclaw/changes/vc/spec.md"
+  printf -- '- [x] T1 one\n  - Files: `src/specclaw-t7-absent.txt`\n' > "$root/.specclaw/changes/vc/tasks.md"
+}
+
+# Stub `systemd-run` both ways, so the cap decision is a property of the test and
+# not of the host. CAP: strip the scope flags and exec the real command (so the
+# usability probe passes and the wrapped command actually runs). NOCAP: always
+# fail, which is exactly edge case 11 — present on PATH but unusable.
+CAP_STUB="$WORK/stub-cap"
+NOCAP_STUB="$WORK/stub-nocap"
+stub_bin "$CAP_STUB" systemd-run 'while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user|--scope|-q) shift ;;
+    -p) shift 2 ;;
+    *) break ;;
+  esac
+done
+exec "$@"'
+stub_bin "$NOCAP_STUB" systemd-run 'exit 1'
+
+# collect_with <stub_dir> <project_root> <errfile> — `verify collect` for change
+# `vc`, with <stub_dir> shadowing systemd-run. Echoes the JSON payload.
+collect_with() {
+  PATH="$1:$PATH" "$VERIFY" collect "$2/.specclaw" vc 2>"$3"
+}
+
+# jval <payload> <key> — the value of a top-level `"key": …` line, unquoted.
+# json_escape() collapses newlines to `\n`, so every value is one line (no jq —
+# NFR3).
+jval() {
+  local v
+  v="$(printf '%s\n' "$1" | sed -n "s/^  \"$2\": //p" | head -1 || true)"
+  v="${v%,}"
+  v="${v#\"}"
+  v="${v%\"}"
+  printf '%s' "$v"
+}
+
+echo "--- Case 27: gate order is lint -> build -> test, then e2e ---"
+p27="$WORK/e2e-order"
+make_verify_project "$p27"
+ord27="$p27/order"
+cat > "$p27/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  lint_command: "echo lint >> $ord27"
+  build_command: "echo build >> $ord27"
+  test_command: "echo test >> $ord27"
+  e2e_command: "echo e2e >> $ord27"
+verify:
+  e2e: last
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p27" "$p27/err")"
+assert_eq "gate order is lint, build, test, then e2e" "lint build test e2e" \
+  "$(tr '\n' ' ' < "$ord27" | sed 's/ $//')"
+assert_eq "all gates green -> e2e_state=passed" "passed" "$(jval "$out" e2e_state)"
+echo
+
+echo "--- Case 28 (AC6/NFR1): no new keys -> payload byte-identical to v0.5.9 ---"
+p28="$WORK/e2e-ac6"
+make_verify_project "$p28"
+# Deliberately none of the five new keys: no build.e2e_command, no verify.e2e,
+# no verify.heartbeat_seconds, no verify.playwright block.
+cat > "$p28/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  lint_command: "echo lint-ok"
+  build_command: "echo build-ok"
+  test_command: "echo unit-ok"
+EOF
+# Golden captured by running v0.5.9's specclaw-verify (git 451301d) against this
+# exact fixture. Any drift here is an NFR1 regression, not a test to update.
+golden28="$(cat <<'ENDGOLDEN'
+{
+  "change": "vc",
+  "acceptance_criteria": [
+    "AC1 — first criterion."
+  ],
+  "changed_files": [
+    {"path": "src/specclaw-t7-absent.txt", "exists": false, "content": null}
+  ],
+  "test_output": "unit-ok",
+  "lint_output": "lint-ok",
+  "build_output": "build-ok",
+  "tests_passed": true,
+  "lint_passed": true,
+  "build_passed": true
+}
+ENDGOLDEN
+)"
+out="$(collect_with "$NOCAP_STUB" "$p28" "$p28/err")"; rc=$?
+assert_eq "AC6 collect exits 0" "0" "$rc"
+assert_eq "AC6 payload is byte-identical to the v0.5.9 golden" "$golden28" "$out"
+assert_not_contains "AC6 not a single e2e key is emitted" "e2e" "$out"
+echo
+
+echo "--- Case 29 (AC8): verify.e2e=skip never runs e2e and cannot read as a pass ---"
+p29="$WORK/e2e-skip"
+make_verify_project "$p29"
+cat > "$p29/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  test_command: "echo unit-ok"
+  e2e_command: "echo ran >> $p29/ran"
+verify:
+  e2e: skip
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p29" "$p29/err")"
+assert_eq "AC8 e2e_state=skipped_policy" "skipped_policy" "$(jval "$out" e2e_state)"
+if [[ -f "$p29/ran" ]]; then
+  fail "AC8 the e2e command was never executed (marker file was written)"
+else
+  pass "AC8 the e2e command was never executed"
+fi
+assert_contains "AC8 the skip states its reason" "verify.e2e=skip" "$(jval "$out" e2e_output)"
+assert_contains "AC8 the skip is explicit that it is not a pass" "This is NOT a pass" \
+  "$(jval "$out" e2e_output)"
+assert_not_contains "AC8 a skip never emits the passed state" '"e2e_state": "passed"' "$out"
+assert_eq "AC8 a skip is not a memory kill either" "false" "$(jval "$out" e2e_memory_limited)"
+# The fast tier still ran and still reports independently of the e2e state.
+assert_eq "AC8 the fast tier is unaffected by the skip" "true" "$(jval "$out" tests_passed)"
+echo
+
+echo "--- Case 30 (AC7): verify.e2e=last + a failing lint skips e2e, naming the gate ---"
+p30="$WORK/e2e-gatefail"
+make_verify_project "$p30"
+cat > "$p30/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  lint_command: "echo lint-broke; exit 9"
+  e2e_command: "echo ran >> $p30/ran"
+verify:
+  e2e: last
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p30" "$p30/err")"
+assert_eq "AC7 lint_passed=false" "false" "$(jval "$out" lint_passed)"
+assert_eq "AC7 e2e_state=skipped_gate_failure" "skipped_gate_failure" "$(jval "$out" e2e_state)"
+if [[ -f "$p30/ran" ]]; then
+  fail "AC7 the e2e command was never executed (marker file was written)"
+else
+  pass "AC7 the e2e command was never executed"
+fi
+assert_contains "AC7 the failing gate is named as the reason" "an earlier gate failed (lint)" \
+  "$(jval "$out" e2e_output)"
+assert_contains "AC7 the gate-failure skip is not a pass" "This is NOT a pass" \
+  "$(jval "$out" e2e_output)"
+assert_not_contains "AC7 a gate-failure skip never emits the passed state" \
+  '"e2e_state": "passed"' "$out"
+echo
+
+echo "--- Case 31 (AC9): verify.e2e=always runs e2e even when lint failed ---"
+p31="$WORK/e2e-always"
+make_verify_project "$p31"
+cat > "$p31/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  lint_command: "echo lint-broke; exit 9"
+  e2e_command: "echo ran >> $p31/ran; echo e2e-output"
+verify:
+  e2e: always
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p31" "$p31/err")"
+assert_eq "AC9 lint still reports failed" "false" "$(jval "$out" lint_passed)"
+assert_eq "AC9 e2e ran anyway -> e2e_state=passed" "passed" "$(jval "$out" e2e_state)"
+if [[ -f "$p31/ran" ]]; then
+  pass "AC9 the e2e command was executed despite the failing gate"
+else
+  fail "AC9 the e2e command was executed despite the failing gate (no marker file)"
+fi
+assert_contains "AC9 e2e stdout is captured into the payload" "e2e-output" "$(jval "$out" e2e_output)"
+echo
+
+echo "--- Case 32: e2e_state=failed, and the browser slot is released anyway ---"
+p32="$WORK/e2e-failed"
+make_verify_project "$p32"
+cat > "$p32/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  e2e_command: "echo e2e-broke; exit 4"
+verify:
+  e2e: always
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p32" "$p32/err")"; rc=$?
+assert_eq "failed e2e does not abort collect" "0" "$rc"
+assert_eq "a non-zero e2e exit -> e2e_state=failed" "failed" "$(jval "$out" e2e_state)"
+assert_contains "the failing e2e output is captured" "e2e-broke" "$(jval "$out" e2e_output)"
+assert_eq "an ordinary e2e failure is not a memory kill" "false" "$(jval "$out" e2e_memory_limited)"
+# The slot must come back even on the failure path: a leaked slot starves the
+# pool for every later run.
+held32="$(ls -d "$p32/.specclaw/.locks/playwright"/slot-* 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq "the browser slot is released after a FAILING e2e run" "0" "$held32"
+assert_eq "browser-lock agrees the pool is idle again" "0/2" \
+  "$("$BIN_DIR/specclaw-browser-lock" "$p32/.specclaw" status)"
+echo
+
+echo "--- Case 33: e2e_state=not_configured when e2e_command is empty ---"
+p33="$WORK/e2e-notconf"
+make_verify_project "$p33"
+cat > "$p33/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  e2e_command: ""
+verify:
+  e2e: last
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p33" "$p33/err")"
+assert_eq "an empty e2e_command -> e2e_state=not_configured" "not_configured" \
+  "$(jval "$out" e2e_state)"
+assert_contains "not_configured is explicit that it is not a pass" "This is NOT a pass" \
+  "$(jval "$out" e2e_output)"
+assert_not_contains "not_configured never emits the passed state" '"e2e_state": "passed"' "$out"
+echo
+
+echo "--- Case 34 (edge 8): e2e_command set, verify.e2e absent -> default 'last' ---"
+p34="$WORK/e2e-edge8"
+make_verify_project "$p34"
+cat > "$p34/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  test_command: "echo unit-ok"
+  e2e_command: "echo ran >> $p34/ran"
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p34" "$p34/err")"
+assert_eq "edge8 the default policy runs e2e after green gates" "passed" "$(jval "$out" e2e_state)"
+if [[ -f "$p34/ran" ]]; then
+  pass "edge8 the e2e command ran under the defaulted policy"
+else
+  fail "edge8 the e2e command ran under the defaulted policy (no marker file)"
+fi
+assert_not_contains "edge8 the absent policy is not treated as 'skip'" "skipped_policy" "$out"
+echo
+
+echo "--- Case 35 (edge 9): an unrecognised verify.e2e warns and falls back to 'last' ---"
+p35="$WORK/e2e-edge9"
+make_verify_project "$p35"
+cat > "$p35/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  lint_command: "exit 9"
+  e2e_command: "echo ran >> $p35/ran"
+verify:
+  e2e: sometimes
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p35" "$p35/err")"; rc=$?
+assert_eq "edge9 an unrecognised policy does not fail the run" "0" "$rc"
+assert_contains "edge9 the unrecognised value is warned about on stderr" \
+  "unrecognised value 'sometimes'" "$(cat "$p35/err")"
+assert_contains "edge9 the warning names the fallback" "falling back to 'last'" "$(cat "$p35/err")"
+# `last` semantics, not a silent skip: the earlier gate failed, so e2e is
+# reported as gate-skipped rather than skipped_policy.
+assert_eq "edge9 the fallback behaves as 'last'" "skipped_gate_failure" "$(jval "$out" e2e_state)"
+assert_not_contains "edge9 an unrecognised policy is never a silent policy-skip" \
+  "skipped_policy" "$out"
+if [[ -f "$p35/ran" ]]; then
+  fail "edge9 the failing gate still gated e2e (marker file was written)"
+else
+  pass "edge9 the failing gate still gated e2e"
+fi
+echo
+
+echo "--- Case 36 (edge 10): an empty test_command is vacuously passing, e2e still runs ---"
+p36="$WORK/e2e-edge10"
+make_verify_project "$p36"
+cat > "$p36/.specclaw/config.yaml" <<EOF
+version: 1
+build:
+  lint_command: ""
+  build_command: ""
+  test_command: ""
+  e2e_command: "echo ran >> $p36/ran"
+verify:
+  e2e: last
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p36" "$p36/err")"
+assert_eq "edge10 an unset fast tier still reports tests_passed=true" "true" \
+  "$(jval "$out" tests_passed)"
+assert_eq "edge10 e2e runs on a vacuously-green fast tier" "passed" "$(jval "$out" e2e_state)"
+if [[ -f "$p36/ran" ]]; then
+  pass "edge10 the e2e command ran with no fast tier configured"
+else
+  fail "edge10 the e2e command ran with no fast tier configured (no marker file)"
+fi
+echo
+
+echo "--- Case 37 (AC13): exit 137 UNDER A CAP is reported as a memory kill ---"
+p37="$WORK/e2e-ac13-capped"
+make_verify_project "$p37"
+cat > "$p37/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  e2e_command: "echo about-to-die; exit 137"
+verify:
+  e2e: always
+  playwright:
+    max_memory_mb: 2048
+EOF
+out="$(collect_with "$CAP_STUB" "$p37" "$p37/err")"
+assert_eq "AC13 a capped 137 is still a failure, never a pass" "failed" "$(jval "$out" e2e_state)"
+assert_eq "AC13 e2e_memory_limited=true under a cap" "true" "$(jval "$out" e2e_memory_limited)"
+o37="$(jval "$out" e2e_output)"
+assert_contains "AC13 the report names the memory limit" "MEMORY LIMIT EXCEEDED" "$o37"
+assert_contains "AC13 the report names the configured cap value" "cap 2048M" "$o37"
+assert_contains "AC13 the report rules out a test assertion failure" \
+  "not a test assertion failure" "$o37"
+assert_contains "AC13 the command's own output is still carried" "about-to-die" "$o37"
+echo
+
+echo "--- Case 38 (AC13b): exit 137 with NO cap applied stays a plain failure ---"
+p38="$WORK/e2e-ac13-uncapped"
+make_verify_project "$p38"
+# Same config, same exit code — only `systemd-run` differs: the NOCAP stub is on
+# PATH but fails, so `wrap` exits 10 and no cap is applied (edge case 11).
+cat > "$p38/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  e2e_command: "echo about-to-die; exit 137"
+verify:
+  e2e: always
+  playwright:
+    max_memory_mb: 2048
+EOF
+out="$(collect_with "$NOCAP_STUB" "$p38" "$p38/err")"
+assert_contains "AC13b wrap reported the uncapped emission" "systemd-run unusable" \
+  "$(cat "$p38/err")"
+assert_eq "AC13b an uncapped 137 is a plain failure" "failed" "$(jval "$out" e2e_state)"
+assert_eq "AC13b e2e_memory_limited=false with no cap applied" "false" \
+  "$(jval "$out" e2e_memory_limited)"
+o38="$(jval "$out" e2e_output)"
+assert_not_contains "AC13b no memory-limit claim without a cap" "MEMORY LIMIT EXCEEDED" "$o38"
+assert_not_contains "AC13b no cap value is invented" "2048M" "$o38"
+assert_contains "AC13b the command's output is reported as-is" "about-to-die" "$o38"
+echo
+
+echo "--- Case 39: verify.heartbeat_seconds reaches run-long as --heartbeat ---"
+# A recording stub for run-long in a copied bin dir: specclaw-verify resolves
+# the helper next to itself, so this is the seam that shows the exact argv.
+fb39="$WORK/hb-bin"
+mkdir -p "$fb39"
+cp "$VERIFY" "$fb39/specclaw-verify"
+argv39="$WORK/hb-argv"
+: > "$argv39"
+stub_bin "$fb39" specclaw-run-long "printf '%s\n' \"\$*\" >> '$argv39'
+exit 0"
+p39="$WORK/e2e-heartbeat"
+make_verify_project "$p39"
+cat > "$p39/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  test_command: "echo unit-ok"
+verify:
+  heartbeat_seconds: 7
+EOF
+"$fb39/specclaw-verify" collect "$p39/.specclaw" vc >/dev/null 2>"$p39/err"
+assert_contains "configured heartbeat_seconds is passed as --heartbeat" "--heartbeat 7" \
+  "$(cat "$argv39")"
+assert_contains "the phase label still reaches run-long" "--phase test" "$(cat "$argv39")"
+# Absent key -> no flag at all, so run-long applies its own 60s default (NFR1).
+: > "$argv39"
+p39b="$WORK/e2e-heartbeat-absent"
+make_verify_project "$p39b"
+printf 'version: 1\nbuild:\n  test_command: "echo unit-ok"\n' > "$p39b/.specclaw/config.yaml"
+"$fb39/specclaw-verify" collect "$p39b/.specclaw" vc >/dev/null 2>"$p39b/err"
+assert_not_contains "an absent heartbeat_seconds passes no --heartbeat flag" "--heartbeat" \
+  "$(cat "$argv39")"
+echo
+
+echo "--- Case 40: the configured heartbeat is honoured end to end ---"
+p40="$WORK/e2e-heartbeat-live"
+make_verify_project "$p40"
+cat > "$p40/.specclaw/config.yaml" <<'EOF'
+version: 1
+build:
+  test_command: "sleep 3"
+verify:
+  heartbeat_seconds: 1
+EOF
+collect_with "$NOCAP_STUB" "$p40" "$p40/err" >/dev/null
+beats40="$(grep -c '^\[run-long\] ' "$p40/err" 2>/dev/null || true)"
+if [[ "${beats40:-0}" -ge 2 ]]; then
+  pass "a 1s heartbeat produces liveness lines on verify's stderr (got $beats40)"
+else
+  fail "a 1s heartbeat produces liveness lines on verify's stderr (got ${beats40:-0})"
+fi
+echo
+
 echo "=================================================="
 echo "$PASS passed, $FAIL failed"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
Closes #47.

## Problem

A verify run against a multi-minute test suite looked exactly like a hang. No output while the suite ran, so the session tore itself down mid-run, then re-ran the whole thing from scratch on the next attempt — and a browser suite could take the box down with it. Four root causes, one per wave:

1. **No liveness signal.** Long commands ran in the foreground with output buffered until exit.
2. **No slow-test tier.** Browser/e2e suites shared `test_command` with unit tests, so fast feedback waited on the slowest thing in the repo.
3. **Unbounded Playwright.** Default worker fan-out and no memory ceiling.
4. **Stale status.** A change with all tasks done and an open PR still rendered as "proposal ready, awaiting planning".

## What changed

**`specclaw-run-long` (new).** Runs a command detached: heartbeats to stderr, a capped 100-line tail to stdout, the full log plus a HEAD-stamped `key=value` sidecar on disk. `specclaw-verify`'s `run_capped()` and `specclaw-build`'s `cmd_finalize` both route through it, with captured output and exit codes byte-identical to before. `--reuse` skips re-execution when HEAD matches, the tree is clean, *and* the sidecar was written for the same command.

**Slow-test tier.** `build.e2e_command` is the slow tier; `build.test_command` stays fast. `verify.e2e` (`skip` | `last` | `always`) decides when it runs — order is lint → build → test, then e2e. The payload gains `e2e_state` as an enumerated value (`passed` | `failed` | `skipped_policy` | `skipped_gate_failure` | `not_configured`) rather than an empty-output sentinel, so **a skip is structurally impossible to read as a pass**, and every non-passed state carries a human-readable reason. SKILL.md instructs the verify agent accordingly.

**Bounded Playwright.** `specclaw-browser-lock wrap` prints (never executes) a transformed command: `--workers=1` for Playwright commands that don't already set it, one sequential `--project=` invocation per `verify.playwright.projects` entry, and a `systemd-run --user --scope -p MemoryMax=<N>M` prefix. systemd-run usability is **probed** by running a trivial scope, not inferred from `command -v` — a present-but-broken binary falls back to an uncapped run and warns. An exit 137 is reported as a memory-limit breach only when a cap was actually applied; the same code uncapped stays a plain failure.

**PR-aware status.** `specclaw-update-status` resolves the real PR state per change (gh, then Azure), memoised, every call wrapped in `timeout 5` and `|| true`. A merged PR no longer reads as open.

### New config keys

All optional; absent keys mean unchanged behaviour.

| Key | Default |
|-----|---------|
| `build.e2e_command` | `""` |
| `verify.e2e` | `last` |
| `verify.heartbeat_seconds` | `60` |
| `verify.playwright.max_memory_mb` | `4096` |
| `verify.playwright.projects` | `[]` |

## Verification

**Verify: PARTIAL — 15 of 16 ACs MET, 0 NOT MET.** The one UNVERIFIED is AC16's "no new shellcheck findings": shellcheck isn't installed on the build host, so CI is the gating point. Report in `.specclaw/changes/long-running-test-orchestration/verify-report.md`.

**Code review: APPROVED_WITH_NOTES — 0 BLOCK, 6 WARN, 4 NOTE.** All 10 findings resolved (one was the reviewer's own "no change required"); resolution table in `review-report.md`. Two WARNs were real bugs in `--reuse`, both of the "a test suite silently doesn't run" shape this change exists to prevent:

- **Untracked files weren't counted dirty.** `git diff` and `git diff --cached` are both blind to them, so a new not-yet-`git add`ed test file left the tree looking clean and `--reuse` served a cached pass for a suite that never saw the file.
- **Slug collision served the wrong result.** The sidecar is located by a truncated slug; reuse compared HEAD and dirty state but never the stored `cmd`, so a prefix-sharing command could be handed another's exit code.

Both fixes have tests that were checked against the reverted implementation — they fail there, and the slug case visibly shows command B receiving command A's result.

**Tests: `run-long-orchestration-tests.sh` — 272 passed, 0 failed**, registered in the CI `test` job (an unregistered suite silently never runs). `run-memory-parallelism-tests` 16/0 and `run-synth-agent-tests` 10/0 unaffected.

`run-parser-tests` shows 30/11 locally, entirely from `jq: command not found` — the identical 11 failures reproduce on a clean `origin/main` worktree, so it is a host gap, not a regression. CI installs jq.

## Notes for review

- Version bumped **0.5.9 → 0.6.0** rather than a patch: five new config keys and a new bin is a feature release. Both manifests are in sync.
- `workflow.code_review: true` is now enabled in this repo's own `.specclaw/config.yaml`.
- The last commit is unrelated housekeeping folded in on request: a `specclaw-gh-sync` sentinel so a repo with Issues disabled records *why* no issue exists, plus a CLAUDE.md reporting rule. The gh-sync change has no test — there is no gh-sync harness in `tests/` to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
