### PR TITLE
fix(pr): stop two sed defects from corrupting status.md and aborting after PR creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: bash plugins/specclaw/tests/run-synth-agent-tests.sh
       - name: Run shellcheck-gate tests
         run: bash plugins/specclaw/tests/run-shellcheck-gate-tests.sh
+      - name: Run status-row tests
+        run: bash plugins/specclaw/tests/run-status-row-tests.sh
 
   shellcheck:
     name: ShellCheck bin scripts

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -46,6 +46,7 @@ All executable scripts live in `bin/`. Key ones:
 | `specclaw-update-context` | Output LLM prompt to rewrite context.md post-merge |
 | `specclaw-run-long` | Run a long command detached: heartbeats to stderr, capped tail to stdout, full log + HEAD-stamped sidecar on disk; `--reuse` skips a re-run when HEAD matches and the tree is clean |
 | `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard (resolves open/merged PR state per change) |
+| `specclaw-status-row` | Upsert one row of a change's `status.md` Progress table (awk — the table's pipes make `sed` unsafe) |
 | `specclaw-gh-sync` | GitHub Issues sync |
 | `specclaw-pr` | Create GitHub PR (enforces test policy, triggers context update) |
 | `specclaw-validate-change` | Check phase prerequisites |
@@ -61,6 +62,7 @@ Suites live in `tests/`, are bash + coreutils only (no jq in the suites themselv
 | `run-long-orchestration-tests.sh` | `run-long`, the e2e tier, `browser-lock wrap`, PR-aware status |
 | `run-synth-agent-tests.sh` | dynamically synthesized build subagents |
 | `run-shellcheck-gate-tests.sh` | the shellcheck gate itself |
+| `run-status-row-tests.sh` | `status-row` upserts, and the two sed defects it replaced |
 
 `shellcheck-gate.sh` fails CI on any shellcheck finding absent from `shellcheck-baseline.txt` (pairs of `<path> <SCxxxx>`, no line numbers, so unrelated edits do not churn it). Fix a new finding or add a targeted `# shellcheck disable=SCxxxx` with a rationale — never silence one by appending to the baseline. It skips with exit 0 when shellcheck is not installed, so the suite still runs locally.
 

