### PR TITLE
feat: add opt-in teaching mode to the lifecycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] — 2026-07-29
+
+### Added
+- **Teaching mode (`/specclaw:teach`).** Opt-in mode that makes the lifecycle
+  explain while it builds, for onboarding, upskilling, and unfamiliar stacks.
+  Off by default; when `teach.enabled` is false nothing changes anywhere.
+  - `propose` names the technologies a change touches and asks the user's level
+    per technology — (a) never used it / (b) theory only / (c) shipped with it /
+    (d) deep — stored in `.specclaw/knowledge/learner-profile.md`.
+  - `plan` surfaces design decisions as 2–4 scored options with pros, cons and
+    costs, including one deliberately simpler than the recommendation. The user
+    chooses; their reason is recorded verbatim in `design.md`.
+  - `build` gates each wave that uses an unfamiliar technology, offering a
+    3-minute concept brief, then builds without narration and returns exactly
+    one verify command.
+  - `verify` asks for a prediction before revealing numbers (`depth: full`).
+  - `pr` runs a debrief: what was built, every decision with its alternatives
+    and costs, and how the user would build it from scratch.
+  - New `teaching.md` per change — the human-facing companion to `learnings.md`.
+    Same change, two directions: one records what the machine learned, the
+    other what the human learned.
+  - **No cheatsheet library by design.** Concept briefs are generated from a
+    recipe in `references/teaching-mode.md` and cached per project under
+    `.specclaw/knowledge/briefs/`. A file per technology is a coverage promise
+    no plugin can keep, and static files rot while model knowledge does not.
+  - **Assessment is the default action.** A bare `/specclaw:teach` now runs a
+    five-step flow — work out which technologies the change touches, ask for any
+    level not self-reported, show the level map back, generate the learning plan,
+    end with one next action. Previously it printed config and stopped, so a
+    pre-populated profile meant the user was never actually assessed.
+  - **Gates are inline in each phase's numbered flow, not appended.** An earlier
+    iteration put the teaching section at the end of each skill, following the
+    existing `loop.ci_gate` cross-reference pattern. That is correct for a
+    cross-reference and wrong for behaviour that must interleave: in `build` the
+    section landed after Step 3's wave loop, so a model working through the steps
+    in order would spawn every coding agent and finish the build before reading
+    the gate. Same class of bug in `verify` (prediction after the tests ran),
+    `plan` (options after `design.md` was written) and `pr` (debrief after the PR
+    was opened). Each skill now carries a short gate at the only position where it
+    works — `build` Step 2.5 (after tasks are parsed, before agents spawn),
+    `verify` Step 0.5, `plan` step 3.5, `pr` step 1.5 — with the detail still at
+    the end for reference.
+  - **Stack table before any question.** The assessment now opens by showing every
+    technology the change touches — libraries included, not just categories —
+    with what each is for *in this project* and where it appears, then asks about
+    every row. Previously it discovered technologies silently and only asked about
+    gaps, so a learner never saw the surface area of the work and specific
+    libraries (the Kafka client, the tracing propagation API, the trace UI) went
+    unassessed while their parent category looked covered.
+  - **Ends with one concrete opening move**, naming the first task, why it is
+    first, which brief it opens with, and the exact words to reply — not a menu.
+  - **Level provenance.** `specclaw-teach level <tech> <a|b|c|d> [self|assumed]`.
+    `assumed` levels are listed by the new `assess` subcommand and must be
+    re-asked before any phase trusts them — an inherited profile is not an
+    assessment.
+  - **Learning plan artifact** at `.specclaw/knowledge/learning-plan.md`, derived
+    from the level map: separate Learn (briefs, each tied to the task that needs
+    it), Explain (decisions that are the user's), PoC (only where watching a
+    mechanism fail beats reading), and Implementation sections, plus predictions
+    and an explicit not-learning-this-time list.
+  - New `assess` and `plan-path` subcommands; `templates/knowledge/learning-plan.md`.
+  - New `bin/specclaw-teach` (status / enable / disable / level / levels / log),
+    `templates/teaching.md`, `templates/knowledge/learner-profile.md`,
+    `references/teaching-mode.md`, and a `teach:` block in `templates/config.yaml`.
+
 ## [0.5.5] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to specclaw are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2] — 2026-07-29
+## [0.6.8] — 2026-08-16
 
 ### Added
 - **Teaching mode (`/specclaw:teach`).** Opt-in mode that makes the lifecycle

--- a/README.md
+++ b/README.md
@@ -86,8 +86,59 @@ When initialized in a project, SpecClaw creates:
         ├── status.md        # Per-change progress tracking
         ├── errors.md        # Build error journal (auto-generated on failures)
         ├── learnings.md     # Build learnings (spec gaps, patterns, insights)
