### PR TITLE
ci: fail shellcheck on new findings, register two suites that never ran (v0.6.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         run: bash plugins/specclaw/tests/run-memory-parallelism-tests.sh
       - name: Run long-running-orchestration tests
         run: bash plugins/specclaw/tests/run-long-orchestration-tests.sh
+      - name: Run synthesized-agent tests
+        run: bash plugins/specclaw/tests/run-synth-agent-tests.sh
+      - name: Run shellcheck-gate tests
+        run: bash plugins/specclaw/tests/run-shellcheck-gate-tests.sh
 
   shellcheck:
     name: ShellCheck bin scripts
@@ -27,8 +31,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Lint bin/ scripts
-        run: shellcheck plugins/specclaw/bin/specclaw-* || true
+      # Fails on findings absent from tests/shellcheck-baseline.txt. The old
+      # `|| true` form reported success no matter what shellcheck said, so a
+      # green check was not evidence of a clean lint.
+      - name: Lint bin/ scripts (no new findings)
+        run: bash plugins/specclaw/tests/shellcheck-gate.sh
 
   json:
     name: Validate plugin manifests

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -50,6 +50,20 @@ All executable scripts live in `bin/`. Key ones:
 | `specclaw-pr` | Create GitHub PR (enforces test policy, triggers context update) |
 | `specclaw-validate-change` | Check phase prerequisites |
 
+## Tests
+
+Suites live in `tests/`, are bash + coreutils only (no jq in the suites themselves; `run-parser-tests.sh` shells out to it), and **every one must be registered in `.github/workflows/ci.yml`** — an unregistered suite silently never runs, which has happened twice.
+
+| Suite | Covers |
+|-------|--------|
+| `run-parser-tests.sh` | tasks/AC/changed-files parsing (needs `jq` installed) |
+| `run-memory-parallelism-tests.sh` | memory-aware build concurrency, browser slot pool |
+| `run-long-orchestration-tests.sh` | `run-long`, the e2e tier, `browser-lock wrap`, PR-aware status |
+| `run-synth-agent-tests.sh` | dynamically synthesized build subagents |
+| `run-shellcheck-gate-tests.sh` | the shellcheck gate itself |
+
+`shellcheck-gate.sh` fails CI on any shellcheck finding absent from `shellcheck-baseline.txt` (pairs of `<path> <SCxxxx>`, no line numbers, so unrelated edits do not churn it). Fix a new finding or add a targeted `# shellcheck disable=SCxxxx` with a rationale — never silence one by appending to the baseline. It skips with exit 0 when shellcheck is not installed, so the suite still runs locally.
+
 ## Templates
 
 Templates live in `templates/`. `context.md` is the seed for new projects — copy it to `.specclaw/context.md` or let `/specclaw:context add` create it automatically.

--- a/plugins/specclaw/tests/run-shellcheck-gate-tests.sh
+++ b/plugins/specclaw/tests/run-shellcheck-gate-tests.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Tests for shellcheck-gate.sh.
+#
+# A gate that cannot fail is the bug it exists to fix, so the gate itself needs
+# coverage. shellcheck is stubbed on PATH: the tests assert on the gate's
+# decisions, not on real shellcheck output.
+#
+# Bash + coreutils only, no jq.
+
+set -uo pipefail
+
+GATE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/shellcheck-gate.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass_n=0
+fail_n=0
+pass() { echo "PASS: $1"; pass_n=$((pass_n + 1)); }
+fail() { echo "FAIL: $1"; fail_n=$((fail_n + 1)); }
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "$want" == "$got" ]]; then pass "$label (= '$got')"; else
+    fail "$label (expected '$want', got '$got')"; fi
+}
+assert_contains() {
+  local label="$1" needle="$2" hay="$3"
+  case "$hay" in
+    *"$needle"*) pass "$label (found '$needle')" ;;
+    *) fail "$label (missing '$needle' in: $hay)" ;;
+  esac
+}
+assert_not_contains() {
+  local label="$1" needle="$2" hay="$3"
+  case "$hay" in
+    *"$needle"*) fail "$label (unexpectedly found '$needle')" ;;
+    *) pass "$label" ;;
+  esac
+}
+
+# A stub shellcheck that emits the gcc-format lines it is given, and exits 1 the
+# way the real one does when it finds something.
+make_stub() {
+  local dir="$1"; shift
+  mkdir -p "$dir"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'if [[ "$1" == "-f" && "$2" == "gcc" ]]; then'
+    echo "cat <<'GCCEOF'"
+    printf '%s\n' "$@"
+    echo 'GCCEOF'
+    echo '  exit 1'
+    echo 'fi'
+    echo 'echo "(tty-format output)"; exit 1'
+  } > "$dir/shellcheck"
+  chmod +x "$dir/shellcheck"
+}
+
+# Run the gate with a stubbed shellcheck against a temporary baseline body.
+# Output lands in $GATE_OUT (a file, not an indirect assignment) and the gate's
+# exit code is returned. The committed baseline is swapped out and restored.
+GATE_OUT="$WORK/gate.out"
+run_gate() {
+  local stub_dir="$1" baseline_body="$2"
+  local baseline backup rc=0
+  baseline="$(dirname "$GATE")/shellcheck-baseline.txt"
+  backup="$WORK/baseline.orig"
+  cp "$baseline" "$backup"
+  printf '%s\n' "$baseline_body" > "$baseline"
+  PATH="$stub_dir:$PATH" bash "$GATE" > "$GATE_OUT" 2>&1 || rc=$?
+  cp "$backup" "$baseline"
+  return "$rc"
+}
+
+BUILD="plugins/specclaw/bin/specclaw-build"
+LONG="plugins/specclaw/bin/specclaw-run-long"
+F_BUILD="${BUILD}:97:20: note: quoted separately. [SC2295]"
+F_LONG="${LONG}:42:3: warning: brand new thing. [SC9999]"
+
+echo "=== shellcheck-gate tests ==="
+echo
+
+echo "--- Case 1: a finding absent from the baseline fails the gate ---"
+make_stub "$WORK/s1" "$F_BUILD" "$F_LONG"
+rc=0
+run_gate "$WORK/s1" "$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "a new finding exits 1" "1" "$rc"
+assert_contains "the new finding is named" "$LONG SC9999" "$out"
+assert_contains "the failure is annotated for CI" "::error::" "$out"
+assert_not_contains "a baselined finding is not reported as new" "$BUILD SC2295" \
+  "$(printf '%s\n' "$out" | sed -n '/not present in the baseline/,$p')"
+echo
+
+echo "--- Case 2: every finding baselined -> exit 0 ---"
+make_stub "$WORK/s2" "$F_BUILD"
+rc=0
+run_gate "$WORK/s2" "$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "a fully baselined run exits 0" "0" "$rc"
+assert_contains "it says so plainly" "no new findings" "$out"
+assert_not_contains "nothing is flagged as an error" "::error::" "$out"
+echo
+
+echo "--- Case 3: a fixed finding is reported but does not fail ---"
+make_stub "$WORK/s3" "$F_BUILD"
+rc=0
+run_gate "$WORK/s3" "$BUILD SC2295
+plugins/specclaw/bin/specclaw-loop SC2015" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "a stale baseline entry still exits 0" "0" "$rc"
+assert_contains "the stale entry is named for pruning" \
+  "plugins/specclaw/bin/specclaw-loop SC2015" "$out"
+assert_contains "pruning is described as the action" "prune" "$out"
+echo
+
+echo "--- Case 4: clean shellcheck output -> exit 0, no findings ---"
+make_stub "$WORK/s4"
+rc=0
+run_gate "$WORK/s4" "$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "no findings at all exits 0" "0" "$rc"
+assert_not_contains "a clean run raises no error" "::error::" "$out"
+echo
+
+echo "--- Case 5: comments and blank lines in the baseline are ignored ---"
+make_stub "$WORK/s5" "$F_BUILD"
+rc=0
+run_gate "$WORK/s5" "# a comment
+
+  # an indented comment
+$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "comments do not break the comparison" "0" "$rc"
+assert_not_contains "a comment is never treated as a finding" "a comment" "$out"
+echo
+
+echo "--- Case 6: the same code in a different file is a NEW finding ---"
+# Pairs are file-scoped: SC2295 being baselined for one script must not license
+# it everywhere.
+make_stub "$WORK/s6" "${LONG}:9:1: note: quoted separately. [SC2295]"
+rc=0
+run_gate "$WORK/s6" "$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "the same code in another file exits 1" "1" "$rc"
+assert_contains "the other file is named" "$LONG SC2295" "$out"
+echo
+
+echo "--- Case 7: line-number churn alone is not a new finding ---"
+# The whole point of comparing pairs rather than line numbers.
+make_stub "$WORK/s7" "${BUILD}:9999:44: note: quoted separately. [SC2295]"
+rc=0
+run_gate "$WORK/s7" "$BUILD SC2295" || rc=$?
+out="$(cat "$GATE_OUT")"
+assert_eq "a moved finding does not fail the gate" "0" "$rc"
+echo
+
+echo "--- Case 8: shellcheck missing from PATH skips, and does not fail ---"
+# Fail-open on a missing linter: a dev without shellcheck can still run the
+# suite. CI installs it, so the gate is real there.
+SHIM="$WORK/no-shellcheck"
+mkdir -p "$SHIM"
+for b in bash sed sort comm grep mktemp rm wc tr cat dirname cd; do
+  src="$(command -v "$b" 2>/dev/null || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$SHIM/$b"
+done
+out=""; rc=0
+out="$(PATH="$SHIM" bash "$GATE" 2>&1)" || rc=$?
+assert_eq "no shellcheck on PATH exits 0" "0" "$rc"
+assert_contains "the skip is explained" "shellcheck not installed" "$out"
+echo
+
+echo "--- Case 9: the committed baseline is well-formed ---"
+BASELINE="$(dirname "$GATE")/shellcheck-baseline.txt"
+malformed="$(grep -vE '^[[:space:]]*(#|$)' "$BASELINE" |
+  grep -vcE '^plugins/specclaw/bin/[A-Za-z0-9_-]+ SC[0-9]{4}$' || true)"
+assert_eq "every baseline entry is '<path> <SCxxxx>'" "0" "$malformed"
+dupes="$(grep -vE '^[[:space:]]*(#|$)' "$BASELINE" | LC_ALL=C sort | uniq -d | wc -l | tr -d ' ')"
+assert_eq "the baseline has no duplicate entries" "0" "$dupes"
+missing="$(grep -vE '^[[:space:]]*(#|$)' "$BASELINE" | cut -d' ' -f1 | LC_ALL=C sort -u |
+  while read -r f; do [[ -f "$(dirname "$GATE")/../../../$f" ]] || echo "$f"; done | wc -l | tr -d ' ')"
+assert_eq "every baselined path exists in the repo" "0" "$missing"
+echo
+
+echo "=================================================="
+echo "${pass_n} passed, ${fail_n} failed"
+[[ "$fail_n" -eq 0 ]]