--- a/plugins/specclaw/bin/specclaw-azdo-pr
+++ b/plugins/specclaw/bin/specclaw-azdo-pr
@@ -356,10 +356,21 @@ json_escape() {
 save_pr_url() {
   local url="$1"
   local status_file="$CHANGE_DIR/status.md"
-  if [[ -f "$status_file" ]]; then
-    echo "**ADO PR:** $url" >> "$status_file"
-  else
+  if [[ ! -f "$status_file" ]]; then
     printf '# Status: %s\n\n**ADO PR:** %s\n' "$CHANGE_NAME" "$url" > "$status_file"
+    return
+  fi
+
+  # Upsert the PR row in the Progress table so a change with an open PR stops
+  # rendering as "still building". Falls back to the plain field line when the
+  # helper is unavailable; the guard keeps a re-run from stacking duplicate
+  # `**ADO PR:**` lines, which the old unconditional append did every time.
+  local status_row_script="$SCRIPT_DIR/specclaw-status-row"
+  if [[ -x "$status_row_script" ]]; then
+    "$status_row_script" "$status_file" "PR" "✅ Raised" "$url" || \
+      warn "could not update the PR row in $status_file (PR itself is created)"
+  elif ! grep -qF "**ADO PR:** $url" "$status_file"; then
+    echo "**ADO PR:** $url" >> "$status_file"
   fi
 }
 
@@ -425,7 +436,10 @@ main() {
   [[ -n "$pr_id" ]] || die "Failed to parse PR ID from ADO response"
 
   local pr_url="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_git/${AZDO_REPO}/pullrequest/${pr_id}"
-  save_pr_url "$pr_url"
+  # The PR exists on the remote from here on, so bookkeeping must warn rather
+  # than abort under `set -e` — an abort here freezes the trackers while still
+  # printing a PR URL, which reads as success.
+  save_pr_url "$pr_url" || warn "failed to record the PR URL in status.md — PR is live at $pr_url"
   echo "✅ ADO PR created: $pr_url"
 
   # Auto-link PR → Azure Boards Work Item (if azdo.boards.sync is enabled and a

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -462,14 +462,19 @@ EOF
     sed_i "s|^\*\*Status:\*\*.*|**Status:** pr-raised|" "$status_file"
   fi
 
-  # Update PR row in the progress table if present; add it after Verify row if absent
-  if grep -qE '^\|[[:space:]]*PR[[:space:]]*\|' "$status_file"; then
-    sed_i "s|^\(| *PR *|\).*|\1 ✅ Raised | $url |" "$status_file"
-  elif grep -qE '^\|[[:space:]]*Verify[[:space:]]*\|' "$status_file"; then
-    # Insert PR row after the Verify row
-    sed_i "/^\|[[:space:]]*Verify[[:space:]]*\|/a\| PR     | ✅ Raised | $url |" "$status_file"
-  else
-    # Neither table row nor Status field — just append PR line
+  # Upsert the PR row in the Progress table. Delegated to specclaw-status-row,
+  # which edits the row in awk: the table is pipe-delimited, and sed cannot be
+  # trusted with pipes here — `\|` in a BRE address is *alternation* (the old
+  # `/^\|…Verify…\|/a` matched every line and appended 33 PR rows to a stock
+  # status.md), and `s|…| *PR *|…|` collides with its own delimiter
+  # (`sed: unknown option to 's'`, which under `set -e` killed this script
+  # immediately after the PR was created — see the change log for the report).
+  local status_row_script="$SCRIPT_DIR/specclaw-status-row"
+  if [[ -x "$status_row_script" ]]; then
+    "$status_row_script" "$status_file" "PR" "✅ Raised" "$url" || \
+      warn "could not update the PR row in $status_file (PR itself is created)"
+  elif ! grep -qE '^\|[[:space:]]*PR[[:space:]]*\|' "$status_file"; then
+    # Helper missing (partial install) — never lose the URL.
     echo "**PR:** $url" >> "$status_file"
   fi
 
@@ -651,8 +656,11 @@ main() {
   local pr_url
   pr_url="$(gh pr create --base "$pr_base" --title "$title" --body "$body")"
 
-  # Step 7: Save URL
-  save_pr_url "$pr_url"
+  # Step 7: Save URL. The PR now exists on the remote, so everything from here on
+  # is bookkeeping — it must warn, never abort under `set -e`. Aborting here is
+  # what left trackers frozen at their pre-PR state while the PR URL was still
+  # printed, so the failure looked like a success.
+  save_pr_url "$pr_url" || warn "failed to record the PR URL in status.md — PR is live at $pr_url"
 
   # Step 8: Update project context (always-on; errors are non-blocking)
   local update_context_script="$SCRIPT_DIR/specclaw-update-context"

--- a/plugins/specclaw/bin/specclaw-status-row
+++ b/plugins/specclaw/bin/specclaw-status-row
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# specclaw-status-row — upsert one row of the Progress table in a change's status.md
+# Usage: specclaw-status-row <status_file> <label> <status_text> [note]
+#
+# The Progress table rows are pipe-delimited, which makes `sed` the wrong tool
+# twice over:
+#
+#   1. In a sed address, `\|` is a GNU BRE *alternation* operator, not a literal
+#      pipe. `/^\|[[:space:]]*Verify[[:space:]]*\|/a…` therefore reads as
+#      "^ OR [[:space:]]*Verify[[:space:]]* OR <empty>" — and the empty branch
+#      matches every line, appending the new row after all of them.
+#   2. `s|^\(| *PR *|\).*|…|` delimits the s command with `|` while the pattern
+#      itself contains literal pipes, which sed rejects outright:
+#      `sed: -e expression #1, char 14: unknown option to 's'`.
+#
+# So the row edit is done in awk with a bracket-expression match (`[|]`), where a
+# pipe is unambiguously literal. Behaviour:
+#
+#   - Row present  → replaced in place, keeping its position in the table.
+#   - Duplicated   → collapsed to a single row (self-heals files already
+#                    corrupted by the sed bug above).
+#   - Row absent   → inserted after the last row of the Progress table, or
+#                    appended as a standalone `**<label>:** <note>` line when the
+#                    file has no table at all.
+#
+# Idempotent: re-running with the same values leaves the file byte-identical.
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-status-row <status_file> <label> <status_text> [note]
+
+  status_file   path to a change's status.md
+  label         first column of the row, e.g. "PR", "Verify", "Build"
+  status_text   second column, e.g. "✅ Raised"
+  note          third column (optional, e.g. the PR URL)
+EOF
+}
+
+case "${1:-}" in
+  -h | --help | '')
+    usage
+    exit 0
+    ;;
+esac
+
+STATUS_FILE="$1"
+LABEL="${2:-}"
+STATUS_TEXT="${3:-}"
+NOTE="${4:-}"
+
+[ -n "$LABEL" ] || {
+  echo "specclaw-status-row: label is required" >&2
+  exit 2
+}
+[ -f "$STATUS_FILE" ] || {
+  echo "specclaw-status-row: no such file: $STATUS_FILE" >&2
+  exit 2
+}
+
+tmpfile="$(mktemp)" || exit 2
+trap 'rm -f "$tmpfile"' EXIT
+
+# Values travel through the environment rather than `-v`: awk expands escape
+# sequences in a `-v` assignment, so a note containing `\z` would silently lose
+# its backslash. ENVIRON is passed through verbatim.
+SR_LABEL="$LABEL" SR_STATUS="$STATUS_TEXT" SR_NOTE="$NOTE" awk '
+  BEGIN {
+    label = ENVIRON["SR_LABEL"]
+    status_text = ENVIRON["SR_STATUS"]
+    note = ENVIRON["SR_NOTE"]
+    row = "| " label " | " status_text " | " note " |"
+    written = 0
+    last_table_line = 0
+  }
+  # A Progress-table row for this label: `| <label> | … |`. `[|]` is a bracket
+  # expression, so the pipe is literal — the whole point of not using sed here.
+  {
+    is_target = ($0 ~ "^[[:space:]]*[|][[:space:]]*" label "[[:space:]]*[|]")
+    is_table_row = ($0 ~ "^[[:space:]]*[|]")
+  }
+  is_target {
+    # First occurrence becomes the canonical row; any further copies (left behind
+    # by the old sed) are dropped rather than re-emitted.
+    if (!written) { lines[++n] = row; written = 1; last_table_line = n }
+    next
+  }
+  {
+    lines[++n] = $0
+    if (is_table_row) last_table_line = n
+  }
+  END {
+    if (!written) {
+      if (last_table_line > 0) {
+        # Insert after the final table row, keeping the row inside the table.
+        for (i = 1; i <= n; i++) {
+          print lines[i]
+          if (i == last_table_line) print row
+        }
+      } else {
+        # No table in this file — fall back to a standalone field line.
+        for (i = 1; i <= n; i++) print lines[i]
+        print "**" label ":** " (note != "" ? note : status_text)
+      }
+    } else {
+      for (i = 1; i <= n; i++) print lines[i]
+    }
+  }
+' "$STATUS_FILE" >"$tmpfile" || {
+  echo "specclaw-status-row: awk failed; $STATUS_FILE left unchanged" >&2
+  exit 1
+}
+
+# Never truncate the file on a failed rewrite.
+[ -s "$tmpfile" ] || {
+  echo "specclaw-status-row: refusing to write empty result to $STATUS_FILE" >&2
+  exit 1
+}
+
+cat "$tmpfile" >"$STATUS_FILE"