+        ├── teaching.md      # What the human learned (teaching mode only)
         └── verify-report.md # Verification results
 ```
+
+## Teaching mode (optional)
+
+Off by default. When enabled, the lifecycle **explains while it builds** — for onboarding, upskilling,
+or an unfamiliar stack. Companion to `/specclaw:learn`: that one records what the *machine* learned
+(spec gaps, patterns); this one records what the *human* learned.
+
+```bash
+/specclaw:teach          # assess, show the plan, suggest how to start
+```
+
+Enable it in `.specclaw/config.yaml`:
+
+```yaml
+teach:
+  enabled: true
+  depth: "brief"      # minimal | brief | full
+  gate_builds: true
+```
+
+A bare `/specclaw:teach` runs five steps:
+
+1. **Show the whole stack** the change touches, as a table — libraries included, not just categories,
+   with what each is for *in this project*
+2. **Ask your level on every row** — (a) never used it / (b) theory only / (c) shipped with it /
+   (d) deep — spot-checking (c)/(d) claims and correcting silently
+3. **Show the level map back**, with what each level means for where your time goes
+4. **Generate `knowledge/learning-plan.md`** — separate Learn (briefs, each tied to the task that
+   needs it), Explain (decisions that are yours), PoC, and Implementation sections
+5. **Suggest one concrete opening move**
+
+Then each phase gains teaching behaviour:
+
+| Phase | With teach mode |
+|-------|-----------------|
+| `propose` | Names the stack, asks your level per technology |
+| `plan` | Design decisions become 2–4 scored options with costs; **you** choose, your reason is recorded verbatim in `design.md` |
+| `build` | Gates each wave using an unfamiliar technology — a 3-minute brief, then one decision, then it builds without narration |
+| `verify` | Asks for a prediction before revealing numbers (`depth: full`) |
+| `pr` | Debriefs: every decision with alternatives and **what it cost**, and how you'd build it from scratch |
+
+Two principles it enforces: **you make the decisions, the agent writes the code** — hand-typing
+boilerplate teaches nothing, choosing between designs with the costs visible is the skill. And **one
+artifact at a time** — documents are written at the step that needs them, never as a reading pile up
+front, and every reply ends with exactly one next action.
+
+**No cheatsheet library by design.** Concept briefs are generated from the recipe in
+`references/teaching-mode.md` and cached per project under `.specclaw/knowledge/briefs/`. A file per
+technology is a coverage promise no plugin can keep, and static files go stale while model knowledge
+does not.
 
 ## Commands
 
@@ -101,6 +152,7 @@ All commands are namespaced under `/specclaw:`. Most are model-invokable — Cla
 | `/specclaw:author-spec <change>` | Author `spec.md` interactively via the `spec-author` subagent (5 Whys, JTBD, Inversion, Pre-mortem, MoSCoW) |
 | `/specclaw:build <change>` | Execute tasks wave-by-wave |
 | `/specclaw:learn <change> "..."` | Record a spec gap, design miss, or pattern |
+| `/specclaw:teach` | Toggle teaching mode, record what you already know, generate concept briefs |
 | `/specclaw:patterns` | Inspect the cross-change pattern registry |
 | `/specclaw:verify <change>` | Validate implementation against spec |
 | `/specclaw:pr <change>` | Open a GitHub PR |

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/bin/specclaw-teach
+++ b/plugins/specclaw/bin/specclaw-teach
@@ -104,8 +104,16 @@ EOF
     }
     { print }
     END { if (!done) exit 3 }
-  ' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" \
-    || { rm -f "$CONFIG_FILE.tmp"; echo "Error: could not set teach.$key" >&2; exit 1; }
+  ' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" || {
+    rm -f "$CONFIG_FILE.tmp"
+    echo "Error: could not set teach.$key" >&2
+    exit 1
+  }
+  mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" || {
+    rm -f "$CONFIG_FILE.tmp"
+    echo "Error: could not install $CONFIG_FILE" >&2
+    exit 1
+  }
 }
 
 ensure_profile() {

--- a/plugins/specclaw/bin/specclaw-teach
+++ b/plugins/specclaw/bin/specclaw-teach
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  specclaw-teach <specclaw_dir> status
+  specclaw-teach <specclaw_dir> assess
+  specclaw-teach <specclaw_dir> enable [--depth minimal|brief|full]
+  specclaw-teach <specclaw_dir> disable
+  specclaw-teach <specclaw_dir> level <technology> <a|b|c|d> [self|assumed]
+  specclaw-teach <specclaw_dir> levels
+  specclaw-teach <specclaw_dir> plan-path
+  specclaw-teach <specclaw_dir> <change_name> log <kind> "<detail>"
+  specclaw-teach <specclaw_dir> <change_name> --list
+
+Modes:
+  status          Print teach config as JSON (enabled, depth, gate_builds)
+  assess          Print what still needs asking: counts plus the list of levels
+                  recorded as "assumed" rather than self-reported. Drives the
+                  assessment step of /specclaw:teach
+  enable/disable  Toggle teach mode in config.yaml
+  level           Record a level. The 4th argument marks provenance:
+                    self    - the learner answered (default)
+                    assumed - inferred; MUST be confirmed before it is trusted
+  levels          Show the learner profile
+  plan-path       Print the canonical path for the learning plan
+  log             Append an entry to a change's teaching.md
+  --list          Show a change's teaching record
+
+Levels:  a = never used it | b = theory only | c = shipped with it | d = deep
+Kinds:   brief | decision | prediction | checkpoint | debrief
+
+Levels are project-wide and live in <specclaw_dir>/knowledge/learner-profile.md.
+Per-change teaching records live in <specclaw_dir>/changes/<change>/teaching.md.
+Nothing is ever written to the plugin itself.
+EOF
+  exit 0
+}
+
+for arg in "$@"; do
+  [[ "$arg" == "--help" || "$arg" == "-h" ]] && usage
+done
+
+[[ $# -lt 2 ]] && { echo "Error: Not enough arguments. Use --help for usage." >&2; exit 1; }
+
+SPECCLAW_DIR="$1"; shift
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+TEMPLATE_DIR="$PLUGIN_ROOT/templates"
+CONFIG_FILE="$SPECCLAW_DIR/config.yaml"
+KNOWLEDGE_DIR="$SPECCLAW_DIR/knowledge"
+PROFILE_FILE="$KNOWLEDGE_DIR/learner-profile.md"
+
+VALID_KINDS="brief decision prediction checkpoint debrief"
+VALID_LEVELS="a b c d"
+VALID_DEPTHS="minimal brief full"
+VALID_SOURCES="self assumed"
+PLAN_FILE="$KNOWLEDGE_DIR/learning-plan.md"
+
+# Read a scalar from the `teach:` block of config.yaml. Absent block or key -> default.
+read_teach_key() {
+  local key="$1" default="$2"
+  [[ -f "$CONFIG_FILE" ]] || { echo "$default"; return; }
+  awk -v k="$key" -v d="$default" '
+    /^teach:[[:space:]]*$/ { inblock=1; next }
+    inblock && /^[^[:space:]#]/ { inblock=0 }
+    inblock {
+      line=$0
+      sub(/#.*$/, "", line)
+      if (match(line, "^[[:space:]]+" k "[[:space:]]*:")) {
+        val=line; sub("^[[:space:]]+" k "[[:space:]]*:[[:space:]]*", "", val)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val); gsub(/^"|"$/, "", val)
+        if (val != "") { print val; found=1; exit }
+      }
+    }
+    END { if (!found) print d }
+  ' "$CONFIG_FILE"
+}
+
+set_teach_key() {
+  local key="$1" value="$2"
+  [[ -f "$CONFIG_FILE" ]] || { echo "Error: $CONFIG_FILE not found. Run /specclaw:init first." >&2; exit 1; }
+  if ! grep -qE '^teach:[[:space:]]*$' "$CONFIG_FILE"; then
+    cat >> "$CONFIG_FILE" <<EOF
+
+# Teaching mode (opt-in). When enabled, lifecycle phases explain before they
+# implement, surface design choices as decisions for the human, and record what
+# was taught in changes/<change>/teaching.md. Absent or false -> phases behave
+# exactly as before.
+teach:
+  enabled: false
+  depth: "brief"       # minimal | brief | full
+  gate_builds: true    # pause before each build wave for an unfamiliar technology
+EOF
+  fi
+  awk -v k="$key" -v v="$value" '
+    /^teach:[[:space:]]*$/ { print; inblock=1; next }
+    inblock && /^[^[:space:]#]/ { inblock=0 }
+    inblock && match($0, "^([[:space:]]+)" k "[[:space:]]*:") {
+      indent=$0; sub(/[^[:space:]].*$/, "", indent)
+      comment=""; if (match($0, /#.*$/)) comment="   " substr($0, RSTART, RLENGTH)
+      print indent k ": " v comment; done=1; next
+    }
+    { print }
+    END { if (!done) exit 3 }
+  ' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" \
+    || { rm -f "$CONFIG_FILE.tmp"; echo "Error: could not set teach.$key" >&2; exit 1; }
+}
+
+ensure_profile() {
+  mkdir -p "$KNOWLEDGE_DIR"
+  [[ -f "$PROFILE_FILE" ]] && return
+  if [[ -f "$TEMPLATE_DIR/knowledge/learner-profile.md" ]]; then
+    cp "$TEMPLATE_DIR/knowledge/learner-profile.md" "$PROFILE_FILE"
+  else
+    cat > "$PROFILE_FILE" <<'EOF'
+# Learner Profile
+
+Self-rated levels. Drives how much explanation each phase gives.
+
+**Scale:** a = never used it | b = theory / tutorials only | c = shipped something real | d = deep
+
+| Technology | Level | Recorded | Notes |
+|------------|-------|----------|-------|
+EOF
+  fi
+}
+
+ensure_teaching() {
+  local change="$1"
+  local dir="$SPECCLAW_DIR/changes/$change"
+  local file="$dir/teaching.md"
+  [[ -d "$dir" ]] || { echo "Error: change '$change' not found at $dir" >&2; exit 1; }
+  if [[ ! -f "$file" ]]; then
+    mkdir -p "$dir"
+    if [[ -f "$TEMPLATE_DIR/teaching.md" ]]; then
+      sed "s/{{change_name}}/$change/g" "$TEMPLATE_DIR/teaching.md" > "$file"
+    else
+      printf '# Teaching: %s\n\nWhat the human learned during this change.\n\n---\n' "$change" > "$file"
+    fi
+  fi
+  echo "$file"
+}
+
+CMD="${1:-}"
+
+case "$CMD" in
+  status)
+    printf '{"enabled":%s,"depth":"%s","gate_builds":%s,"profile":"%s"}\n' \
+      "$(read_teach_key enabled false)" \
+      "$(read_teach_key depth brief)" \
+      "$(read_teach_key gate_builds true)" \
+      "$PROFILE_FILE"
+    ;;
+
+  enable|disable)
+    depth=""
+    if [[ "$CMD" == "enable" && "${2:-}" == "--depth" ]]; then
+      depth="${3:-}"
+      grep -qw -- "$depth" <<<"$VALID_DEPTHS" || { echo "Error: depth must be one of: $VALID_DEPTHS" >&2; exit 1; }
+    fi
+    set_teach_key enabled "$([[ "$CMD" == "enable" ]] && echo true || echo false)"
+    [[ -n "$depth" ]] && set_teach_key depth "\"$depth\""
+    ensure_profile
+    echo "teach mode $CMD""d${depth:+ (depth: $depth)}"
+    ;;
+
+  level)
+    tech="${2:-}"; lvl="${3:-}"; src="${4:-self}"
+    [[ -n "$tech" && -n "$lvl" ]] || { echo "Error: usage: level <technology> <a|b|c|d> [self|assumed]" >&2; exit 1; }
+    grep -qw -- "$lvl" <<<"$VALID_LEVELS" || { echo "Error: level must be one of: $VALID_LEVELS" >&2; exit 1; }
+    grep -qw -- "$src" <<<"$VALID_SOURCES" || { echo "Error: source must be one of: $VALID_SOURCES" >&2; exit 1; }
+    ensure_profile
+    if grep -qiE "^\| *$tech *\|" "$PROFILE_FILE"; then
+      awk -v t="$tech" -v l="$lvl" -v s="$src" -v d="$(date -u +%Y-%m-%d)" '
+        BEGIN{IGNORECASE=1}
+        $0 ~ "^\\| *" t " *\\|" { printf "| %s | %s | %s | %s |\n", t, l, s, d; next }
+        { print }' "$PROFILE_FILE" > "$PROFILE_FILE.tmp" && mv "$PROFILE_FILE.tmp" "$PROFILE_FILE"
+      echo "updated $tech -> $lvl ($src)"
+    else
+      printf '| %s | %s | %s | %s |\n' "$tech" "$lvl" "$src" "$(date -u +%Y-%m-%d)" >> "$PROFILE_FILE"
+      echo "recorded $tech -> $lvl ($src)"
+    fi
+    ;;
+
+  levels)
+    [[ -f "$PROFILE_FILE" ]] || { echo "No learner profile yet. Record one with: level <technology> <a|b|c|d>"; exit 0; }
+    cat "$PROFILE_FILE"
+    ;;
+
+  # What still needs asking. An "assumed" level is one nobody confirmed — trusting it silently is
+  # how a learner ends up either bored or lost, so the skill must re-ask before relying on it.
+  assess)
+    ensure_profile
+    rows=$(grep -cE '^\| *[^|# ][^|]* *\| *[abcd] *\|' "$PROFILE_FILE" 2>/dev/null || true)
+    assumed=$(awk -F'|' '/^\| *[^|# ]/ && $3 ~ /^ *[abcd] *$/ && $4 ~ /assumed/ {gsub(/^ +| +$/,"",$2); printf "%s ", $2}' "$PROFILE_FILE")
+    selfn=$(awk -F'|' '/^\| *[^|# ]/ && $3 ~ /^ *[abcd] *$/ && $4 ~ /self/ {n++} END{print n+0}' "$PROFILE_FILE")
+    legacy=$(awk -F'|' '/^\| *[^|# ]/ && $3 ~ /^ *[abcd] *$/ && $4 !~ /self|assumed/ {gsub(/^ +| +$/,"",$2); printf "%s ", $2}' "$PROFILE_FILE")
+    printf '{"recorded":%s,"self_reported":%s,"needs_confirmation":[%s],"unknown_provenance":[%s],"profile":"%s","plan":"%s","plan_exists":%s}\n' \
+      "${rows:-0}" "$selfn" \
+      "$(for t in $assumed; do printf '"%s",' "$t"; done | sed 's/,$//')" \
+      "$(for t in $legacy; do printf '"%s",' "$t"; done | sed 's/,$//')" \
+      "$PROFILE_FILE" "$PLAN_FILE" \
+      "$([[ -f "$PLAN_FILE" ]] && echo true || echo false)"
+    ;;
+
+  plan-path)
+    mkdir -p "$KNOWLEDGE_DIR"
+    echo "$PLAN_FILE"
+    ;;
+
+  *)
+    # Per-change modes: <change_name> log|--list
+    CHANGE="$CMD"; shift || true
+    SUB="${1:-}"
+    case "$SUB" in
+      log)
+        kind="${2:-}"; detail="${3:-}"
+        [[ -n "$kind" && -n "$detail" ]] || { echo "Error: usage: <change> log <kind> \"<detail>\"" >&2; exit 1; }
+        grep -qw -- "$kind" <<<"$VALID_KINDS" || { echo "Error: kind must be one of: $VALID_KINDS" >&2; exit 1; }
+        file="$(ensure_teaching "$CHANGE")"
+        printf '\n### %s — %s\n\n%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$kind" "$detail" >> "$file"
+        echo "logged $kind to $file"
+        ;;
+      --list)
+        file="$SPECCLAW_DIR/changes/$CHANGE/teaching.md"
+        [[ -f "$file" ]] || { echo "No teaching record for '$CHANGE' yet."; exit 0; }
+        cat "$file"
+        ;;
+      *)
+        echo "Error: unknown command '$CMD'. Use --help for usage." >&2
+        exit 1
+        ;;
+    esac
+    ;;
+esac

--- a/plugins/specclaw/references/teaching-mode.md
+++ b/plugins/specclaw/references/teaching-mode.md
@@ -1,0 +1,217 @@
+# Teaching Mode — protocol
+
+Read this before running a lifecycle phase with `teach.enabled: true`. Check state first:
+
+```bash
+specclaw-teach .specclaw status   # {"enabled":true,"depth":"brief","gate_builds":true,...}
+```
+
+If `enabled` is false, ignore this file entirely and run the phase exactly as normal.
+
+---
+
+## Why this exists
+
+A user who ends a change holding working code they cannot explain has not been served, however good
+the code is. Teaching mode exists for the case where **understanding is the deliverable** and the
+code is the vehicle — onboarding, upskilling programmes, unfamiliar stacks, or any engineer who says
+"walk me through it" rather than "just build it".
+
+## The two laws
+
+### 1. The human decides; the agent codes
+
+| The agent owns | The human owns |
+|---|---|
+| All code, config, scaffolding, debugging | Every architectural and tooling **decision** |
+| Presenting options with honest costs, plus a recommendation | Choosing — or overruling the recommendation |
+| Explaining at the depth the profile calls for | Predicting outcomes before measuring |
+| Fixing its own bugs without narration | Declaring what they already know, honestly |
+
+Never ask a user to type code "to learn by doing" — it's slow and teaches syntax, not judgement.
+Ask them to **decide, predict, or explain**.
+
+### 2. One artifact at a time
+
+Producing a document set up front is the failure this mode was designed against: it reads as
+thorough and functions as noise.
+
+- **One living document** — `.specclaw/changes/<change>/teaching.md`
+- Docs written **at the phase that needs them**, never in advance
+- **One diagram per phase**, and only when it replaces prose
+- **Every reply ends with exactly one next action**
+- If the user seems lost, **shrink the step** — do not add explanation
+
+Before writing any document, ask: *will they read this in the next ten minutes?* If not, don't.
+
+---
+
+## Calibration — ask before teaching
+
+Read `.specclaw/knowledge/learner-profile.md`. For any technology the change touches that isn't
+listed, **ask** — using `AskUserQuestion` with these four options:
+
+**(a)** never used it · **(b)** theory / tutorials only · **(c)** shipped something real · **(d)** deep
+
+| Level | Brief? | Who decides |
+|-------|--------|-------------|
+| a | Yes, 3 min | Agent recommends strongly, explains the alternative |
+| b | Production concerns only — skip the basics | Agent recommends, user confirms |
+| c | No | User chooses from presented options |
+| d | No | **User proposes, agent critiques** |
+
+Ask in batches covering **the next one or two phases only**. Record with
+`specclaw-teach .specclaw level <tech> <a|b|c|d>`.
+
+**Spot-check inflated ratings** with one specific question rather than trusting the self-rating —
+*"You said (c) for Redis: what's the difference between a TTL and an eviction?"* Adjust the profile
+silently; the goal is a correctly calibrated plan, not a score.
+
+---
+
+## Generating a concept brief
+
+**There is deliberately no cheatsheet library in this plugin.** A file per technology is a coverage
+promise that can't be kept — it holds only what someone happened to write, and it rots while model
+knowledge does not. Generate briefs instead; this section is the quality bar.
+
+### Step 1 — classify, to decide knowledge vs docs
+
+| Class | Examples | Source |
+|-------|----------|--------|
+| Stable concept | saga, idempotency, CAP, LRU, backpressure, ACID | **Your own knowledge.** Don't fetch |
+| Stable tool semantics | Kafka offsets, Redis `INCR` atomicity, HTTP 302 vs 301 | **Your knowledge**, with magnitudes |
+| Volatile specifics | current major version, install command, config keys, API signatures, ports | **Fetch official docs.** Say you fetched |
+| Fast-moving ecosystem | framework routers, OTel SDK APIs, cloud limits | **Fetch**, and state the version described |
+
+Explain *concepts* from knowledge; verify *specifics* from docs. Writing an exact CLI flag or config
+key from memory is the moment to stop and fetch. If you can't fetch, say the fact is unverified — an
+honest gap costs seconds, a confidently wrong flag costs twenty minutes.
+
+### Step 2 — the six parts, in order
+
+Problem before mechanism, always. **Budget: 3–4 minutes of reading.**
+
+1. **The problem it solves** — show the naive approach and what breaks. A learner who feels the
+   problem retains the solution; one handed the solution memorises it.
+2. **The mental model** — one analogy, then **where the analogy breaks**. The break is the
+   load-bearing part; it's where a wrong model would have produced a bug.
+3. **The 3–5 primitives** — only what this change uses. Not the API surface.
+4. **The numbers** — mandatory. Latency, throughput, size, limits, **and what this project actually
+   needs**, so the user can see which numbers don't matter. *"Kafka does 1M/s, Rabbit 50k/s, we need
+   10/s — so throughput isn't the deciding factor"* teaches more than either figure alone.
+5. **The failure mode** — specific to this technology's semantics, not generic. "At-least-once means
+   duplicates *will* arrive, so consumers must be idempotent" — not "the process might crash".
+6. **What it costs** — if you can't name the cost, you don't understand it well enough to teach it.
+
+### Step 3 — cache it
+
+Write to `.specclaw/knowledge/briefs/<topic>.md`, stamped with the date and version described. The
+user can re-read it for free, and the next person on the project inherits it. **Never write generated
+briefs into the plugin.**
+
+### Quality checklist
+
+- [ ] Opens with a problem, not a definition
+- [ ] The analogy's limits are stated
+- [ ] At least three concrete numbers, one being *what this project needs*
+- [ ] A failure mode specific to this technology
+- [ ] Names what the choice costs
+- [ ] One to two screens
+- [ ] Volatile facts fetched, or flagged unverified
+- [ ] Ends with one question that makes them predict, decide or explain
+
+---
+
+## Phase hooks
+
+### `propose`
+After drafting the proposal, list the technologies the change will touch. Ask for levels on any not
+in the profile. Note in the proposal which parts are **learning surface** versus plumbing, so effort
+feels aimed.
+
+### `plan`
+For each significant design decision, present **2–4 options** — including at least one *simpler* than
+your recommendation, the "do we even need this?" option. Naming and rejecting the simpler option with
+a reason is itself the lesson, and the antidote to over-engineering.
+
+| Option | Shape | Pros | Cons | Learning cost | Run cost | Verdict |
+|---|---|---|---|---|---|---|
+
+Then give **one recommendation with the single deciding factor** — not a list — and **what would
+change your mind**. The user chooses. Record their choice and their reason verbatim in `design.md`,
+and log it:
+
+```bash
+specclaw-teach .specclaw <change> log decision "<what and why, in their words>"
+```
+
+If they pick against the recommendation, use *their* reason as the rationale, not yours.
+
+### `build`
+When `gate_builds: true`, before each wave that uses a technology rated **a** or **b**:
+
+```
+**Wave N: <what>**
+Where you are: <one line>
+1. Concept: know <tech>, or want the 3-minute brief?
+2. Depth: quick PoC first, or straight into the change?
+3. Parallel: build while you read ahead?
+
+**Decision needed:** <the actual question>
+*(Recommendation: X, because Y. It costs us Z.)*
+```
+
+Then build at full speed with no narration, fixing your own bugs. After the wave, give **one**
+verify command with what they should see and what it means.
+
+If they say "just do it": do it, then one line — *"Built. The one thing worth knowing: <insight>."*
+Don't sulk, don't over-explain, don't skip the insight.
+
+### `verify`
+At `depth: full`, ask for a prediction **before** revealing any number:
+
+> "Sustained 150 rps against 4 shards. What p95 do you expect?"
+
+Then compare explicitly and log it. A wrong prediction is the most valuable event in the change — it
+marks exactly where the user's model diverges from the system. Never skip the prediction to save
+time; it costs fifteen seconds.
+
+```bash
+specclaw-teach .specclaw <change> log prediction "Predicted <x>; measured <y>; gap = <cause>"
+```
+
+### `pr`
+Before opening the PR, run the debrief:
+
+1. **What was built** — component map, one line each, flagging pure plumbing so attention isn't wasted
+2. **Every decision** — this table, and the *costs us* column is mandatory:
+
+   | Decision | Chose | Alternatives | Why | Costs us | Reversibility | Forced by the spec? |
+   |---|---|---|---|---|---|---|
+
+3. **If you built this from scratch** — the *order*, and the decision faced at each step. Not the
+   code. Plus what you'd do differently in production, and what was deliberately left out.
+4. **Two questions:** *"Explain to a sceptical reviewer why we <key decision>, when they think
+   <obvious alternative> is better."* and **"Which decision above do you think is wrong or
+   over-engineered?"** If the answer is "none", push once — there is always a weakest one.
+
+```bash
+specclaw-teach .specclaw <change> log debrief "<summary>"
+```
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Instead |
+|---|---|---|
+| Generating docs before they're needed | Reads as thorough, functions as noise | Just-in-time or not at all |
+| Explaining before checking the profile | Wastes a (c)/(d) user's session | Calibrate first |
+| One design presented as the answer | Not a decision, just a habit | 2–4 options with costs |
+| More than one next action per reply | Reintroduces "what now?" | Pick one |
+| Teaching the tool instead of the concept | `SETEX` syntax is trivia | *Why* the TTL is jittered is the lesson |
+| Walking the user through debugging | It's the agent's bug | Fix it; one line on the cause if instructive |
+| "Does that make sense?" | Invites yes | Ask them to predict, decide, or explain |
+| Answering your own gate question | Removes the decision | Ask, then stop |
+| A brief for a (c)/(d) user | Signals the profile wasn't read | Skip to the decision |

--- a/plugins/specclaw/skills/build/SKILL.md
+++ b/plugins/specclaw/skills/build/SKILL.md
@@ -41,6 +41,15 @@ Outputs JSON: `[{"id":"T1","title":"...","wave":1,"depends":[],"files":[...],"es
 
 **Retry:** to re-run failed tasks, parse with `--status failed`, reset each to `pending` via `specclaw-update-task-status .specclaw/changes/<change>/tasks.md <TASK_ID> pending`, then re-parse with `--status pending`.
 
+## Step 2.5 — Teaching gate (if `teach.enabled: true`)
+
+Run `specclaw-teach .specclaw status`. If `enabled` and `gate_builds` are true, **stop here before
+spawning any agent** and gate the first wave — see the Teaching mode section at the end of this skill
+for the gate format. Re-gate at the top of each subsequent wave.
+
+This step exists at this position on purpose: tasks must be parsed (Step 2) before you can gate on
+them, and the gate is worthless after Step 3 has already built everything.
+
 ## Step 3 — Wave loop
 
 For each wave number (1, 2, 3, ...):
@@ -168,3 +177,14 @@ Send a final **build summary**:
 - **Fail-fast on dependencies** — if a task fails, all dependents are immediately marked failed.
 - **Agent guardrails** — every coding agent is auto-prepended four behavioral rules (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution), vendored verbatim from Andrej Karpathy's CLAUDE.md. See `references/agent-guardrails.md`. Injection happens inside `specclaw-build-context`; no config flag.
 - **Loop-aware** — when `loop.enabled: true` (the default), this build is one turn of the autonomous loop driven by `/specclaw:loop`, which re-runs verify+review and fixes the smallest diff until every gate is green or a guardrail halts. Build produces the first implementation; the loop remediates it. When `loop.enabled: false`, build behaves single-pass exactly as documented above — no loop, no extra files.
+
+## Teaching mode (if `teach.enabled: true`)
+
+Check with `specclaw-teach .specclaw status`. When enabled with `gate_builds: true`, before each wave that uses a technology the learner profile rates **a** or **b**:
+
+1. **Gate** — state where they are in one line, offer a 3-minute concept brief, offer a quick PoC or straight-in, and ask for the **one decision** this wave needs (with a recommendation and what it costs). Then stop.
+2. **Build** at full speed with no narration. Fix your own bugs — do not walk the user through debugging.
+3. **After the wave**, give exactly **one** verify command, with what they should see and what it means.
+4. Log briefs given: `specclaw-teach .specclaw <change> log brief "<topic and key points>"`.
+
+Generate briefs from the recipe in `references/teaching-mode.md` — there is deliberately no cheatsheet library. Cache each at `.specclaw/knowledge/briefs/<topic>.md`. Never ask the user to type code "to learn"; ask them to decide, predict, or explain.

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -20,6 +20,7 @@ Turn an approved proposal into an executable plan.
    - **Codebase survey:** build a structured survey and keep it in your working context for spec/design/tasks generation: top-two-level directory summary (e.g. from `git ls-files | cut -d/ -f1-2 | sort -u`), detected manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `*.csproj`, `pom.xml`, `Makefile`, ...) and the languages/tooling they imply, and where tests live.
    - **Discovered project docs:** run `specclaw-discover-context .specclaw list` to see ranked candidate docs (rank, line count, path), then `specclaw-discover-context .specclaw emit` for the budget-capped digest. Read the digest and apply the project's documented conventions, constraints, and non-goals throughout planning. Prefer docs most relevant to this change when deciding what to read in depth. **Cite your evidence:** when a spec requirement, design decision, or task constraint comes from a discovered doc, name the doc path and quote the exact line(s) it rests on — never attribute a claim to a doc without a quote. If discovery is disabled or finds nothing, both commands print nothing — skip this step silently.
    - **Promoted spec knowledge:** read `.specclaw/knowledge/spec-guidelines.md` if it exists — it holds spec/design guidance promoted from earlier build learnings; apply it when writing `spec.md` and `design.md`.
+3.5. **Teaching gate** (if `teach.enabled: true`, via `specclaw-teach .specclaw status`): surface each significant design decision as scored options and **let the user choose before step 4 writes `design.md`**. Deciding silently and documenting afterwards defeats the mode. See the Teaching mode section at the end of this skill.
 4. Generate three files in `.specclaw/changes/<change>/`:
    - `spec.md` — functional requirements, non-functional requirements, acceptance criteria, edge cases.
      - **If `--author-spec` is set:** invoke the `spec-author` subagent via the `Agent` tool with `subagent_type: "spec-author"` to author the spec interactively. After the agent writes the file, **STOP and require explicit user approval** (e.g. "approved", "yes", "go") before proceeding to `design.md` and `tasks.md`. Do not generate the remaining files until the user approves.
@@ -42,3 +43,13 @@ Turn an approved proposal into an executable plan.
 ## Planner guardrails
 
 When generating `tasks.md`, apply the same rules `/specclaw:build` injects into coding agents — see `references/agent-guardrails.md`. In particular: **Rule 1 (Think Before Coding)** — state assumptions explicitly in the spec/design and ask if anything is unclear, rather than picking silently between interpretations. **Rule 2 (Simplicity First)** — no speculative tasks, no over-decomposition; if three tasks could be one, make it one.
+
+## Teaching mode (if `teach.enabled: true`)
+
+Check with `specclaw-teach .specclaw status`. When enabled, design decisions become the user's, not yours:
+
+1. For each significant decision in `design.md`, present **2–4 options** in a table with pros, cons, learning cost and run cost — including at least one option *simpler* than your recommendation. Naming and rejecting the simpler option with a reason is itself the lesson.
+2. Give **one recommendation with the single deciding factor** — not a list — plus **what would change your mind**. Then stop and let the user choose.
+3. Record their choice and their reason **verbatim** in `design.md` under Key Decisions, and log it: `specclaw-teach .specclaw <change> log decision "<what and why>"`. If they choose against your recommendation, their reason is the rationale, not yours.
+
+Full option-table format and worked example: `references/teaching-mode.md`.

--- a/plugins/specclaw/skills/pr/SKILL.md
+++ b/plugins/specclaw/skills/pr/SKILL.md
@@ -11,6 +11,7 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
 1. **Code review block (conditional):** Read `workflow.code_review_block` from `.specclaw/config.yaml`. If `true`:
    - Check if `.specclaw/changes/<change>/review-report.md` exists. If it does not exist, warn: "code_review_block is enabled but no review-report.md found — run /specclaw:verify first" and continue.
    - If `review-report.md` exists and verdict is `CHANGES_REQUESTED`, **abort** with: "PR blocked: code review verdict is CHANGES_REQUESTED. Fix BLOCK findings in review-report.md then re-run /specclaw:verify." List all BLOCK findings from the report before aborting.
+1.5. **Teaching debrief** (if `teach.enabled: true`, via `specclaw-teach .specclaw status`): run the debrief **before** the PR is created — once `specclaw-pr` has run, the PR is open and the debrief is a postscript. See the Teaching mode section at the end of this skill.
 2. **Validate:** `specclaw-validate-change .specclaw <change> pr`. Exits with a warning (exit 0) if a PR already exists for this change. Fails if `verify-report.md` is missing.
 2. **Run:** `specclaw-pr .specclaw <change>` — **always** create the PR through this script, never hand-roll `gh pr create`. `specclaw-pr` stages and commits the full `.specclaw/changes/<change>/` planning trail (proposal, spec, design, tasks, status, verify-report) into the branch and **aborts if any of it is left uncommitted** — a raw `gh pr create` skips this and ships a PR missing the proposal artifacts.
    - **First run:** prompts for test policy (`none|unit|e2e|both`), saves it to `config.yaml` under `pr.test_policy`. Never prompts again.
@@ -33,3 +34,14 @@ Create a GitHub PR for a verified change. Requires `verify-report.md` (build + v
 4. Report the PR URL to the user.
 
 **CI outer loop (if `loop.ci_gate: true`):** once the PR branch is pushed, the CI tier of `/specclaw:loop` (Step 3 / `specclaw-loop ci-poll`) polls GitHub Actions checks and iterates fixes until they are green, or `loop.ci_max_iterations` / `loop.ci_timeout_seconds` halts and escalates. This is a cross-reference only — PR creation above is unchanged, and nothing extra runs when `loop.ci_gate` is false.
+
+## Teaching mode (if `teach.enabled: true`)
+
+Check with `specclaw-teach .specclaw status`. When enabled, run the **debrief before opening the PR**:
+
+1. **What was built** — component map, one line each, flagging pure plumbing so attention isn't wasted.
+2. **Every decision**, in a table where the *costs us* column is mandatory: decision | chose | alternatives | why | costs us | reversibility | forced by the spec?
+3. **If you built this from scratch** — the *order*, and the decision faced at each step. Not the code. Plus what you'd do differently in production, and what was deliberately left out.
+4. **Two questions:** *"Explain to a sceptical reviewer why we <key decision>, when they think <obvious alternative> is better."* and **"Which decision above do you think is wrong or over-engineered?"** If they say "none", push once — there is always a weakest one.
+
+Log it: `specclaw-teach .specclaw <change> log debrief "<summary>"`. The debrief, not the code, is the deliverable of teaching mode.

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -68,3 +68,13 @@ Create a new proposal for a change.
 9. **Once the user approves the proposal**, record the phase: `specclaw-set-phase .specclaw <change-name> proposal approved`. `specclaw-set-phase` is the only writer of phase state — it records `state.json` and upserts the Proposal row in `status.md`. Never hand-edit those rows. Until approval the template's `🟡 Draft` row stands.
 
 Do not proceed to `/specclaw:plan` until the user has approved the proposal.
+
+## Teaching mode (if `teach.enabled: true`)
+
+Check with `specclaw-teach .specclaw status`. When enabled, after presenting the proposal:
+
+1. Show a **stack table** of every technology this change touches — libraries included, not just categories (`kafka` and `kafkajs` are different things to know) — with what each is for *in this project* and where it appears. Mark which parts are learning surface versus plumbing.
+2. Ask for the user's level on **every row**: **(a)** never used it, **(b)** theory only, **(c)** shipped with it, **(d)** deep — via `AskUserQuestion`, batched 4 at a time in first-needed order. Record each: `specclaw-teach .specclaw level <tech> <a|b|c|d> self`. Being asked is not overhead — it's how the user sees the surface area of the work.
+3. Spot-check every (c)/(d) claim with one specific question and correct it silently if it doesn't hold.
+
+Never assume a level in either direction. Protocol: `references/teaching-mode.md`.

--- a/plugins/specclaw/skills/teach/SKILL.md
+++ b/plugins/specclaw/skills/teach/SKILL.md
@@ -1,0 +1,215 @@
+---
+description: Turn teaching mode on or off, record what the human already knows, and generate on-demand concept briefs. When teach mode is enabled, propose/plan/build/verify explain before implementing and surface design choices as decisions for the human instead of deciding silently. Use when a user wants to learn the technologies while a change is built, or asks to be walked through rather than handed finished code.
+---
+
+# specclaw teach
+
+**First, run** `specclaw-ensure-init .specclaw` — idempotently creates `.specclaw/` if it doesn't exist (silent if already initialized; auto-inits using the current directory's basename as the project name).
+
+Teaching mode makes the lifecycle **explain while it builds**. It does not add a parallel workflow —
+`propose`, `plan`, `build` and `verify` gain teaching behaviour when it's on, and behave exactly as
+before when it's off.
+
+Full protocol: `references/teaching-mode.md`. Read it before running a teaching phase.
+
+> **Not to be confused with `/specclaw:learn`**, which records what the *machine* learned — spec
+> gaps and patterns fed back into agent context. This skill teaches the *human*.
+> `learnings.md` and `teaching.md` are the two halves.
+
+## Invoked with no arguments? Run the assessment.
+
+**This is the default behaviour and it is not optional.** A bare `/specclaw:teach` means *"assess me
+and show me the plan"* — not *"print the config"*. Reporting status and stopping is the failure mode
+this section exists to prevent.
+
+```bash
+specclaw-teach .specclaw status    # enabled, depth, gate_builds
+specclaw-teach .specclaw assess    # what still needs asking
+```
+
+`assess` returns `recorded`, `self_reported`, `needs_confirmation` (levels marked `assumed`),
+`unknown_provenance` (older rows with no source), and whether a learning plan exists.
+
+Then run these five steps in order:
+
+### Step 1 — Show the whole stack first, as a table
+
+**Before asking anything, show them what they're dealing with.** Read the change's `proposal.md`,
+`spec.md`, `design.md`, `tasks.md`, plus `package.json` / compose files / lockfiles for the concrete
+libraries. Then present **every** technology the work touches:
+
+| # | Technology | What it's for *here* | Where it appears | Your level |
+|---|-----------|---------------------|------------------|-----------|
+| 1 | Kafka | The event bus all four services publish to | T1, T3, T5 | ? |
+| 2 | kafkajs | The Node client — the actual API you'll read | T3, T4 | ? |
+
+Rules for this table:
+- **Include libraries, not just categories.** "Kafka" and "kafkajs" are different things to know;
+  so are "tracing" and "the OTel SDK". Vague rows produce vague levels.
+- **Include what's already recorded**, showing the level rather than `?`. They need the whole
+  picture, not the gaps.
+- **"What it's for here"** is project-specific, not a definition. `"The event bus all four services
+  publish to"`, not `"a distributed streaming platform"`.
+- Order by when it's first needed.
+
+This table is half the value of the whole skill: it's the first time the learner sees the actual
+surface area of the work.
+
+### Step 2 — Ask about every row
+
+**Ask across the whole stack, not just the gaps.** Being asked is not overhead — it's how the
+learner discovers what the project involves. `AskUserQuestion` takes 4 per call, so batch by
+first-needed order and say how many batches are coming.
+
+- **(a)** never used it · **(b)** theory / tutorials only · **(c)** shipped something real · **(d)** deep
+
+For rows already marked `self` and recorded recently, don't re-ask from scratch — show the recorded
+level and ask for confirmation in a single question covering several rows at once.
+
+```bash
+specclaw-teach .specclaw level kafkajs a self
+```
+
+If a profile came pre-populated and you cannot tell who answered, **ask again** — a profile you
+inherited is not an assessment.
+
+**Spot-check every (c)/(d) claim** with one specific, answerable question, and correct the level
+silently if it doesn't hold. Say you're correcting it and why. The aim is a correctly calibrated
+plan, not a score — and an honest downgrade buys them the teaching they'd otherwise have been
+denied.
+
+### Step 3 — Show the level map back
+Technology, level, source, and **what that means for their time** — brief / production-concerns only
+/ no teaching / you-lead. They should see where the hours will go before agreeing to spend them.
+Call out the ratio: *"five of eight at (a)/(b), which is why briefs go one-per-task rather than as a
+reading pile."*
+
+### Step 4 — Generate the learning plan
+```bash
+specclaw-teach .specclaw plan-path      # canonical location
+```
+
+Write it from `templates/knowledge/learning-plan.md`, filling all eight sections:
+
+| Section | Contents |
+|---------|----------|
+| 1 Level map | Every technology, level, source, treatment |
+| 2 **Learn** | One brief per (a)/(b) technology, each tied to the task that needs it — *not* delivered up front |
+| 3 **Explain** | Every decision that is theirs, with the task it blocks |
+| 4 **PoC** | Only where watching a mechanism fail is faster than reading about it. Justify each; skip the rest |
+| 5 Implementation | The build sequence, marking which waves gate and what their part is (decide / predict / observe) |
+| 6 **How to start** | One concrete opening move — see step 5 |
+| 7 Predictions | Empty, filled as you go |
+| 8 Not learning | What's deliberately skipped, and why |
+
+The plan is derived from the level map. Someone at (d) on Docker gets no Docker entries at all;
+someone at (a) on Kafka gets a brief, possibly a PoC, and a gate.
+
+**Align it to the specclaw lifecycle, not to an abstract syllabus.** Every learning item hangs off a
+real phase, wave or task id — `T5`, `wave 2`, `/specclaw:verify` — so "learning" and "the work" are
+the same list. If an item can't be attached to a task, either it belongs in section 7 (not learning
+this time) or the plan is missing a task.
+
+### Step 5 — Suggest how to start
+
+Don't end with a menu. End with **one concrete opening move**, and say what it opens with:
+
+> **Start with T1 (Kafka + Jaeger containers).** It opens with the Kafka brief — partitions,
+> offsets, consumer groups — then the one decision that gets expensive later: partition key.
+> Everything else in wave 1 is Compose, which I write without commentary.
+>
+> Say **"start T1"** and I'll open with the brief.
+
+Name the first thing, why it's first, what teaching it opens with, and the exact words to reply.
+"Approve the plan or tell me what to change" is a menu, not a suggestion.
+
+## Toggle
+
+```bash
+specclaw-teach .specclaw enable --depth brief      # minimal | brief | full
+specclaw-teach .specclaw disable
+```
+
+`depth` controls how much explanation each phase offers:
+
+| depth | Behaviour |
+|-------|-----------|
+| `minimal` | Decisions surfaced as options; no concept briefs |
+| `brief` | + a 3-minute brief before any phase using a technology rated **a** or **b** *(default)* |
+| `full` | + a prediction before every measurement, and a debrief after `verify` |
+
+## Levels
+
+```bash
+specclaw-teach .specclaw level kafka a self       # they answered
+specclaw-teach .specclaw level docker d assumed   # inferred - must be confirmed later
+specclaw-teach .specclaw levels
+```
+
+Project-wide, in `.specclaw/knowledge/learner-profile.md`. The fourth argument is provenance and it
+is load-bearing:
+
+| Source | Meaning | Consequence |
+|--------|---------|-------------|
+| `self` | The learner answered | Trusted; phases act on it |
+| `assumed` | You inferred it | **Must be re-asked** before any phase relies on it. `assess` lists these |
+
+Default is `self`, so only pass `assumed` when you're guessing. Recording a guess as `self` is the
+bug that makes teaching mode silently skip someone's assessment.
+
+Ask in **batches covering the next one or two phases only** — twelve questions up front is its own
+kind of overwhelm. Re-ask whenever a change introduces a technology not already in the profile.
+
+## Log what was taught
+
+```bash
+specclaw-teach .specclaw <change> log brief      "Kafka: log vs queue, offsets, consumer groups"
+specclaw-teach .specclaw <change> log decision   "Chose orchestration over choreography — easier to trace"
+specclaw-teach .specclaw <change> log prediction "Predicted p95 250ms; measured 310ms; gap = broker fsync"
+specclaw-teach .specclaw <change> log checkpoint "Explained why at-least-once forces idempotency"
+specclaw-teach .specclaw <change> log debrief    "Reviewed 6 decisions; overruled the DLQ retry count"
+specclaw-teach .specclaw <change> --list
+```
+
+Writes to `.specclaw/changes/<change>/teaching.md`. That file *is* the evidence of learning — it's
+what a mentor, reviewer, or the learner themselves reads three weeks later.
+
+## Generate a concept brief
+
+Do **not** ship or expect a cheatsheet library — a file per technology is a coverage promise no
+plugin can keep, and static files rot while model knowledge doesn't. Generate briefs on demand
+following the recipe in `references/teaching-mode.md`:
+
+1. **Classify the topic.** Stable concept (saga, idempotency, CAP) → write from your own knowledge.
+   Volatile specifics (versions, CLI flags, config keys, API signatures) → **fetch the official docs
+   first**, and say you did.
+2. **Six parts, in order:** the problem it solves → mental model *and where the analogy breaks* →
+   3–5 primitives → **the numbers** → the failure mode → what it costs.
+3. **Cache it** at `.specclaw/knowledge/briefs/<topic>.md`, stamped with the date and the version
+   described. Never write it into the plugin.
+4. **One to two screens.** Longer means it's two briefs — give the first, offer the second.
+
+End every brief with one question that makes the user predict, decide, or explain something back.
+Never "does that make sense?" — it invites yes.
+
+## The two rules the phases enforce
+
+**1. The human makes the decisions; the agent writes the code.** Hand-typing boilerplate teaches
+nothing. Choosing between two designs *with the costs visible* is the skill being learned. So never
+ask the user to type code "to learn"; ask them to decide, predict, or explain.
+
+**2. One artifact at a time.** Documents are written at the phase that needs them, never in advance,
+and every reply ends with exactly **one** next action. If the user seems lost, **shrink the step** —
+adding explanation is the wrong fix for overwhelm.
+
+## Phase behaviour when enabled
+
+| Phase | Teaching behaviour |
+|-------|--------------------|
+| `propose` | Names the technologies the change will touch; asks for levels not yet in the profile |
+| `plan` | Surfaces design decisions as 2–4 options with pros, cons and costs. The user picks; their reason is recorded verbatim in `design.md` |
+| `build` | Before a wave using a technology rated a/b: offer a brief. After each wave: one verify command, what to expect, what it means |
+| `verify` | Asks for a prediction before revealing numbers; logs predicted-vs-actual |
+| `pr` | Debrief: what was built, every decision with its alternatives and costs, and how they'd build it from scratch |
+
+When `teach.enabled` is false, none of the above happens and no teaching files are created.