--- a/plugins/specclaw/tests/shellcheck-baseline.txt
+++ b/plugins/specclaw/tests/shellcheck-baseline.txt
@@ -1,0 +1,39 @@
+# ShellCheck baseline — findings that already existed when the gate was added.
+#
+# One `<path> <SCxxxx>` pair per line, sorted. Line numbers are deliberately
+# absent: a pair survives unrelated edits to the file, so the baseline does not
+# churn every time a script is touched.
+#
+# The gate (shellcheck-gate.sh) fails CI on any pair NOT listed here. Fixing a
+# listed finding is always safe; the gate reports the now-unused line so it can
+# be pruned, but never fails for it.
+#
+# Do not add a line to silence a new finding — fix it, or add a targeted
+# `# shellcheck disable=SCxxxx` comment with a rationale at the call site.
+plugins/specclaw/bin/specclaw-azdo-pr SC2295
+plugins/specclaw/bin/specclaw-build SC2155
+plugins/specclaw/bin/specclaw-build SC2209
+plugins/specclaw/bin/specclaw-build SC2221
+plugins/specclaw/bin/specclaw-build SC2222
+plugins/specclaw/bin/specclaw-build SC2295
+plugins/specclaw/bin/specclaw-build-context SC2016
+plugins/specclaw/bin/specclaw-build-context SC2034
+plugins/specclaw/bin/specclaw-detect-patterns SC2001
+plugins/specclaw/bin/specclaw-detect-patterns SC2094
+plugins/specclaw/bin/specclaw-discover-context SC2254
+plugins/specclaw/bin/specclaw-discover-context SC2295
+plugins/specclaw/bin/specclaw-gh-sync SC2034
+plugins/specclaw/bin/specclaw-gh-sync SC2064
+plugins/specclaw/bin/specclaw-gh-sync SC2295
+plugins/specclaw/bin/specclaw-jira-issue SC2295
+plugins/specclaw/bin/specclaw-loop SC2015
+plugins/specclaw/bin/specclaw-loop SC2034
+plugins/specclaw/bin/specclaw-loop SC2254
+plugins/specclaw/bin/specclaw-pr SC2034
+plugins/specclaw/bin/specclaw-pr SC2295
+plugins/specclaw/bin/specclaw-validate-change SC2168
+plugins/specclaw/bin/specclaw-validate-change SC2295
+plugins/specclaw/bin/specclaw-verify SC2034
+plugins/specclaw/bin/specclaw-verify SC2155
+plugins/specclaw/bin/specclaw-verify-context SC2016
+plugins/specclaw/bin/specclaw-verify-context SC2034