--- a/plugins/specclaw/tests/run-status-row-tests.sh
+++ b/plugins/specclaw/tests/run-status-row-tests.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# run-status-row-tests.sh — regression suite for the status.md Progress-table row
+# writer (bin/specclaw-status-row) and the two sed defects it replaces.
+#
+# The defects, both reproduced against the shipped templates/status.md:
+#
+#   D1: `sed -i "/^\|[[:space:]]*Verify[[:space:]]*\|/a| PR | … |"` — in a sed BRE
+#       address `\|` is *alternation*, so the empty branch matched every line and
+#       the PR row was appended after all 33 of them.
+#   D2: `sed -i "s|^\(| *PR *|\).*|\1 ✅ Raised | $url |"` — the s command is
+#       delimited by `|` while its pattern contains literal pipes, so sed refused
+#       it outright: `sed: -e expression #1, char 14: unknown option to 's'`.
+#       Non-zero under `set -euo pipefail` aborted specclaw-pr *after* the PR was
+#       created, freezing every tracker at its pre-PR state.
+#
+# Plain bash + coreutils only. Run from anywhere:
+#   bash plugins/specclaw/tests/run-status-row-tests.sh
+# Exits non-zero if any case fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/../bin" && pwd)"
+TEMPLATE="$(cd "$SCRIPT_DIR/.." && pwd)/templates/status.md"
+
+STATUS_ROW="$BIN_DIR/specclaw-status-row"
+PR_SCRIPT="$BIN_DIR/specclaw-pr"
+AZDO_PR_SCRIPT="$BIN_DIR/specclaw-azdo-pr"
+
+for f in "$STATUS_ROW" "$TEMPLATE"; do
+  if [[ ! -f "$f" ]]; then
+    echo "FATAL: missing file: $f" >&2
+    exit 2
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label (= '$actual')"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+URL="https://github.com/chan4lk/specclaw/pull/417"
+
+# A status.md in the shipped template's shape, with the placeholders filled the
+# way propose/verify leave them.
+make_status() {
+  local dest="$1"
+  cat > "$dest" <<'EOF'
+# Status: Multiple Owners per Objective
+
+**Change:** objective-multi-owner
+**Started:** 2026-07-30
+**Last Updated:** 2026-07-30
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | ✅ Approved | Operator resolved Q1/Q2/Q4 |
+| Spec | ✅ Done | 14 FRs, 10 ACs |
+| Design | ✅ Done | Shared permission service |
+| Tasks | ✅ Done | 11 tasks / 4 waves |
+| Build | ✅ Done | 11/11 tasks |
+| Verify | ✅ Passed | All 10 ACs |
+
+## Task Progress
+
+**Completed:** 11 / 11
+**Failed:** 0
+
+## Issues
+
+_None._
+EOF
+}
+
+# ─── T1: the D1 regression — one PR row, not one per line ─────────────────────
+S="$WORK/t1.md"
+make_status "$S"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+assert_eq "T1a insert adds exactly one PR row" "1" "$(grep -c '^| PR |' "$S")"
+assert_eq "T1b no stray rows outside the table" "0" \
+  "$(grep -c '^| PR |' <<<"$(sed -n '1,9p' "$S")")"
+
+# The old sed appended after *every* line of the file, header included.
+assert_eq "T1c header line untouched" "# Status: Multiple Owners per Objective" \
+  "$(head -1 "$S")"
+
+# ─── T2: the row lands inside the Progress table, after the last row ──────────
+S="$WORK/t2.md"
+make_status "$S"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+assert_eq "T2a PR row follows the Verify row" "| Verify | ✅ Passed | All 10 ACs |" \
+  "$(grep -B1 '^| PR |' "$S" | head -1)"
+assert_eq "T2b PR row carries the URL" "| PR | ✅ Raised | $URL |" \
+  "$(grep '^| PR |' "$S")"
+
+# ─── T3: the D2 regression — updating an existing row must not error ──────────
+S="$WORK/t3.md"
+make_status "$S"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+NEW_URL="https://github.com/chan4lk/specclaw/pull/999"
+if "$STATUS_ROW" "$S" "PR" "✅ Merged" "$NEW_URL" >/dev/null 2>"$WORK/t3.err"; then
+  pass "T3a second write exits 0 (old sed exited 1 and killed specclaw-pr)"
+else
+  fail "T3a second write failed: $(cat "$WORK/t3.err")"
+fi
+assert_eq "T3b row replaced, not duplicated" "1" "$(grep -c '^| PR |' "$S")"
+assert_eq "T3c row shows the new value" "| PR | ✅ Merged | $NEW_URL |" \
+  "$(grep '^| PR |' "$S")"
+assert_eq "T3d no sed error text leaked" "0" \
+  "$(awk '/unknown option to/ { c++ } END { print c + 0 }' "$WORK/t3.err")"
+
+# ─── T4: idempotence — same values twice is a byte-identical file ─────────────
+S="$WORK/t4.md"
+make_status "$S"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+cp "$S" "$WORK/t4.snapshot"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+if cmp -s "$S" "$WORK/t4.snapshot"; then
+  pass "T4 re-running with identical values changes nothing"
+else
+  fail "T4 re-run mutated the file: $(diff "$WORK/t4.snapshot" "$S" | head -5)"
+fi
+
+# ─── T5: self-heal a file already corrupted by the D1 sed ─────────────────────
+# 33 duplicate rows is what the stock template produced; collapse them to one.
+S="$WORK/t5.md"
+make_status "$S"
+{
+  for _ in $(seq 1 33); do echo "| PR | ✅ Raised | $URL |"; done
+} >> "$S"
+assert_eq "T5a fixture starts corrupted" "33" "$(grep -c '^| PR |' "$S")"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+assert_eq "T5b duplicates collapsed to one row" "1" "$(grep -c '^| PR |' "$S")"
+
+# ─── T6: other rows are never touched ────────────────────────────────────────
+S="$WORK/t6.md"
+make_status "$S"
+BEFORE="$(grep -c '^| ' "$S")"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+assert_eq "T6a exactly one row added" "$((BEFORE + 1))" "$(grep -c '^| ' "$S")"
+assert_eq "T6b Build row intact" "| Build | ✅ Done | 11/11 tasks |" \
+  "$(grep '^| Build |' "$S")"
+assert_eq "T6c Verify row intact" "| Verify | ✅ Passed | All 10 ACs |" \
+  "$(grep '^| Verify |' "$S")"
+
+# ─── T7: a file with no Progress table falls back to a field line ────────────
+S="$WORK/t7.md"
+printf '# Status: bare\n\n**Change:** bare\n' > "$S"
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$URL" >/dev/null
+assert_eq "T7 falls back to a **PR:** line" "**PR:** $URL" "$(grep '^\*\*PR:\*\*' "$S")"
+
+# ─── T8: notes containing regex/sed metacharacters survive ───────────────────
+S="$WORK/t8.md"
+make_status "$S"
+ODD='https://ex.com/p/1?a=b&c=[x]|y\z'
+"$STATUS_ROW" "$S" "PR" "✅ Raised" "$ODD" >/dev/null
+assert_eq "T8a metacharacter note stored verbatim" "| PR | ✅ Raised | $ODD |" \
+  "$(grep '^| PR |' "$S")"
+assert_eq "T8b still exactly one PR row" "1" "$(grep -c '^| PR |' "$S")"
+
+# ─── T9: the file is never truncated on a bad invocation ─────────────────────
+S="$WORK/t9.md"
+make_status "$S"
+BYTES_BEFORE="$(wc -c < "$S")"
+"$STATUS_ROW" "$WORK/does-not-exist.md" "PR" "✅ Raised" "$URL" >/dev/null 2>&1
+RC=$?
+assert_eq "T9a missing file exits 2" "2" "$RC"
+assert_eq "T9b unrelated file untouched" "$BYTES_BEFORE" "$(wc -c < "$S")"
+
+# ─── T10: the broken sed forms are gone from both PR scripts ─────────────────
+# Guards against a re-introduction: `\|` in a sed address, or an `s|` whose
+# pattern contains a literal pipe.
+for script in "$PR_SCRIPT" "$AZDO_PR_SCRIPT"; do
+  name="$(basename "$script")"
+  [[ -f "$script" ]] || { fail "T10 $name missing"; continue; }
+  if grep -qE 'sed_i "/\^\\\|' "$script"; then
+    fail "T10 $name still has a sed address starting with \\| (D1)"
+  else
+    pass "T10 $name has no \\|-addressed sed (D1 fixed)"
+  fi
+  if grep -qE 'sed_i "s\|\^\\\(\|' "$script"; then
+    fail "T10 $name still has the s| pattern with literal pipes (D2)"
+  else
+    pass "T10 $name has no pipe-delimited s| over table rows (D2 fixed)"
+  fi
+done
+
+# ─── T11: post-PR bookkeeping cannot abort the script ────────────────────────
+# save_pr_url runs after `gh pr create` / the ADO POST; an unguarded non-zero
+# there aborts under `set -e` and freezes the trackers while the PR is already live.
+for script in "$PR_SCRIPT" "$AZDO_PR_SCRIPT"; do
+  name="$(basename "$script")"
+  [[ -f "$script" ]] || continue
+  if grep -qE '^[[:space:]]*save_pr_url "\$pr_url"[[:space:]]*$' "$script"; then
+    fail "T11 $name calls save_pr_url unguarded (an abort here freezes trackers)"
+  else
+    pass "T11 $name guards the save_pr_url call"
+  fi
+done
+
+echo
+echo "─────────────────────────────"
+echo "PASS: $PASS   FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Why