--- a/plugins/specclaw/skills/verify/SKILL.md
+++ b/plugins/specclaw/skills/verify/SKILL.md
@@ -18,6 +18,12 @@ If it fails (tasks not all complete), report and stop.
 
 **If `.specclaw/context.md` exists**, read it before evaluating — the verifier must check that the implementation respects the project's coding rules, patterns, and constraints documented there, in addition to the spec's acceptance criteria.
 
+## Step 0.5 — Prediction (if `teach.enabled` and `depth: full`)
+
+Run `specclaw-teach .specclaw status`. If `depth` is `full`, ask the user to predict the headline
+numbers **before** Step 1 runs anything — a prediction offered after the results are on screen is
+worthless. See the Teaching mode section at the end of this skill.
+
 ## Step 1 — Collect evidence
 
 ```bash
@@ -124,3 +130,17 @@ When `loop.enabled: false`, remediation is manual. If verdict is FAIL or PARTIAL
 1. List the failed acceptance criteria.
 2. Suggest creating remediation tasks targeting the gaps.
 3. The user can re-plan just the failed criteria or manually fix and re-verify.
+
+## Teaching mode (if `teach.enabled: true`)
+
+Check with `specclaw-teach .specclaw status`. When `depth: full`, ask for a **prediction before revealing any number**:
+
+> "Sustained 150 rps across 4 shards — what p95 do you expect?"
+
+Then compare explicitly and log it:
+
+```bash
+specclaw-teach .specclaw <change> log prediction "Predicted <x>; measured <y>; gap = <cause>"
+```
+
+A wrong prediction is the most valuable event in the change — it marks exactly where the user's mental model diverges from the system. It costs fifteen seconds; never skip it to save time.

--- a/plugins/specclaw/templates/config.yaml
+++ b/plugins/specclaw/templates/config.yaml
@@ -106,6 +106,21 @@ github:
   token: ""                      # GitHub PAT for curl fallback (not needed if gh CLI is authed)
   label: "specclaw"              # Label applied to SpecClaw issues
 
+# Teaching mode (opt-in). When enabled, lifecycle phases explain before they
+# implement, surface design choices as decisions for the human instead of
+# deciding silently, and record what was taught in
+# changes/<change>/teaching.md. Absent or false -> phases behave as before.
+#
+# Companion to /specclaw:learn, which records what the MACHINE learned.
+# This records what the HUMAN learned.
+teach:
+  enabled: false
+  depth: "brief"        # minimal | brief | full
+                        #   minimal - decisions surfaced as options, no briefs
+                        #   brief   - + 3-min concept brief for tech rated a/b
+                        #   full    - + prediction beforeevery measurement, debrief at pr
+  gate_builds: true     # pause before a build wave using an unfamiliar technology
+
 # Workflow enforcement
 workflow:
   strict: true                     # Enforce phase prerequisites (disable for rapid prototyping)

--- a/plugins/specclaw/templates/knowledge/learner-profile.md
+++ b/plugins/specclaw/templates/knowledge/learner-profile.md
@@ -1,0 +1,20 @@
+# Learner Profile
+
+Self-rated levels per technology. Drives how much explanation each lifecycle phase gives, so an
+honest **a** saves time rather than costing face, and an inflated **c** wastes an afternoon.
+
+**Scale**
+
+| Level | Means | What the phases do |
+|-------|-------|--------------------|
+| **a** | Never used it | 3-min brief before the phase that needs it; decisions come with a strong recommendation and its alternative |
+| **b** | Theory / tutorials only | Skip basics; cover the production concerns tutorials omit |
+| **c** | Shipped something real | No teaching; you choose from presented options |
+| **d** | Deep — could teach it | You propose, the agent critiques |
+
+**Provenance matters.** `self` = the learner answered. `assumed` = inferred and **not yet
+confirmed** — the assessment step must re-ask before any phase trusts it. Trusting an unconfirmed
+level silently is how a learner ends up either bored by basics or lost in something skipped.
+
+| Technology | Level | Source | Recorded |
+|------------|-------|--------|----------|

--- a/plugins/specclaw/templates/knowledge/learning-plan.md
+++ b/plugins/specclaw/templates/knowledge/learning-plan.md
@@ -1,0 +1,105 @@
+# Learning Plan — {{project}}
+
+**Change:** {{change}} · **Generated:** {{date}} · **Depth:** {{depth}}
+
+> **Start here → reply `{{first_action}}`.** What it opens with is in §6.
+
+> The one document to keep open. Everything else is written at the step that needs it.
+> Regenerate with `/specclaw:teach` after any level changes.
+
+---
+
+## 1. Your level map
+
+| Technology | Level | Treatment |
+|------------|-------|-----------|
+| | | |
+
+State the ratio: how many sit at (a)/(b), and therefore why briefs are one-per-task rather than a
+reading pile. Note any level corrected by spot-check, and that a correction is not a mark against
+them — an inflated level silently denies them teaching they'd have wanted.
+
+---
+
+## 2. Learn — concept briefs queued
+
+One per technology rated **(a)** or **(b)**, delivered **immediately before** the task that needs it,
+never in a batch up front. 3–4 minutes each: the problem it solves → mental model and where the
+analogy breaks → 3–5 primitives → real numbers → the failure mode → what it costs.
+
+| # | Brief | For task | Why you need it there | Status |
+|---|-------|----------|----------------------|--------|
+| | | | | ⬜ queued / ✅ given |
+
+Cached to `knowledge/briefs/<topic>.md` as they're delivered.
+
+---
+
+## 3. Explain — decisions that are yours
+
+Each is presented as 2–4 scored options with costs, one recommendation with a single deciding factor,
+and what would change the recommender's mind. **You choose.** Your reason is recorded verbatim.
+
+| # | Decision | Options | Blocks task | Status |
+|---|----------|---------|-------------|--------|
+| | | | | ⬜ open / ✅ ADR-000N |
+
+---
+
+## 4. PoC — where a throwaway experiment is faster than reading
+
+Only where seeing a mechanism fail is genuinely quicker than being told about it. Not for every
+technology — a PoC you don't need is the same waste as a brief you don't need.
+
+| # | Experiment | Proves | Time | Status |
+|---|-----------|--------|------|--------|
+| | | | | ⬜ |
+
+**The test for including one:** would watching this break change what you build? If not, skip it.
+
+---
+
+## 5. Implementation — the build sequence, interleaved
+
+| Wave | Task | Level | Gate? | Your part |
+|------|------|-------|-------|-----------|
+| | | | | |
+
+**Gate?** = the build pauses for a brief and a decision before starting. Triggered by any task
+touching a technology rated (a) or (b), when `teach.gate_builds` is true.
+
+**Your part** = decide / predict / observe. Never "type this code".
+
+---
+
+## 6. How to start
+
+One concrete opening move — not a menu. Name the first task, why it's first, which briefs and
+decisions it opens with, and the exact words to reply.
+
+> **`{{first_action}}`** — {{first_task_title}}.
+>
+> It opens with {{briefs}}, then asks you {{decisions}}. Nothing gets written until you've decided.
+>
+> Reply **`{{first_action}}`**.
+
+---
+
+## 7. Predictions vs reality
+
+The most useful table here. A wrong prediction marks exactly where your mental model diverges from
+the system — which is the fastest thing to learn from.
+
+| Task | You predicted | Measured | Gap explained by |
+|------|--------------|----------|------------------|
+| | | | |
+
+---
+
+## 8. Deliberately not learning this time
+
+Naming what you're skipping is what keeps a plan finishable.
+
+| Topic | Why skipped | Revisit when |
+|-------|------------|--------------|
+| | | |

--- a/plugins/specclaw/templates/teaching.md
+++ b/plugins/specclaw/templates/teaching.md
@@ -1,0 +1,10 @@
+# Teaching: {{change_name}}
+
+What the **human** learned during this change.
+
+Companion to `learnings.md`, which records what the **machine** learned (spec gaps, patterns).
+Same change, two directions.
+
+**Kinds:** brief | decision | prediction | checkpoint | debrief
+
+---


### PR DESCRIPTION
Adds /specclaw:teach — a mode that makes the propose → plan → build → verify → pr lifecycle explain while it builds, for onboarding, upskilling and unfamiliar stacks. Off by default; when teach.enabled is false, no phase behaves differently and no teaching files are created.

Distinct from /specclaw:learn, which records what the MACHINE learned (spec gaps, patterns) into agent context. This records what the HUMAN learned. learnings.md and teaching.md are the two halves.

Phase behaviour when enabled:
- propose  names the technologies a change touches, asks the user's level per technology, stores it in knowledge/learner-profile.md
- plan     surfaces design decisions as 2-4 scored options with pros,
           cons and costs (including one simpler than the recommendation);
           the user chooses and their reason is recorded in design.md
- build    gates each wave using an unfamiliar technology, offers a
           3-minute brief, then builds without narration and returns
           exactly one verify command
- verify   asks for a prediction before revealing numbers (depth: full)
- pr       debriefs: what was built, every decision with alternatives and
           costs, and how the user would build it from scratch

No cheatsheet library by design. Concept briefs are generated from the recipe in references/teaching-mode.md and cached per project under .specclaw/knowledge/briefs/. A file per technology is a coverage promise no plugin can keep, and static files rot while model knowledge does not.

Added:  bin/specclaw-teach, skills/teach/SKILL.md,
        references/teaching-mode.md, templates/teaching.md,
        templates/knowledge/learner-profile.md
Changed: teach: block in templates/config.yaml, teaching-mode sections
        appended to propose/plan/build/verify/pr skills, README, CHANGELOG

<!-- Thanks for contributing to SpecClaw! -->

## What & why

<!-- What does this change do, and why is it needed? -->

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Chore / refactor

## Checklist

- [ ] Version bumped in `plugins/specclaw/.claude-plugin/plugin.json` **and** `.claude-plugin/marketplace.json` (kept in sync)
- [ ] `CHANGELOG.md` updated
- [ ] Tested locally (describe how below)

## How tested

<!-- Commands run, output, or the change working. -->