--- a/plugins/specclaw/tests/shellcheck-gate.sh
+++ b/plugins/specclaw/tests/shellcheck-gate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Fail on shellcheck findings that are not in the baseline.
+#
+# The previous CI step ran `shellcheck ... || true`, so the job reported success
+# no matter what shellcheck said — a green check was not evidence of a clean
+# lint. That let 22 real new findings through unnoticed. This gate compares the
+# current finding set against plugins/specclaw/tests/shellcheck-baseline.txt and
+# fails on anything new.
+#
+# Findings are compared as `<path> <SCxxxx>` pairs, not line numbers, so moving
+# code around does not manufacture "new" findings.
+#
+# Exit codes: 0 = no new findings (or shellcheck unavailable), 1 = new findings.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+baseline="${script_dir}/shellcheck-baseline.txt"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "shellcheck not installed — skipping the gate (install it to run this locally)" >&2
+  exit 0
+fi
+
+[[ -f "$baseline" ]] || { echo "baseline not found at $baseline" >&2; exit 1; }
+
+cd "$repo_root" || exit 1
+
+# `-f gcc` gives one finding per line as `path:line:col: severity: msg [SCxxxx]`,
+# which normalises to a pair with a single sed. shellcheck exits non-zero when it
+# finds anything, so `|| true` here is about *its* exit code, not the gate's.
+current="$(mktemp)"
+expected="$(mktemp)"
+trap 'rm -f "$current" "$expected"' EXIT
+
+# LC_ALL=C on both sides: `comm` needs identical collation, and the default
+# locale sorts hyphens inconsistently across environments.
+shellcheck -f gcc plugins/specclaw/bin/specclaw-* 2>/dev/null |
+  sed -nE 's/^([^:]+):[0-9]+:[0-9]+: [a-z]+: .*\[(SC[0-9]+)\]$/\1 \2/p' |
+  LC_ALL=C sort -u > "$current" || true
+
+grep -vE '^[[:space:]]*(#|$)' "$baseline" | LC_ALL=C sort -u > "$expected"
+
+new_findings="$(comm -13 "$expected" "$current")"
+fixed_findings="$(comm -23 "$expected" "$current")"
+
+if [[ -n "$fixed_findings" ]]; then
+  echo "These baseline entries no longer occur — prune them from shellcheck-baseline.txt:"
+  echo "$fixed_findings" | sed 's/^/  /'
+  echo
+fi
+
+if [[ -n "$new_findings" ]]; then
+  echo "::error::shellcheck found new findings not present in the baseline:"
+  echo "$new_findings" | sed 's/^/  /'
+  echo
+  echo "Fix them, or add a targeted '# shellcheck disable=SCxxxx' with a rationale."
+  echo "Full shellcheck output follows:"
+  shellcheck plugins/specclaw/bin/specclaw-* || true
+  exit 1
+fi
+
+echo "shellcheck: no new findings ($(wc -l < "$current" | tr -d ' ') known, all in the baseline)"