A change with an open PR kept rendering as **still building**. Real example — `keyflow/.specclaw/changes/objective-multi-owner/status.md`, with PR #417 open since 2026-07-30:

```
| Build  | ✅ Done    | 11/11 tasks, `bun run build` passing |
| Verify | ⬜ Pending | —                                     |
```

No PR row at all, `Last Updated: 2026-07-30`. Two defects in `save_pr_url`, both **reproduced** against the shipped `templates/status.md`.

### Defect 1 — the insert `sed` matched every line

```bash
sed_i "/^\|[[:space:]]*Verify[[:space:]]*\|/a\| PR | ✅ Raised | $url |"
```

`sed` uses BRE, where GNU `\|` is **alternation**, not a literal pipe. The address reads `^` OR `[[:space:]]*Verify[[:space:]]*` OR `` — and the empty branch matches everything:

```
$ sed -i "/^\|[[:space:]]*Verify[[:space:]]*\|/a\| PR ... |" status.md
$ grep -c 'Raised' status.md
33
```

33 PR rows, one after every line, inside the header too. The `grep -qE '^\|…'` guard directly above it looks like the same pattern but is **ERE**, where `\|` *is* literal — one string, two meanings.

### Defect 2 — the update `sed` was invalid syntax

```bash
sed_i "s|^\(| *PR *|\).*|\1 ✅ Raised | $url |"
```