### PR DESCRIPTION
Follow-up to #48, which surfaced both problems.

## 1. The shellcheck job could not fail

```yaml
- name: Lint bin/ scripts
  run: shellcheck plugins/specclaw/bin/specclaw-* || true
```

`|| true` meant the job reported `pass` no matter what shellcheck said, so a green check was **not** evidence of a clean lint. That is not theoretical — it hid **22 real new findings** in the v0.6.0 branch (21× SC2317, 1× SC2064). They only came to light because the counts were pulled out of the raw job log and diffed against main by hand. AC16 of that change ("no new shellcheck findings") had no automatic gate at all.

Removing `|| true` outright isn't an option: 27 findings already exist across `bin/`. So `tests/shellcheck-gate.sh` diffs against a committed baseline instead.

- Findings are keyed as `<path> <SCxxxx>` **pairs, not line numbers** — moving code around doesn't manufacture a "new" finding, and a code baselined for one script is still new in another.
- Stale baseline entries are reported for pruning but never fail the build.
- Missing shellcheck skips with exit 0, so contributors without it can still run the suite. CI installs it, so the gate is real there.
- Baseline seeded with the 27 pairs present on main at `c5e5cef`. These are grandfathered, not endorsed — **SC2168 in `specclaw-validate-change` (`local` outside a function) looks like a genuine bug** and deserves its own change.