The `s` command is delimited by `|` while its own pattern contains literal pipes:

```
sed: -e expression #1, char 14: unknown option to `s'
```

`specclaw-pr` runs `set -euo pipefail` (line 5) and called `save_pr_url` **unguarded** right after `gh pr create`. So that non-zero **aborted the script after the PR already existed**, skipping `specclaw-update-context`, the `STATUS.md` regeneration, and the issue sync. The PR URL was still printed — which is why this failed silently for so long.

## What changed

- **`bin/specclaw-status-row`** (new) — upserts one Progress-table row in `awk`, matching with a bracket expression (`[|]`, unambiguously literal) and rewriting the file instead of patching it in place. The pipe-delimited table is simply the wrong shape for `sed`; this removes the whole class of bug rather than patching two instances.
- **Self-heals** files already corrupted by defect 1 — duplicate rows collapse to one.
- Values reach `awk` through the **environment, not `-v`** — `-v` expands escape sequences and silently ate a backslash in a note (caught by T8).
- **Post-`gh pr create` bookkeeping now warns instead of aborting.** The PR is live on the remote; losing a tracker update is not grounds for exiting non-zero.
- **`specclaw-azdo-pr`** gets the same row upsert. Its old unconditional append also stacked a duplicate `**ADO PR:**` line on every run.

## Tests

`tests/run-status-row-tests.sh` — 26 assertions, all passing:

| | Covers |
|---|---|
| T1, T5 | the 33-row regression, and self-heal of an already-corrupted file |
| T3 | the invalid-`s`-command regression — second write exits 0 |
| T4 | idempotence — same values twice is byte-identical |
| T8 | notes containing `[`, `\|`, `\` survive verbatim |
| T9 | the file is never truncated on a bad invocation |
| T10, T11 | greps that **fail** if either `sed` form or the unguarded call site returns |

Registered in `ci.yml` — an unregistered suite silently never runs, which has happened twice in this repo.

Other suites: memory-parallelism 16/16, long-orchestration 272/272, synth-agent 10/10, shellcheck-gate 22/22. `run-parser-tests` reports 11 failures **locally only** — `jq` is not installed on this box and that suite shells out to it; CI installs `jq` first.

Version bumped 0.6.1 → 0.6.2.

## Follow-up

This is the hotfix half. The structural fix — no phase source of truth at all, `STATUS.md` inferring state from `tasks.md` checkbox counts, `GOALS.md` having zero writers — is proposed separately as `tracker-state-integrity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)