## 2. Two suites were never running

`run-synth-agent-tests.sh` (10 assertions) has been in `tests/` without ever being executed by CI. Registered, along with the new gate suite.

This is the second time an unregistered suite has gone unnoticed, so the rule is now written down in `plugins/specclaw/CLAUDE.md` alongside a table of the suites.

## Testing the gate

A gate that cannot fail is precisely the bug being fixed here, so it gets its own coverage: `run-shellcheck-gate-tests.sh`, 22 assertions with shellcheck stubbed on `PATH`. It asserts the gate exits 1 on a new finding and names it, exits 0 when everything is baselined, ignores line-number churn, treats the same code in a different file as new, ignores comments in the baseline, skips cleanly with no shellcheck on `PATH`, and that the committed baseline is well-formed with every path actually existing.

While writing them the harness was passing 16/6 for the wrong reason — an indirect `printf -v` assignment silently produced empty output, so three assertions were reading `""`. Replaced with a plain output file.

## Verification

| Suite | Result |
|-------|--------|
| `run-long-orchestration-tests.sh` | 272 / 0 |
| `run-shellcheck-gate-tests.sh` | 22 / 0 |
| `run-memory-parallelism-tests.sh` | 16 / 0 |
| `run-synth-agent-tests.sh` | 10 / 0 |
| `run-parser-tests.sh` | needs `jq`, absent on this host — passes in CI |

The real proof is this PR's own CI run: the shellcheck job now has to actually agree there are no new findings.

Version bumped to 0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
