### PR TITLE
specclaw: one writer for phase state, plus a drift detector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: bash plugins/specclaw/tests/run-shellcheck-gate-tests.sh
       - name: Run status-row tests
         run: bash plugins/specclaw/tests/run-status-row-tests.sh
+      - name: Run phase-state tests
+        run: bash plugins/specclaw/tests/run-phase-state-tests.sh
 
   shellcheck:
     name: ShellCheck bin scripts

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,12 +1,13 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-07-25 09:30 UTC
+**Last Updated:** 2026-08-01 13:21 UTC
 
 ## Active Changes
 
 
 - 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed | PR #46 merged
+- 🔍 **tracker-state-integrity** — verify PARTIAL | 7/7 tasks (100%) | 0 failed
 
 ## Pending Proposals
 
@@ -44,6 +45,6 @@ _None._
 
 ## Stats
 
-- **Total changes:** 27
-- **Active:** 1
+- **Total changes:** 28
+- **Active:** 2
 - **Completed:** 26

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,13 +1,13 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-08-01 13:21 UTC
+**Last Updated:** 2026-08-01 13:22 UTC
 
 ## Active Changes
 
 
 - 🔨 **memory-aware-parallelism** — 5/6 tasks (83%) | 0 failed | PR #46 merged
-- 🔍 **tracker-state-integrity** — verify PARTIAL | 7/7 tasks (100%) | 0 failed
+- 🔀 **tracker-state-integrity** — pr raised | 7/7 tasks (100%) | 0 failed | PR #57 open
 
 ## Pending Proposals
 

--- a/.specclaw/STATUS.md
+++ b/.specclaw/STATUS.md
@@ -1,7 +1,7 @@
 # 🦞 SpecClaw Dashboard
 
 **Project:** specclaw
-**Last Updated:** 2026-08-01 13:22 UTC
+**Last Updated:** 2026-08-01 13:38 UTC
 
 ## Active Changes
 
@@ -11,7 +11,9 @@
 
 ## Pending Proposals
 
-_None._
+
+- 📋 **phase-time-accounting** — proposal ready, awaiting planning
+- 📋 **staged-files-auditor** — proposal ready, awaiting planning
 
 ## Recently Completed
 

--- a/.specclaw/changes/tracker-state-integrity/design.md
+++ b/.specclaw/changes/tracker-state-integrity/design.md
@@ -1,0 +1,130 @@
+# Design: Tracker state integrity
+
+**Change:** tracker-state-integrity
+**Created:** 2026-08-01
+**Spec:** `.specclaw/changes/tracker-state-integrity/spec.md`
+
+## Technical Approach
+
+Two layers, one writer:
+
+```
+                    specclaw-set-phase          ← the only writer
+                     /                \
+            state.json                 specclaw-status-row → status.md
+         (machine truth)                    (human artifact, row upsert)
+                    \
+                     └── read by ── specclaw-update-status → STATUS.md
+                                    specclaw-reconcile     → drift report
+```
+
+The proposal called for `status.md` to be **re-rendered wholesale** from template + state. This
+design does not. PR #52 shipped `bin/specclaw-status-row`, an idempotent awk upsert that replaces a
+row in place, collapses duplicates, and leaves the rest of the file byte-identical. Re-rendering
+would rewrite lines that three integration scripts grep for (NFR1), buying format-churn risk for no
+gain. Row upsert reaches the same end state — status.md always agrees with state.json — with a
+strictly smaller blast radius, and it makes the proposal's open question 4 (byte-stability)
+disappear rather than needing enforcement.
+
+`state.json` is written atomically: build the new document in `$(mktemp)`, validate it parses, then
+`mv` over the target. A crash mid-write leaves the old file intact (Edge case 3).
+
+## Architecture
+
+### `state.json` schema
+
+```json
+{
+  "change": "tracker-state-integrity",
+  "phase": "build",
+  "branch": "claude/tracker-state-integrity",
+  "phases": {
+    "proposal": {"status": "approved", "at": "2026-08-01T06:00:00Z"},
+    "spec":     {"status": "done",     "at": "2026-08-01T06:40:00Z"},
+    "build":    {"status": "done",     "at": "...", "tasks": {"done": 7, "total": 7, "failed": 0}},
+    "verify":   {"status": "passed",   "at": "...", "verdict": "PASS"},
+    "pr":       {"status": "raised",   "at": "...", "url": "https://…/57", "state": "open"}
+  }
+}
+```
+
+Phase order, used for the monotonicity check (FR3):
+`proposal < spec < design < tasks < build < verify < pr < archived`.
+Rank comparison only — a transition to a *lower* rank than `phase` is rejected without `--force`;
+equal rank is always allowed (re-verify, Edge case 10).
+
+### Phase → `status.md` row mapping
+
+`set-phase` translates each transition into one `specclaw-status-row <file> <label> <text> [note]`
+call. Labels match the existing template rows (`Proposal`, `Spec`, `Design`, `Tasks`, `Build`,
+`Verify`) plus `PR`, which `specclaw-status-row` inserts after the last table row when absent.
+
+### Reading state without a hard `jq` dependency
+
+Reads go through one helper, `state_field <file> <jq_path>`, which uses `jq` when present and a
+minimal `python3 -c` fallback otherwise. Both are already CI dependencies (`ci.yml` installs `jq`;
+the manifest job uses `python3`). Any read failure returns empty → callers take the FR7 fallback
+path.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `plugins/specclaw/bin/specclaw-set-phase` | **new** — the sole phase writer: validate args, read/merge state, atomic write, delegate row upsert |
+| `plugins/specclaw/bin/specclaw-reconcile` | **new** — drift report + `--fix` |
+| `plugins/specclaw/bin/specclaw-update-status` | read `state.json` for phase and branch; keep the checkbox inference as fallback (FR6, FR7) |
+| `plugins/specclaw/bin/specclaw-build` | record `branch` and build completion via `set-phase` (FR4) |
+| `plugins/specclaw/bin/specclaw-verify` | replace the hand-rolled Verify-row rewrite (`:570-610`) with `set-phase … verify` |
+| `plugins/specclaw/bin/specclaw-pr` | `save_pr_url` → `set-phase … pr raised --url`, fail-soft (FR9) |
+| `plugins/specclaw/bin/specclaw-azdo-pr` | same treatment as `specclaw-pr` |
+| `plugins/specclaw/skills/{propose,plan,build,verify,archive}/SKILL.md` | call `set-phase` at each transition instead of instructing the model to edit prose (FR5) |
+| `plugins/specclaw/tests/run-phase-state-tests.sh` | **new** — suite for set-phase, fallback rendering, reconcile |
+| `.github/workflows/ci.yml` | register the new suite |
+| `plugins/specclaw/tests/shellcheck-baseline.txt` | only if a pre-existing finding moves line numbers — no new findings permitted |
+
+## Key Decisions
+
+1. **Row upsert over wholesale re-render.** See Technical Approach. Smaller diff, no format churn,
+   reuses a helper that already has 26 assertions behind it.
+2. **Monotonic, not strict, transitions.** Strict ordering would reject legitimate re-verify loops.
+   Rank comparison with `--force` catches the actual bug class (silent regression) at a fraction of
+   the friction.
+3. **Fail-open everywhere.** Every read of `state.json` degrades to current behaviour on any error.
+   A tracker bug must never become a lifecycle blocker — that would trade a cosmetic failure for a
+   functional one.
+4. **`branch` recorded, never computed.** The `${branch_prefix}${change}` guess is wrong in this very
+   repo (`config.yaml` says `specclaw/`, `CLAUDE.md` mandates `claude/<short-task>`). Recording it
+   at build time is a one-line fix to a whole class of silent misses.
+5. **GOALS.md cut.** Two writers, the other one external and untestable here. Shipping a
+   half-understood second writer to an untracked file is how the drift got here.
+6. **Depends on PR #52.** Branch from `claude/fix-status-row-sed`, or wait for it to merge.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Format churn breaks `gh-sync` / `jira-issue` / `azdo-issue` greps | Row upsert never touches other lines; AC4 asserts the `GitHub Issue` line survives a PR transition |
+| `state.json` and `status.md` diverge | One writer, both written in the same call; `reconcile` detects any divergence that still happens |
+| Regression in `STATUS.md` for changes without state | AC6 pins byte-identical output against the current implementation |
+| `--fix` regressing correct state from a network miss | `unknown` is never actionable; AC10 |
+| #52 not merging | Whole design rests on `specclaw-status-row`; re-cut the plan if that happens |
+
+## Grounding sources
+
+`specclaw-discover-context` is unavailable in this install (the cached binary is not executable:
+`Permission denied`), and no `.specclaw/context.md` or `.specclaw/knowledge/` exists. Grounding is
+therefore direct source reading:
+
+- **`CLAUDE.md`** — "Always bump the plugin version before opening a PR." Both
+  `plugins/specclaw/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` must move
+  together; the CI `json` job enforces the match.
+- **`CLAUDE.md`** — branch naming: "`claude/<short-task>` or `<operator-handle>/<topic>`", which is
+  the concrete conflict with `git.branch_prefix: specclaw/` behind Key Decision 4.
+- **`plugins/specclaw/bin/specclaw-status-row`** (PR #52) — "Idempotent: re-running with the same
+  values leaves the file byte-identical." The guarantee Key Decision 1 rests on.
+- **`plugins/specclaw/tests/run-status-row-tests.sh`** (PR #52) — "Plain bash + coreutils only",
+  `pass`/`fail` counters, `mktemp -d` workdir. The house test style (NFR4).
+- **`.github/workflows/ci.yml`** — suites are registered as explicit named steps under the
+  "Parser regression suite" job; a new suite is invisible to CI until added there.
+- **`plugins/specclaw/bin/specclaw-verify:541-557`** — the existing self-heal-from-template pattern
+  `set-phase` reuses for Edge case 4.

--- a/.specclaw/changes/tracker-state-integrity/proposal.md
+++ b/.specclaw/changes/tracker-state-integrity/proposal.md
@@ -1,0 +1,212 @@
+# Proposal: Tracker state integrity — one writer, one source of truth for phase
+
+**Created:** 2026-08-01
+**Status:** 🟡 Draft
+
+## Problem
+
+Tracker files lie. A change with an open PR still renders as *Build* — the operator reported it, and
+the cause is not one oversight but **four independent defects**, two of them reproduced below.
+
+### Evidence in the wild
+
+`keyflow/.specclaw/changes/objective-multi-owner/status.md`, with PR #417 open since 2026-07-30:
+
+```
+| Build  | ✅ Done    | 11/11 tasks, `bun run build` passing |
+| Verify | ⬜ Pending | —                                     |
+```
+
+No PR row at all. `**Last Updated:** 2026-07-30 11:39 UTC`. The file's last honest statement is that
+build finished — exactly the "stuck at build" the operator sees.
+
+### Defect 1 — the PR-row insert `sed` matches *every line* (reproduced)
+
+`bin/specclaw-pr:470` (and the twin at `bin/specclaw-azdo-pr`):
+
+```bash
+sed_i "/^\|[[:space:]]*Verify[[:space:]]*\|/a\| PR     | ✅ Raised | $url |" "$status_file"
+```
+
+`sed` uses BRE, where GNU `\|` is **alternation**, not a literal pipe. So the address reads
+`^` OR `[[:space:]]*Verify[[:space:]]*` OR `` — and the empty alternative matches every line.
+Run against the real `templates/status.md`:
+
+```
+$ sed -i "/^\|[[:space:]]*Verify[[:space:]]*\|/a\| PR ... |" status.md
+$ grep -c 'Raised' status.md
+33
+```
+
+33 PR rows, one after every line in the file, including inside the header. The guard `grep -qE '^\|…'`
+above it is correct only because **ERE** treats `\|` as a literal — the same string means two different
+things in the test and in the edit.
+
+### Defect 2 — the PR-row update `sed` is syntactically invalid (reproduced)
+
+`bin/specclaw-pr:467`, taken on every subsequent run once a `| PR |` row exists:
+
+```bash
+sed_i "s|^\(| *PR *|\).*|\1 ✅ Raised | $url |" "$status_file"
+```
+
+The `s` command is delimited by `|`, and the pattern itself contains literal `|` characters. Result:
+
+```
+sed: -e expression #1, char 14: unknown option to `s'
+```
+
+`specclaw-pr` runs under `set -euo pipefail` (line 5) and `save_pr_url` is called **unguarded** at
+line 655, immediately after `gh pr create`. So a non-zero `sed` **aborts the whole script after the PR
+already exists**, skipping everything downstream: `specclaw-update-context`, the `STATUS.md`
+regeneration, and the issue-sync step. The PR is real; every tracker is frozen at its pre-PR state.
+This is the mechanism that makes the failure *silent* — the PR URL gets posted, so it looks like it worked.
+
+### Defect 3 — no source of truth for "phase"; the dashboard infers it from checkboxes
+
+`bin/specclaw-update-status:104-121` derives a change's entire rendered state from `tasks.md` marker
+counts:
+
+```bash
+status_emoji="🔨"
+[ "$failed" -gt 0 ] && status_emoji="⚠️"
+[ "$done" -eq "$total" ] && [ "$total" -gt 0 ] && status_emoji="✅"
+```
+
+There is no phase concept anywhere in the pipeline — no `state.json`, no `current_phase` field
+(grep confirms neither exists). "Verified", "PR raised", and "build finished" are indistinguishable;
+🔨 is what a fully-built, PR-open change renders as. `pr_state_for()` partly compensates by querying
+`gh pr list --head "${branch_prefix}${change}"`, but that is a *network guess* about local state, and it
+silently yields nothing whenever the branch name doesn't match `git.branch_prefix` — this repo's config
+says `specclaw/` while `CLAUDE.md` mandates `claude/<short-task>` branches, so the lookup misses here by
+construction.
+
+Meanwhile the per-change `status.md` phase rows are written by **three different mechanisms with no
+shared contract**: Proposal by skill prose (`skills/propose/SKILL.md:16`), Verify by script
+(`bin/specclaw-verify:570-585`), PR by the two broken `sed` calls — and the **Build row by nothing at
+all** except an instruction to a model (`skills/build/SKILL.md:100`). Every hand-maintained row drifts.
+
+### Defect 4 — `GOALS.md` has no writer
+
+`grep -rl GOALS plugins/specclaw` returns **zero files**. The `## Proposals` checklist that the
+scheduler and the operator both read is maintained entirely by hand. This is why keyflow needed a
+110-proposal reconciliation audit that archived 104 already-shipped entries — the drift is not
+incidental, it accumulates until someone pays it down manually.
+
+**Common root cause:** phase state is derived, never recorded; and it is edited by regex surgery from
+several call sites instead of rendered from one place.
+
+## Proposed Solution
+
+Record phase state once, in a machine-readable file; render every tracker from it; delete the regex
+surgery.
+
+**1. `state.json` per change — the single source of truth (new).**
+
+`.specclaw/changes/<change>/state.json`:
+
+```json
+{
+  "change": "objective-multi-owner",
+  "phase": "pr",
+  "phases": {
+    "proposal": {"status": "approved", "at": "2026-07-29T..."},
+    "spec":     {"status": "done",     "at": "..."},
+    "build":    {"status": "done",     "at": "...", "tasks": {"done": 11, "total": 11, "failed": 0}},
+    "verify":   {"status": "passed",   "at": "...", "verdict": "PASS"},
+    "pr":       {"status": "raised",   "at": "...", "url": "https://…/417", "state": "open"}
+  },
+  "branch": "claude/objective-multi-owner"
+}
+```
+
+`branch` is **recorded at build time**, so `STATUS.md` never has to guess it from `branch_prefix` —
+this alone fixes the silent PR-lookup miss in Defect 3.
+
+**2. `specclaw-set-phase` — the only writer (new `bin/` script).**
+
+```
+specclaw-set-phase .specclaw <change> <phase> <status> [--note "…"] [--url …] [--verdict …]
+```
+
+Every phase transition goes through it: propose, plan, build (per wave + on completion), verify, pr,
+archive. It updates `state.json`, then **re-renders `status.md` wholesale from the template + state** —
+no in-place `sed`, so Defects 1 and 2 cease to exist as a class rather than being patched. Idempotent
+and monotonic: re-running a transition is a no-op, and a later phase never silently un-sets an earlier one.
+
+**3. Fix the two `sed` bugs immediately, ahead of the refactor.**
+`save_pr_url` becomes a `specclaw-set-phase … pr raised --url` call. Until it lands, the two expressions
+are replaced with a delimiter that doesn't collide and a literal-pipe address (`[|]`, not `\|`) —
+they are shipping corruption today and should not wait for the full design.
+
+Also: **`save_pr_url` must not be able to abort the script after the PR exists.** Anything post-`gh pr
+create` is bookkeeping and must be fail-soft with a loud warning, never `set -e` death.
+
+**4. `STATUS.md` renders phase from `state.json`, not from checkbox counts.**
+Active-changes rows show real phase (`🔀 pr open`, `🔍 verify`, `🔨 build 7/11`), falling back to the
+current inference only when `state.json` is missing — so pre-existing changes keep rendering as they do
+now.
+
+**5. `specclaw-reconcile` — drift detector (new subcommand).**
+Compares `state.json` against observable reality (`tasks.md` markers, `verify-report.md` presence,
+`gh pr view` on the recorded branch, git log) and reports mismatches; `--fix` adopts reality. This is
+the keyflow 110-proposal audit as a script instead of an afternoon.
+
+**6. `GOALS.md` gets a writer.** `specclaw-update-status` also syncs the `## Proposals` checklist:
+ticked when archived, unticked while active, appended when a proposal appears. One owner, no hand edits.
+
+## Scope
+
+### In Scope
+- `state.json` schema + `bin/specclaw-set-phase` as sole writer; `status.md` rendered, never `sed`-patched.
+- Immediate fix for both broken `sed` expressions in `specclaw-pr` and `specclaw-azdo-pr`.
+- Make all post-`gh pr create` bookkeeping fail-soft (no `set -e` abort after the PR exists).
+- Record `branch` in `state.json` at build time; `STATUS.md` uses it instead of `branch_prefix` guessing.
+- Phase transitions wired into propose, plan, build, verify, pr, archive.
+- `STATUS.md` phase-aware rendering with fallback for changes lacking `state.json`.
+- `bin/specclaw-reconcile` (report + `--fix`).
+- `GOALS.md` `## Proposals` sync inside `specclaw-update-status`.
+- Bats coverage: the 33-row regression, the invalid-`s`-command regression, phase monotonicity,
+  reconcile drift cases. Registered in CI; shellcheck-clean.
+
+### Out of Scope
+- Timing/duration fields — that is `phase-time-accounting`. This change owns *which* phase, not *how long*.
+- Enforcing that PRs open only via `specclaw-pr` — that is `staged-files-auditor` (Layer 3). The two are
+  complementary: this one makes the state correct when the script runs; that one makes the script run.
+- Backfilling `state.json` for already-archived changes (`reconcile --fix` can, opportunistically).
+- Replacing `status.md` as a human-readable artifact, or moving to a database.
+- Changing the phase list itself.
+
+## Impact
+
+- **Files affected:** ~12 (estimated) — 2 new `bin/` scripts (`set-phase`, `reconcile`),
+  `specclaw-pr`, `specclaw-azdo-pr`, `specclaw-build`, `specclaw-verify`, `specclaw-update-status`,
+  `specclaw-archive`, 3 SKILL.md updates, `templates/status.md`, 1 new bats suite.
+- **Complexity:** medium — schema and renderer are simple; the work is replacing scattered edits with
+  one writer without breaking the format that `gh-sync`, `azdo-issue`, and `jira-issue` already parse
+  out of `status.md` (they grep it for issue/PR lines — the renderer must keep those lines intact).
+- **Risk:** low-to-medium. The `sed` fixes are strictly corrective — the current behaviour is a proven
+  bug. The refactor's real risk is *format churn* breaking the three integration scripts that grep
+  `status.md`; mitigate by pinning the rendered format in a bats golden file and reading those greps
+  first. Fail-open throughout: a missing or malformed `state.json` must degrade to today's behaviour,
+  never block a phase.
+
+## Open Questions
+
+1. **Ship the two `sed` fixes as a separate hotfix PR first?** They are corrupting `status.md` in every
+   repo running specclaw right now, independent of the rest of this design. Recommend yes.
+2. Is `state.json` **committed** (reviewers see phase in the PR diff, but it churns every transition) or
+   gitignored with `status.md` as the committed rendering?
+3. **How much does `reconcile` trust the network?** `gh pr view` failing offline must read as "unknown",
+   never as "no PR" — the latter would let `--fix` regress a correct state.
+4. Does the rendered `status.md` need to be **byte-stable** for unrelated transitions, to keep PR diffs
+   small? That constrains the renderer (stable ordering, no timestamp churn in untouched rows).
+5. **Should `phase` be strictly ordered** (proposal→…→pr→archived) with illegal transitions rejected, or
+   a free-form label? Strict catches bugs; free-form survives non-linear reality like re-verify after a
+   loop fix.
+6. `GOALS.md` is also written by the mcd bot's `backlogWatch` (it tracks `{done, total}` snapshots per
+   channel). Does specclaw owning the checklist **collide** with that? Needs checking before wiring.
+
+---
+
+**To proceed:** Review this proposal and approve to begin planning.

--- a/.specclaw/changes/tracker-state-integrity/review-report.md
+++ b/.specclaw/changes/tracker-state-integrity/review-report.md
@@ -1,0 +1,110 @@
+# Code Review Report: tracker-state-integrity
+
+**Reviewed:** 2026-08-01
+**Model:** claude-sonnet-4-6
+**Verdict:** APPROVED_WITH_NOTES
+
+## Summary
+
+7 findings: 0 BLOCK, 4 WARN, 3 NOTE
+
+## Findings
+
+### [WARN] plugins/specclaw/bin/specclaw-set-phase:265 — Correctness
+
+**Problem:** The `CHANGE` variable is interpolated directly into a double-quoted `sed` expression without escaping. A change name containing `/` (the sed delimiter), `&` (back-reference), or `\` will corrupt the replacement expression, causing `sed` to error or produce garbled output. The sed call sits after the atomic `mv` of `state.json` (line 255), so `state.json` is already written correctly when this path runs — the failure mode is a partial install where `status.md` is absent and the self-heal fails, leaving only `state.json`. The script catches the `sed` failure with `|| die`, so it fails loudly rather than silently, but the die at line 270 exits 2 after the correct `state.json` is in place.
+
+```bash
+sed -e "s/{{title}}/${CHANGE}/g" \
+    -e "s/{{change_name}}/${CHANGE}/g" \
+    -e "s/{{date}}/${today}/g" \
+    -e "s/{{updated}}/${today}/g" \
+```
+
+Change names are conventionally slugified (lowercase, hyphens only), and the calling SKILL.md files enforce that convention. No input validation in `specclaw-set-phase` itself prevents a name like `foo/bar` from reaching this code path.
+
+**Fix:** Either validate that `CHANGE` matches `^[a-z0-9][a-z0-9-]*$` before the template substitution, or escape `CHANGE` before splicing into the sed pattern (e.g. `"${CHANGE//\//\\/}"` for the slash delimiter, plus `&` and `\` escaping).
+
+---
+
+### [WARN] plugins/specclaw/bin/specclaw-set-phase:40 / plugins/specclaw/bin/specclaw-reconcile:41 — Correctness
+
+**Problem:** Both new scripts use `set -uo pipefail` rather than `set -euo pipefail`. The omission of `-e` is intentional for the fail-open reads, and every critical write path is individually guarded with `|| die`. However, two specific spots can silently swallow failures without `-e`:
+
+1. `AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"` (set-phase line 217) — if `date` fails, `AT` is set to the empty string and `build_record` emits `"at":""` into the JSON. Under `-e` this would abort; without it, a corrupt timestamp is silently written.
+
+2. `BUILD_RANK="$(phase_rank build)"` (reconcile line 166) — if `phase_rank` returns non-zero (impossible today since `build` is in `PHASE_ORDER`, but fragile to future edits), `BUILD_RANK` is empty and every subsequent `-le "$BUILD_RANK"` comparison produces an arithmetic error that is silenced.
+
+**Fix:** For item 1: add `|| die "date command failed"` after the `date` assignment. For item 2: the current code is safe as written, but adding `|| die "internal: build not in PHASE_ORDER"` makes the invariant explicit.
+
+---
+
+### [WARN] plugins/specclaw/tests/run-phase-state-tests.sh — Test quality
+
+**Problem:** Acceptance criteria AC5 (a `pr`-phase change renders in `STATUS.md` without a network call), AC6 (a change without `state.json` renders byte-identically to the current implementation), and AC7 (corrupt `state.json` degrades gracefully in the renderer) are all specified in the spec and listed in the task notes but have no assertions in `run-phase-state-tests.sh`. They exercise `specclaw-update-status`, which the suite never invokes. The spec's own acceptance criteria list them without qualification. A reviewer inspecting CI green cannot confirm those three acceptance criteria are met.
+
+**Fix:** Add a section in the suite that invokes `specclaw-update-status` against a synthetic `.specclaw/` tree, capturing its stdout output, and asserts:
+- AC5: a change with `state.json` recording `phase:pr` renders as `🔀` without consulting `gh` (use the `SPECCLAW_STATUS_NO_PR=1` env var or the `NOGH` shim).
+- AC6: a change with no `state.json` produces the same output as a run from scratch (byte-identical `cmp`).
+- AC7: a change with a truncated `state.json` renders via fallback, exits 0, and writes a warning to stderr.
+
+---
+
+### [WARN] plugins/specclaw/bin/specclaw-reconcile:113-117 — Complexity
+
+**Problem:** `state_field` is copy-pasted verbatim in three files (`specclaw-set-phase`, `specclaw-reconcile`, `specclaw-update-status`). The comment at reconcile line 113 acknowledges this explicitly ("Third copy of the reader…kept byte-identical on purpose") and the rationale is sound (no shared-sourcing convention). The `diff` between set-phase and the other two confirms the copies differ only in two comment lines (the `ensure_ascii=False` explanation). The risk is drift: a bug fix or feature change (e.g. supporting integer JSON values that today return `json.dumps` output) must be applied to all three by hand with no mechanical check that they stayed in sync.
+
+**Fix:** No change required given the design constraint (standalone executables, no sourcing). The risk is noted; the comment at reconcile:113 documents the rule. A future change adding a `lib/specclaw-state-reader.sh` source-once helper could fix this properly but would be YAGNI for now.
+
+---
+
+### [NOTE] plugins/specclaw/bin/specclaw-reconcile:599 — Correctness
+
+**Problem:** The guard `[ "$ONLY_CHANGE" = "archive" ] && die "'archive' is not a change"` catches the exact string `archive`, but a caller passing `archive/2026-07-01-old` would reach `[ -d "${CHANGES_DIR}/${ONLY_CHANGE}" ]` and succeed — `$CHANGES_DIR/archive/2026-07-01-old` exists. `reconcile_one` would then run on an archived change, contra edge case 7. This is a path-traversal via the positional argument.
+
+```bash
+[ "$ONLY_CHANGE" = "archive" ] && die "'archive' is not a change"
+[ -d "${CHANGES_DIR}/${ONLY_CHANGE}" ] || die "no such change: ${ONLY_CHANGE}"
+reconcile_one "${CHANGES_DIR}/${ONLY_CHANGE}"
+```
+
+In practice `ONLY_CHANGE` is operator-supplied, and the reconcile of an archived change is harmless (it would report `no drift`). The test suite only tests `"archive"` and a non-existent name.
+
+**Suggestion:** Add `[[ "$ONLY_CHANGE" == */* ]] && die "change name must not contain '/': ${ONLY_CHANGE}"` before the directory check, or broaden the archive guard to `[[ "$ONLY_CHANGE" == archive || "$ONLY_CHANGE" == archive/* ]] && die "…"`.
+
+---
+
+### [NOTE] plugins/specclaw/bin/specclaw-reconcile:283-289 — YAGNI / Simplicity
+
+**Problem:** The `DRIFTS` and `UNKNOWNS` bash arrays are declared at global scope and reset at the top of `reconcile_one` on every call. The `drift()` and `unknown()` appenders are two-line functions used only inside `reconcile_one`. Because the arrays are reset on entry, this is correct but requires the reader to mentally track the reset-at-top convention to be sure findings from one change do not bleed into the next.
+
+```bash
+DRIFTS=()
+UNKNOWNS=()
+drift() {
+  DRIFTS+=("$1|$2")
+}
+unknown() {
+  UNKNOWNS+=("$1|$2")
+}
+```
+
+**Suggestion:** Declare `local DRIFTS=() UNKNOWNS=()` inside `reconcile_one` and move `drift()`/`unknown()` there as local functions (bash 4+ supports local functions). This eliminates the reset-convention dependency and makes the scope obvious. Minor; the current form is correct.
+
+---
+
+### [NOTE] plugins/specclaw/bin/specclaw-set-phase:40 — Naming
+
+**Problem:** The script header says `set -uo pipefail` but the pattern in every other script in `bin/` (including `specclaw-update-status`, `specclaw-build`, `specclaw-verify`, `specclaw-pr`) is `set -euo pipefail`. A reader landing on this file for the first time has to re-read the comment at the top or audit the `|| die` chains to understand the omission is deliberate rather than a mistake.
+
+**Suggestion:** Add a one-line comment immediately after `set -uo pipefail` explaining why `-e` is absent:
+
+```bash
+set -uo pipefail
+# -e is intentionally absent: reads are fail-open (state_field always returns 0);
+# every write that must not fail is individually guarded with || die.
+```
+
+## Verdict Rationale
+
+The change achieves its core goal cleanly: `specclaw-set-phase` is verifiably the sole writer of `state.json`, the `--fix` path in `specclaw-reconcile` correctly distinguishes a failing `gh` call (`unknown`) from a successful empty result (`none`) and refuses to downgrade recorded state on an unobservable dimension, and the fail-soft wiring in both PR scripts meets FR9. The 172-assertion test suite is substantive and non-tautological — the shim-PATH technique for testing the jq-less fallback path and the `gh`-absent/`gh`-failing/`gh`-succeeding trinity are thorough. No security issues, no single-writer violations, and no logic errors were found. Four WARN findings remain: an unescaped variable in a `sed` pattern that fails loudly in a narrow edge case, the implicit `date`-failure silent empty-timestamp risk from omitting `-e`, missing test coverage for AC5/AC6/AC7 against `specclaw-update-status`, and the copy-pasted `state_field` with no mechanical sync check. None of these are blockers; all are improvements to correctness or future maintainability.

--- a/.specclaw/changes/tracker-state-integrity/spec.md
+++ b/.specclaw/changes/tracker-state-integrity/spec.md
@@ -1,0 +1,158 @@
+# Spec: Tracker state integrity — one writer, one source of truth for phase
+
+**Change:** tracker-state-integrity
+**Created:** 2026-08-01
+**Status:** 🟡 Draft
+**Proposal:** `.specclaw/changes/tracker-state-integrity/proposal.md` · GitHub Issue #56
+
+## Summary
+
+Phase state is currently *derived* (from `tasks.md` checkbox counts and a network `gh pr list`
+guess) and *edited from several call sites* rather than recorded once. The result is trackers that
+lie: a change with an open PR renders as 🔨 build.
+
+This change records phase in a machine-readable `state.json` per change, makes
+`bin/specclaw-set-phase` the only writer, and has every renderer read from it — with a fallback to
+today's inference so pre-existing changes keep working.
+
+## Assumptions & resolved open questions
+
+The proposal left six open questions. Resolved as follows; each is a decision this spec commits to,
+not a guess left to the builder.
+
+| # | Question | Resolution | Evidence |
+|---|----------|------------|----------|
+| 1 | Ship the two `sed` fixes as a separate hotfix first? | **Already done.** PR #52 landed `bin/specclaw-status-row` (idempotent awk row upsert, self-heals duplicated rows) and rewired `specclaw-pr` / `specclaw-azdo-pr` to it. Defects 1 and 2 are **out of scope here**. This change branches off #52. | `git show origin/claude/fix-status-row-sed:plugins/specclaw/bin/specclaw-status-row` |
+| 2 | Is `state.json` committed or gitignored? | **Committed.** Everything under `.specclaw/` is tracked; `.gitignore` excludes only `.specclaw/.env` (line 6) and `.specclaw/.update-check` (line 8). A gitignored state file would also be invisible to CI and to reviewers. | `.gitignore:6,8` |
+| 3 | How much does `reconcile` trust the network? | A failed or unavailable `gh` call yields **`unknown`**, never `no PR`. `--fix` refuses to act on `unknown` and exits reporting what it skipped. | Proposal Q3 — a network miss must never let `--fix` regress correct state |
+| 4 | Must the rendered `status.md` be byte-stable? | **Moot, by design.** Because `specclaw-set-phase` upserts a single row via `specclaw-status-row` rather than re-rendering the file from the template, untouched rows are never rewritten. Byte-stability is a property of the approach, not a constraint to enforce. | `specclaw-status-row` header comment: "Idempotent: re-running with the same values leaves the file byte-identical." |
+| 5 | Strictly ordered phases, or free-form? | **Monotonic, not strict.** A phase may be re-entered (re-verify after a loop fix is normal), but a *backward* transition — `pr` → `build` — is rejected unless `--force` is passed. Catches the bug class without breaking non-linear reality. | Proposal Q5 |
+| 6 | Does specclaw owning `GOALS.md` collide with the mcd bot? | **Yes — so Defect 4 is cut from this change.** `GOALS.md` is untracked (`git ls-files GOALS.md` → 0) and carries a `## Scheduling` block with the bot's own `Last updated` timestamp, i.e. an active external writer whose behaviour cannot be tested from this repo. Deferred to its own change. | `GOALS.md:3-7`; `git ls-files GOALS.md` |
+
+Further assumption: **`specclaw-status-row` exists.** Every design decision below depends on PR #52
+being merged first. If #52 is abandoned, this plan must be re-cut.
+
+## Functional Requirements
+
+**FR1 — `state.json` is the recorded phase.**
+Each change may have `.specclaw/changes/<change>/state.json` holding `change`, `phase` (the current
+phase), a `phases` map of per-phase `{status, at}` records, and `branch`. It is valid JSON, written
+atomically (temp file + move), and never partially written.
+
+**FR2 — `specclaw-set-phase` is the only writer.**
+`specclaw-set-phase <specclaw_dir> <change> <phase> <status> [--note S] [--url U] [--verdict V]
+[--branch B] [--tasks done/total/failed] [--force]` updates `state.json` and then upserts the
+matching human row in `status.md` by delegating to `specclaw-status-row`. No other script writes
+phase rows by regex.
+
+**FR3 — Transitions are idempotent and monotonic.**
+Re-running the same transition leaves both files byte-identical and exits 0. A transition to an
+earlier phase than the recorded one is rejected with a non-zero exit and a clear message, unless
+`--force` is given. Re-entering the *current* phase (verify → verify) is always allowed.
+
+**FR4 — The branch is recorded at build time.**
+`specclaw-build` records the real branch name into `state.json`. Renderers use it instead of
+computing `${branch_prefix}${change}` — the guess that silently misses whenever branch naming
+diverges from `git.branch_prefix`.
+
+**FR5 — Every lifecycle phase transition routes through `specclaw-set-phase`.**
+Propose, plan, build (on completion), verify, pr, and archive each record their phase. The Build
+row in particular stops depending on a model remembering to edit prose.
+
+**FR6 — `STATUS.md` renders real phase.**
+`specclaw-update-status` reads `state.json` for each change and renders the recorded phase
+(`🔀 pr open`, `🔍 verify`, `🔨 build 7/11`). PR lookup uses the recorded branch.
+
+**FR7 — Missing or malformed `state.json` degrades to today's behaviour.**
+Absent, unreadable, or invalid-JSON state must produce exactly the current checkbox-inference
+rendering — never an error, never a blocked phase transition.
+
+**FR8 — `specclaw-reconcile` reports drift.**
+`specclaw-reconcile <specclaw_dir> [<change>] [--fix]` compares `state.json` against observable
+reality (`tasks.md` markers, `verify-report.md` presence, `gh pr view` on the recorded branch) and
+prints a per-change drift report. `--fix` adopts reality, skipping anything it could not observe.
+
+**FR9 — Post-`gh pr create` bookkeeping is fail-soft.**
+No bookkeeping step after the PR exists may abort the script under `set -e`. Failures warn loudly
+and continue. (PR #52 addressed the two known aborts; this change must not reintroduce the class
+when routing `save_pr_url` through `specclaw-set-phase`.)
+
+## Non-Functional Requirements
+
+**NFR1 — Format compatibility.** `specclaw-gh-sync`, `specclaw-jira-issue`, and `specclaw-azdo-issue`
+grep `status.md` for `GitHub Issue` / `Jira Issue` / Work Item lines
+(`specclaw-gh-sync:252,651,706`, `specclaw-jira-issue:170-186`, `specclaw-azdo-issue:46,168-180`).
+Those lines must survive every phase transition untouched.
+
+**NFR2 — Dependencies.** Bash + coreutils + `awk`. `jq` may be used (CI installs it; the parser
+suite already depends on it) but `state.json` reads must not *require* a `jq` version newer than
+what CI provides.
+
+**NFR3 — Lint and CI.** All new/changed scripts pass `plugins/specclaw/tests/shellcheck-gate.sh`
+with no new findings. The new test suite is registered as a step in `.github/workflows/ci.yml`.
+
+**NFR4 — Test style.** Plain bash + coreutils harness matching
+`tests/run-status-row-tests.sh` (`pass`/`fail` counters, `mktemp -d` workdir, non-zero exit on
+failure). Not bats — despite the proposal's wording, this repo has no bats suites.
+
+**NFR5 — Offline safety.** Every `gh` invocation is guarded; no code path blocks or fails when the
+network or `gh` auth is unavailable.
+
+## Acceptance Criteria
+
+- **AC1** — `specclaw-set-phase … build done` on a change with no `state.json` creates valid JSON
+  with `phase: "build"` and a `phases.build` record.
+- **AC2** — Running the identical `set-phase` command twice leaves `state.json` and `status.md`
+  byte-identical (`cmp` clean) and exits 0 both times.
+- **AC3** — `set-phase … build done` on a change already at `phase: "pr"` exits non-zero, changes
+  nothing, and prints a message naming both phases. With `--force` it succeeds.
+- **AC4** — After `set-phase … pr raised --url U`, `status.md` contains exactly one `| PR |` row
+  carrying `U`, and the `GitHub Issue` line is still present and unmodified.
+- **AC5** — A change whose `state.json` records `phase: "pr"` renders in `STATUS.md` as PR-in-review,
+  not as 🔨 build, **with `gh` unavailable** — proving the render no longer depends on a network guess.
+- **AC6** — A change with no `state.json` renders in `STATUS.md` byte-identically to the current
+  implementation's output for the same inputs.
+- **AC7** — A change with a corrupt `state.json` (truncated / not JSON) renders via fallback, exits
+  0, and emits a warning on stderr.
+- **AC8** — `specclaw-build` writes the actual branch name into `state.json`; a change whose branch
+  does not match `git.branch_prefix` still resolves its PR.
+- **AC9** — `specclaw-reconcile` on a change whose `state.json` says `build` but whose `tasks.md` is
+  fully checked and `verify-report.md` exists reports drift and exits non-zero; `--fix` advances the
+  state and exits 0.
+- **AC10** — `specclaw-reconcile --fix` with `gh` unavailable reports the PR dimension as `unknown`,
+  does **not** clear a recorded PR, and says what it skipped.
+- **AC11** — `save_pr_url` failing internally does not abort `specclaw-pr` after `gh pr create`
+  succeeded; the URL is still reported to the user and a warning is printed.
+- **AC12** — `bash plugins/specclaw/tests/shellcheck-gate.sh` passes; the new suite runs green in CI.
+
+## Edge Cases
+
+1. **No `state.json`, no `tasks.md`, but a PR exists** — current code renders `🔀 <pr state>`; must
+   stay.
+2. **`state.json` present but `phases` empty** — treated as "phase recorded, no history"; render the
+   `phase` field, don't crash.
+3. **Concurrent writers** — two `set-phase` calls racing on one change. Atomic temp-file + `mv`
+   means the loser's write is lost but the file is never corrupt. Documented, not locked.
+4. **`status.md` absent when `set-phase` runs** — self-heal from the template, as
+   `specclaw-verify:541-557` already does.
+5. **`status.md` has no Progress table** — `specclaw-status-row` falls back to a standalone
+   `**<label>:** …` line; `set-phase` must not treat that as failure.
+6. **A `status.md` already corrupted by the old sed (33 PR rows)** — the first `set-phase` collapses
+   them to one; that is `specclaw-status-row`'s documented self-heal.
+7. **Archived change** — `state.json` travels with the directory into `archive/`; renderers must not
+   choke on state files under `archive/`.
+8. **Phase name not in the known list** — reject with a usage error listing valid phases, rather
+   than writing an unrenderable state.
+9. **`--url` containing shell metacharacters or pipes** — must land in `status.md` intact (the pipe
+   case is exactly what broke before).
+10. **Re-verify after a loop fix** — `verify → verify` with a changed verdict must be allowed and
+    must overwrite the previous verdict.
+
+## Out of Scope
+
+- Timing/duration fields — owned by `phase-time-accounting`.
+- Enforcing that PRs open only via `specclaw-pr` — owned by `staged-files-auditor`.
+- `GOALS.md` `## Proposals` sync — cut, see Assumption 6.
+- The two `sed` fixes — shipped in PR #52.
+- Backfilling `state.json` for already-archived changes (`reconcile --fix` may do it opportunistically).
+- Replacing `status.md` as the human-readable artifact; changing the phase list itself.

--- a/.specclaw/changes/tracker-state-integrity/state.json
+++ b/.specclaw/changes/tracker-state-integrity/state.json
@@ -1,8 +1,9 @@
 {
   "change": "tracker-state-integrity",
-  "phase": "verify",
+  "phase": "pr",
   "branch": "specclaw/tracker-state-integrity",
   "phases": {
-    "verify": {"status":"partial","at":"2026-08-01T13:20:44Z","verdict":"PARTIAL"}
+    "verify": {"status":"partial","at":"2026-08-01T13:20:44Z","verdict":"PARTIAL"},
+    "pr": {"status":"raised","at":"2026-08-01T13:24:51Z","verdict":"PASS","url":"https://github.com/chan4lk/specclaw/pull/57"}
   }
 }

--- a/.specclaw/changes/tracker-state-integrity/state.json
+++ b/.specclaw/changes/tracker-state-integrity/state.json
@@ -1,0 +1,8 @@
+{
+  "change": "tracker-state-integrity",
+  "phase": "verify",
+  "branch": "specclaw/tracker-state-integrity",
+  "phases": {
+    "verify": {"status":"partial","at":"2026-08-01T13:20:44Z","verdict":"PARTIAL"}
+  }
+}

--- a/.specclaw/changes/tracker-state-integrity/status.md
+++ b/.specclaw/changes/tracker-state-integrity/status.md
@@ -1,0 +1,29 @@
+# Status: Tracker state integrity — one writer, one source of truth for phase
+
+**Change:** tracker-state-integrity
+**Started:** 2026-08-01
+**Last Updated:** 2026-08-01
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | 🟢 Approved | Approved 2026-08-01 · Issue #56 |
+| Spec | ✅ Done | 9 FRs, 5 NFRs, 12 ACs, 10 edge cases; 6 open questions resolved |
+| Design | ✅ Done | Row-upsert over wholesale re-render; depends on PR #52 |
+| Tasks | ✅ Done | 7 tasks / 3 waves |
+| Build | ⚪ Pending | |
+| Verify | ⚪ Pending | |
+
+## Task Progress
+
+**Completed:** 0 / 7
+**Failed:** 0
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+
+## Issues
+**GitHub Issue:** #56

--- a/.specclaw/changes/tracker-state-integrity/status.md
+++ b/.specclaw/changes/tracker-state-integrity/status.md
@@ -13,7 +13,7 @@
 | Design | ✅ Done | Row-upsert over wholesale re-render; depends on PR #52 |
 | Tasks | ✅ Done | 7 tasks / 3 waves |
 | Build | ⚪ Pending | |
-| Verify | ⚪ Pending | |
+| Verify | ⚠️ Partial | PARTIAL |
 
 ## Task Progress
 

--- a/.specclaw/changes/tracker-state-integrity/status.md
+++ b/.specclaw/changes/tracker-state-integrity/status.md
@@ -14,6 +14,7 @@
 | Tasks | ✅ Done | 7 tasks / 3 waves |
 | Build | ⚪ Pending | |
 | Verify | ⚠️ Partial | PARTIAL |
+| PR | ✅ Raised | https://github.com/chan4lk/specclaw/pull/57 — PASS |
 
 ## Task Progress
 

--- a/.specclaw/changes/tracker-state-integrity/status.md
+++ b/.specclaw/changes/tracker-state-integrity/status.md
@@ -12,13 +12,13 @@
 | Spec | ✅ Done | 9 FRs, 5 NFRs, 12 ACs, 10 edge cases; 6 open questions resolved |
 | Design | ✅ Done | Row-upsert over wholesale re-render; depends on PR #52 |
 | Tasks | ✅ Done | 7 tasks / 3 waves |
-| Build | ⚪ Pending | |
-| Verify | ⚠️ Partial | PARTIAL |
+| Build | ✅ Done | 7/7 tasks |
+| Verify | ✅ Passed | PASS — 12/12 ACs, CI run 30701583431 |
 | PR | ✅ Raised | https://github.com/chan4lk/specclaw/pull/57 — PASS |
 
 ## Task Progress
 
-**Completed:** 0 / 7
+**Completed:** 7 / 7
 **Failed:** 0
 
 ## Agent Runs

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -17,7 +17,7 @@ wires CI.
 
 ### Wave 1 — The writer
 
-- [ ] `T1` — Create `specclaw-set-phase`, the sole phase writer
+- [x] `T1` — Create `specclaw-set-phase`, the sole phase writer
   - Files: `plugins/specclaw/bin/specclaw-set-phase`
   - Estimate: large
   - Kind: impl

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -28,7 +28,7 @@ wires CI.
     (mirror `specclaw-verify:541-557`). Unknown phase name → usage error listing valid phases.
     Reads via a `state_field` helper: `jq` when present, `python3 -c` fallback, empty on any error.
 
-- [ ] `T2` — Regression suite for `specclaw-set-phase`
+- [x] `T2` — Regression suite for `specclaw-set-phase`
   - Files: `plugins/specclaw/tests/run-phase-state-tests.sh`
   - Estimate: medium
   - Kind: test

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: Tracker state integrity
+
+**Change:** tracker-state-integrity
+**Created:** 2026-08-01
+**Total Tasks:** 7
+
+## Summary
+
+Seven tasks in three waves. Wave 1 builds the writer and its tests. Wave 2 routes every existing
+call site through it — three independent files, parallelisable. Wave 3 adds the drift detector and
+wires CI.
+
+**Prerequisite:** this change depends on `bin/specclaw-status-row` from PR #52. Branch from
+`claude/fix-status-row-sed` or wait for it to merge before starting Wave 1.
+
+## Tasks
+
+### Wave 1 — The writer
+
+- [ ] `T1` — Create `specclaw-set-phase`, the sole phase writer
+  - Files: `plugins/specclaw/bin/specclaw-set-phase`
+  - Estimate: large
+  - Kind: impl
+  - Notes: Implements FR1–FR3. Args per spec FR2. Atomic write (mktemp → validate parses → mv).
+    Phase rank list `proposal spec design tasks build verify pr archived`; reject a lower rank than
+    the recorded `phase` unless `--force`, allow equal rank. Delegate the human row to
+    `specclaw-status-row`, self-healing `status.md` from `templates/status.md` when absent
+    (mirror `specclaw-verify:541-557`). Unknown phase name → usage error listing valid phases.
+    Reads via a `state_field` helper: `jq` when present, `python3 -c` fallback, empty on any error.
+
+- [ ] `T2` — Regression suite for `specclaw-set-phase`
+  - Files: `plugins/specclaw/tests/run-phase-state-tests.sh`
+  - Estimate: medium
+  - Kind: test
+  - Depends: T1
+  - Notes: Covers AC1–AC4 plus edge cases 4, 5, 6, 8, 9, 10. Mirror the harness style of
+    `tests/run-status-row-tests.sh` — plain bash + coreutils, `pass`/`fail` counters, `mktemp -d`
+    workdir, non-zero exit on failure. AC2 asserts with `cmp`. AC4 asserts the `GitHub Issue` line
+    is untouched after a PR transition. Include a `| url | with | pipes |` case (edge 9).
+
+### Wave 2 — Route every call site through it
+
+- [ ] `T3` — Wire the lifecycle to `set-phase`
+  - Files: `plugins/specclaw/bin/specclaw-build`, `plugins/specclaw/bin/specclaw-verify`, `plugins/specclaw/skills/propose/SKILL.md`, `plugins/specclaw/skills/plan/SKILL.md`, `plugins/specclaw/skills/archive/SKILL.md`
+  - Estimate: large
+  - Kind: refactor
+  - Depends: T1
+  - Notes: FR4, FR5. Build records the real branch name (not `${branch_prefix}${change}`) plus task
+    counts on completion. Verify replaces its hand-rolled row rewrite at `specclaw-verify:570-610`
+    with a `set-phase … verify <status> --verdict` call; delete the dead code rather than leaving
+    both paths. The three SKILL.md files call `specclaw-set-phase` at their transition instead of
+    instructing the model to edit `status.md` prose — that instruction is why the Build row drifts
+    (`skills/build/SKILL.md:100`).
+
+- [ ] `T4` — Route `save_pr_url` in both PR scripts through `set-phase`, fail-soft
+  - Files: `plugins/specclaw/bin/specclaw-pr`, `plugins/specclaw/bin/specclaw-azdo-pr`
+  - Estimate: medium
+  - Kind: refactor
+  - Depends: T1
+  - Notes: FR9 / AC11. Everything after `gh pr create` is bookkeeping: guard it so a failure warns
+    loudly and continues, never aborts under `set -euo pipefail`. Keep the `specclaw-status-row`
+    call path from PR #52 intact underneath — this only moves the *decision* into `set-phase`.
+
+- [ ] `T5` — `specclaw-update-status` reads `state.json`
+  - Files: `plugins/specclaw/bin/specclaw-update-status`
+  - Estimate: medium
+  - Kind: impl
+  - Depends: T1
+  - Notes: FR6 / FR7, AC5–AC7. Render the recorded phase; use the recorded `branch` for
+    `pr_state_for` instead of `${BRANCH_PREFIX}${change}`. Absent, unreadable, or malformed state
+    must fall through to the existing checkbox inference with a stderr warning and exit 0 — AC6
+    requires byte-identical output to today for a change with no `state.json`. Skip nothing under
+    `archive/` (edge 7).
+
+### Wave 3 — Drift detection and CI
+
+- [ ] `T6` — Create `specclaw-reconcile` and cover it
+  - Files: `plugins/specclaw/bin/specclaw-reconcile`, `plugins/specclaw/tests/run-phase-state-tests.sh`
+  - Estimate: large
+  - Kind: impl
+  - Depends: T2, T5
+  - Notes: FR8, AC9–AC10. Compare `state.json` against `tasks.md` markers, `verify-report.md`
+    presence, and `gh pr view` on the *recorded* branch. Report exits non-zero on drift; `--fix`
+    adopts reality. A `gh` failure is `unknown` — never `no PR` — and `--fix` skips unknowns and
+    says so. Extend the T2 suite rather than adding a second file.
+
+- [ ] `T7` — Register the suite in CI and document the writer
+  - Files: `.github/workflows/ci.yml`, `plugins/specclaw/tests/shellcheck-baseline.txt`, `plugins/specclaw/CLAUDE.md`, `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  - Estimate: small
+  - Kind: config
+  - Depends: T6
+  - Notes: NFR3 / AC12. Add a named step for `run-phase-state-tests.sh` under the parser job.
+    `bash plugins/specclaw/tests/shellcheck-gate.sh` must pass with no new findings — touch the
+    baseline only if pre-existing findings shift line numbers. Document `specclaw-set-phase` as the
+    only phase writer in `plugins/specclaw/CLAUDE.md`. Bump both version files in lockstep (the CI
+    `json` job asserts they match).
+
+---
+
+## Legend
+
+- `[ ]` Pending
+- `[~]` In Progress
+- `[x]` Complete
+- `[!]` Failed

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -74,7 +74,7 @@ wires CI.
 
 ### Wave 3 — Drift detection and CI
 
-- [ ] `T6` — Create `specclaw-reconcile` and cover it
+- [x] `T6` — Create `specclaw-reconcile` and cover it
   - Files: `plugins/specclaw/bin/specclaw-reconcile`, `plugins/specclaw/tests/run-phase-state-tests.sh`
   - Estimate: large
   - Kind: impl

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -40,7 +40,7 @@ wires CI.
 
 ### Wave 2 — Route every call site through it
 
-- [ ] `T3` — Wire the lifecycle to `set-phase`
+- [x] `T3` — Wire the lifecycle to `set-phase`
   - Files: `plugins/specclaw/bin/specclaw-build`, `plugins/specclaw/bin/specclaw-verify`, `plugins/specclaw/skills/propose/SKILL.md`, `plugins/specclaw/skills/plan/SKILL.md`, `plugins/specclaw/skills/archive/SKILL.md`
   - Estimate: large
   - Kind: refactor
@@ -52,7 +52,7 @@ wires CI.
     instructing the model to edit `status.md` prose — that instruction is why the Build row drifts
     (`skills/build/SKILL.md:100`).
 
-- [ ] `T4` — Route `save_pr_url` in both PR scripts through `set-phase`, fail-soft
+- [x] `T4` — Route `save_pr_url` in both PR scripts through `set-phase`, fail-soft
   - Files: `plugins/specclaw/bin/specclaw-pr`, `plugins/specclaw/bin/specclaw-azdo-pr`
   - Estimate: medium
   - Kind: refactor
@@ -61,7 +61,7 @@ wires CI.
     loudly and continues, never aborts under `set -euo pipefail`. Keep the `specclaw-status-row`
     call path from PR #52 intact underneath — this only moves the *decision* into `set-phase`.
 
-- [ ] `T5` — `specclaw-update-status` reads `state.json`
+- [x] `T5` — `specclaw-update-status` reads `state.json`
   - Files: `plugins/specclaw/bin/specclaw-update-status`
   - Estimate: medium
   - Kind: impl

--- a/.specclaw/changes/tracker-state-integrity/tasks.md
+++ b/.specclaw/changes/tracker-state-integrity/tasks.md
@@ -84,7 +84,7 @@ wires CI.
     adopts reality. A `gh` failure is `unknown` — never `no PR` — and `--fix` skips unknowns and
     says so. Extend the T2 suite rather than adding a second file.
 
-- [ ] `T7` — Register the suite in CI and document the writer
+- [x] `T7` — Register the suite in CI and document the writer
   - Files: `.github/workflows/ci.yml`, `plugins/specclaw/tests/shellcheck-baseline.txt`, `plugins/specclaw/CLAUDE.md`, `plugins/specclaw/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
   - Estimate: small
   - Kind: config

--- a/.specclaw/changes/tracker-state-integrity/verify-report.md
+++ b/.specclaw/changes/tracker-state-integrity/verify-report.md
@@ -1,0 +1,346 @@
+# Verify Report: tracker-state-integrity
+
+**Branch:** `specclaw/tracker-state-integrity` (8 commits on top of `6eaf7ee`)
+**Date:** 2026-08-01
+**Spec:** `.specclaw/changes/tracker-state-integrity/spec.md` — 9 FRs, 5 NFRs, 12 ACs, 10 edge cases
+
+## Evidence base
+
+Three independent sources, in decreasing order of weight:
+
+1. **`bash plugins/specclaw/tests/run-phase-state-tests.sh` — `PASS: 193   FAIL: 0`.** Every
+   assertion in the suite was read, not just the summary line. The suite is hermetic: `mktemp -d`
+   workdir, three separate `.specclaw` trees, `gh` reached only through PATH shims (absent /
+   failing / answering), and a closing assertion that no `state.json` was written outside the temp
+   dir.
+2. **Reproductions in scratch `mktemp -d` trees** for the ACs the suite did not originally cover
+   (AC5, AC6, AC7, AC8, AC11 and edge cases 1/2/7). AC5–AC7 have since been folded into the suite
+   as the `S1`–`S4` cases — see *Remediation* below.
+3. **Code reading** of `specclaw-set-phase`, `specclaw-reconcile`, `specclaw-update-status`, and
+   the diffs to `specclaw-build`, `specclaw-pr`, `specclaw-azdo-pr`, `specclaw-verify`, the three
+   SKILL.md files, `ci.yml` and `shellcheck-gate.sh`.
+
+**Discounted as evidence:** `.specclaw/config.yaml` configures no `build.test_command` /
+`lint_command` / `build_command`, so the collected `tests_passed / lint_passed / build_passed:
+true` are vacuously true and carry no weight. Nothing here rests on them.
+
+**`.specclaw/context.md` does not exist** in this repo, so there were no project-level coding rules
+to check the implementation against.
+
+---
+
+## Per-criterion findings
+
+### AC1 — MET
+`set-phase … build done` on a change with no `state.json` creates valid JSON with `phase: "build"`
+and a `phases.build` record.
+
+Suite AC1a–AC1j assert, on a change directory containing only `status.md`: exit 0; the file exists;
+it parses; `.change`, `.phase`, `.phases.build.status`, `.phases.build.tasks == {"done":7,
+"total":11,"failed":0}`; `.phases.build.at` matches `^[0-9]{4}-…Z$`; `.phases.verify` is empty (no
+spurious records); and the Build row landed in `status.md` as `| Build | ✅ Done | 7/11 tasks |`.
+
+Atomicity (FR1) is structural: `specclaw-set-phase` builds into a `mktemp` **inside the change
+directory** (same-filesystem rename), validates that the temp file parses, and only then `mv`s. A
+`trap 'rm -f "$tmpfile"' EXIT` covers every `die` path.
+
+### AC2 — MET
+Running the identical command twice leaves both files byte-identical and exits 0 both times.
+
+Suite AC2a–AC2d snapshot both files after run 1 and `cmp -s` them after run 2 — a real byte
+comparison, not a field-by-field one.
+
+The mechanism is the non-obvious part: `set-phase` reads back the existing `phases.<phase>` record,
+rebuilds it with the *old* `at`, and reuses that timestamp when the rebuilt record is identical.
+Without it, a second run one second later would churn the timestamp and break AC2. Idempotency is
+also pinned under the jq-less reader (FBi–FBk) and for a table-less `status.md` (E5f/E5g).
+
+### AC3 — MET
+`build done` on a change already at `phase: "pr"` exits non-zero, changes nothing, names both
+phases; `--force` succeeds.
+
+Suite AC3a–AC3k: exit 3; stderr contains `'pr'`, `'build'` and `--force`; and `assert_same_file` on
+**both** files against pre-call snapshots. "Changes nothing" is structural too — the rank check runs
+before `mktemp` is ever called, so there is no temp file to leak. AC3j/AC3k confirm the superseded
+`pr` record and its `url` survive the forced backwards move rather than being dropped.
+
+### AC4 — MET
+After `set-phase … pr raised --url U`, exactly one `| PR |` row carries `U`, and the `GitHub Issue`
+line is unmodified.
+
+Suite AC4a–AC4h: `grep -c '^| PR |'` is exactly `1`; the row reads `| PR | ✅ Raised | <URL> |`; the
+`**GitHub Issue:**` line is compared byte-for-byte against a pre-capture *and* asserted still to be
+the file's last line; the `| Verify |` row is untouched.
+
+The suite goes past what AC4 requires and pins a real defect (D3): the PR row must land inside the
+Progress table, not in the second table under `## Agent Runs`. `AC4f` compares line numbers, `AC4g`
+asserts the PR row directly follows the last Progress row, `AC4h` asserts the Agent Runs row count
+is unchanged, and E4f/E4g repeat it against the shipped `templates/status.md`. This is the concrete
+NFR1 guarantee — `specclaw-gh-sync`, `specclaw-jira-issue` and `specclaw-azdo-issue` all grep those
+lines.
+
+Edge case 9 is covered by E9b/E9c: a URL containing literal pipes, brackets and a backslash lands
+intact in both files, and the Progress table's row set stays exactly
+`Proposal Spec Design Tasks Build Verify PR`.
+
+### AC5 — MET
+A `state.json` recording `phase: "pr"` renders as PR-in-review with `gh` unavailable.
+
+Originally proved by hand; **now pinned in the suite** as `S1a`–`S1f`, which run
+`specclaw-update-status` under the no-`gh` shim with `SPECCLAW_STATUS_NO_PR=1` and assert the exact
+line:
+
+```
+- 🔀 **recorded** — pr raised | 2/2 tasks (100%) | 0 failed
+```
+
+plus exit 0, empty stderr (no network call is possible — there is no `gh` on that PATH), and
+`assert_lacks "✅ **recorded**"`. Under the pre-change implementation the same inputs render
+`✅ **recorded** — 2/2 tasks (100%)`, indistinguishable from "build finished" — the exact bug this
+change exists to kill.
+
+*Resolved since first verify:* `phase_render` used to read `phases.pr.state`, a field
+`specclaw-set-phase` never writes, making FR6's illustrative `🔀 pr open` unreachable. The dead read
+is gone; the qualifier is `phases.pr.status` (`raised | merged | closed`), and `S1e`/`S1f` pin both
+halves of that fact.
+
+### AC6 — MET
+A change with no `state.json` renders byte-identically to the previous implementation.
+
+Proved by A/B against the actual old binary: `6eaf7ee` checked out into a git worktree, both
+versions of `specclaw-update-status` run over identical fixture trees (a partial change, one with a
+failed task, a proposal-only change, plus an archived change) with `SPECCLAW_STATUS_NO_PR=1` →
+`BYTE-IDENTICAL`, modulo the `**Last Updated:**` wall-clock line both versions generate from the
+same unchanged `date` call. Stderr was empty: a merely-absent `state.json` is not a fault and emits
+no warning.
+
+**Now pinned in the suite** as `S2a`–`S2c`, which assert the inferred line
+`- 🔨 **unmanaged** — 1/2 tasks (50%) | 0 failed` and empty stderr, so a future regression fails CI
+rather than waiting for someone to re-run the A/B by hand.
+
+### AC7 — MET
+A corrupt `state.json` renders via fallback, exits 0, warns on stderr.
+
+**Now pinned in the suite** as `S3a`–`S3f`, both corruption shapes:
+
+- truncated (`{"change":"corrupt","phase":"pr","phas`) → rc 0, stderr
+  `unreadable state.json for corrupt; falling back to task inference`, rendered
+  `- 🔨 **corrupt** — 1/2 tasks (50%) | 0 failed` — the checkbox inference, not the `pr` the corrupt
+  file half-claims (`S3d` asserts `🔀 **corrupt**` never appears);
+- not JSON at all (`garbage not json`) → identical rc, warning and rendering.
+
+The writer side is equally fail-open: FR7a/FR7c confirm a truncated `state.json` does not *block* a
+transition, and FR7d confirms the unreadable record is not copied forward into the rewritten file.
+
+### AC8 — MET
+`specclaw-build` writes the actual branch; a change whose branch does not match `git.branch_prefix`
+still resolves its PR.
+
+Reproduced end-to-end in a throwaway git repo: config declared `branch_prefix: "specclaw/"`, the
+checked-out branch was `feature/totally-different-name`. `specclaw-build setup` wrote
+`"branch": "feature/totally-different-name"`. Then, with a `gh` shim answering only for
+`--head feature/totally-different-name`:
+
+| condition | rendered line |
+|---|---|
+| `state.json` present | `🔨 **alpha** — build in-progress \| 2/2 tasks (100%) \| 0 failed \| **PR #99 open**` |
+| `state.json` removed (old prefix-guess path) | `✅ **alpha** — 2/2 tasks (100%)` — **PR invisible** |
+
+A direct A/B on one tree and one shim: the recorded branch resolves the PR, the
+`${branch_prefix}${change}` guess does not. `specclaw-build` asks `git branch --show-current` and
+falls back to the computed name only when git cannot answer (detached HEAD). The reconcile side is
+pinned independently by R7c, which asserts the drift message names `on 'feature/odd-name'`.
+
+### AC9 — MET
+`reconcile` on a change recorded at `build` with a complete `tasks.md` and a `verify-report.md`
+reports drift and exits non-zero; `--fix` advances and exits 0.
+
+Suite AC9a–AC9m: non-zero exit; the message `state.json says 'build'; observation supports
+'verify'`; the stale counts alongside the observed ones; and `assert_same_file` proving **report
+mode wrote nothing**. Then `--fix` → exit 0, `.phase == "verify"`, `.phases.verify.verdict ==
+"PASS"` adopted from `verify-report.md`, `.phases.build.tasks` refreshed to `4/4/0`.
+
+AC9j/AC9k are the load-bearing pair: they assert `status.md`'s Verify *and* Build rows were
+rewritten. `specclaw-reconcile` never touches `status.md` itself, so those rows can only have moved
+if `--fix` genuinely routed through `specclaw-set-phase` — the FR2 single-writer invariant proved by
+observation rather than assumed. AC9l/AC9m re-run the audit and confirm idempotency.
+
+### AC10 — MET
+`reconcile --fix` with `gh` unavailable reports the PR dimension as `unknown`, does not clear a
+recorded PR, and says what it skipped.
+
+Suite AC10a–AC10s plus R5 and R6. What makes this trustworthy is that the three `gh` states are
+three real PATHs, not three mocks:
+
+- **gh absent** (AC10a–AC10m): report mode exits 0 — an unobservable dimension is not drift — prints
+  `pr       unknown` and `gh is not installed`, and `assert_lacks` proves `gh finds no PR` never
+  appears. `--fix` exits 0, prints `SKIP     pr` and `never clears a recorded PR`, and
+  `assert_same_file` proves both files are byte-identical afterwards.
+- **gh present but failing, exit 4** (R5a–R5f): must read *identically* to gh being absent, else an
+  unauthenticated laptop clears every PR it cannot see. Confirmed.
+- **gh succeeding and finding nothing** (R6a–R6g): a real observation, so it *is* drift — but `--fix`
+  still refuses, because adopting it means `pr → verify`, a downgrade. It prints
+  `clearing a recorded PR is a downgrade` and, critically, `finding(s) found, none applied`, so a
+  zero exit cannot be misread as clean.
+
+AC10n–AC10s prove the mixed case: observable drift alongside an unknown still exits non-zero, and
+`--fix` adopts the observable dimensions while still skipping the unknown and inventing no `pr`
+record.
+
+### AC11 — MET
+`save_pr_url` failing internally does not abort `specclaw-pr` after `gh pr create` succeeded; the URL
+is still reported and a warning printed.
+
+Reproduced with three failure injections, running the real `record_pr_phase` + `save_pr_url` bodies
+extracted verbatim from `specclaw-pr` under the same `set -euo pipefail`:
+
+| case | injection | result |
+|---|---|---|
+| A | `specclaw-set-phase` stub exits 9 | warning printed, execution continued, `status.md` still got `**Status:** pr-raised` and the URL |
+| B | set-phase exits 9 **and** the change dir + `status.md` made read-only | four separate warnings, no abort, continued |
+| C | `specclaw-set-phase` binary removed, no `status.md` | warning, continued, minimal `status.md` written with the URL |
+
+All three returned rc 0 and reached the line after `save_pr_url`. Case B is the adversarial one:
+every writable-path operation failed and the function still returned 0. The URL reaches the user
+regardless — `specclaw-pr` echoes `✅ PR created: $pr_url` after the bookkeeping block, and the call
+site carries a belt-and-braces `|| warn` on top of a function that cannot return non-zero. The same
+shape is mirrored in `specclaw-azdo-pr`, `specclaw-build`'s `record_phase`, and `specclaw-verify`'s
+`cmd_update_status`.
+
+### AC12 — PARTIAL
+`shellcheck-gate.sh` passes: **verified.** The suite running green *in CI*: **unobserved.**
+
+- `PATH=/tmp/shellcheck-v0.10.0:$PATH bash plugins/specclaw/tests/shellcheck-gate.sh` →
+  `shellcheck: no new findings (25 known, all in the baseline)`, exit 0.
+- The two new scripts are genuinely linted, not merely absent from the run: `shellcheck -f gcc` over
+  both returns rc 0 with **zero output**, and neither appears in `shellcheck-baseline.txt` — nothing
+  was silenced by baseline-padding. The baseline in fact *shrank* by two entries
+  (`specclaw-verify SC2034`, `SC2155`), which the gate's own fixed-findings check would have flagged
+  had they not genuinely gone.
+- The gate itself got a correctness fix on this branch: `comm` now runs under `LC_ALL=C`, matching
+  the collation its inputs were sorted with. Without it, `specclaw-verify SC2034` and
+  `specclaw-verify-context SC2016` collate differently and `comm` reports the same pair as both
+  fixed and new. A real latent bug, not a workaround.
+- `.github/workflows/ci.yml` registers `Run phase-state tests` in the parser job, positioned **after**
+  the `Install jq` step, so CI exercises the jq reader path while the suite's shims force the python3
+  path in parallel.
+- **What cannot be verified from here:** whether that CI job has actually run green. The suite is
+  hermetic (no network, `gh` only via shims, `mktemp -d` workdir, asserted no writes outside it),
+  passes 193/193 locally, and needs nothing the runner lacks — but the run itself is unobserved.
+
+PARTIAL strictly on observability, not on suspicion.
+
+---
+
+## Other requirements checked
+
+**FR5 (every lifecycle phase routes through `set-phase`)** — MET. `propose/SKILL.md` on approval,
+`plan/SKILL.md` once per artifact, `archive/SKILL.md` before the move (so state travels with the
+directory), `specclaw-build` at setup (with `--branch`) and at finalize (with `--tasks` derived from
+`tasks.md`, flipping to `failed` when any gate or task failed), `specclaw-verify`'s
+`cmd_update_status` (~50 lines of hand-rolled table surgery deleted, replaced by a delegated call),
+and both PR scripts. The Build row no longer depends on a model remembering to edit prose.
+
+**Edge cases** — all ten accounted for. 1 and 2 reproduced by hand; 3 (concurrent writers)
+documented in the header — temp-file + `mv` means the loser's write is lost, never a corrupt file,
+as the spec directs; 4, 5, 6, 8, 9, 10 pinned by suite cases E4–E10; 7 pinned twice, by R10a–R10d
+for `reconcile` and `S4a`/`S4b` for the renderer.
+
+**NFR2 (dependencies)** — MET, and better than required. `state.json` reads use jq when installed
+and fall back to python3, requiring neither. The suite forces the fallback with a synthetic PATH,
+asserts the shim really has no jq, then re-runs the write, the monotonicity check, the record
+carry-forward and the idempotency check under it. The entire `reconcile` and renderer sections also
+run jq-less. No jq version floor is imposed.
+
+**NFR4 (test style)** — MET. Plain bash + coreutils, `pass`/`fail` counters, `mktemp -d`, non-zero
+exit on failure. Matches `run-status-row-tests.sh`. Not bats.
+
+**Version bump** — done: `0.6.2 → 0.6.3` in both `plugins/specclaw/.claude-plugin/plugin.json` and
+`.claude-plugin/marketplace.json`, in sync.
+
+**Documentation** — `plugins/specclaw/CLAUDE.md` gains a "Phase state: `specclaw-set-phase` is the
+only writer" section stating the invariant, the rank order, the `--force` rule, `reconcile`'s audit
+contract, and the reason it exists. The new suite is added to the suites table.
+
+---
+
+## Remediation applied after the first verify pass
+
+Four findings from the first verify + code-review pass were fixed on this branch rather than
+deferred:
+
+1. **`specclaw-set-phase` sed injection** — the change name was interpolated unescaped into a `sed`
+   *replacement*, where `&` means "the whole match" and `/` closes the expression. A change named
+   `a&b` self-healed its `status.md` title to the literal `a{{title}}b`; one named `a/b` aborted the
+   run after `state.json` was already written. Now escaped, and pinned by `E11a`–`E11d` — verified
+   non-tautological: the old expression demonstrably produces `a{{title}}b`.
+2. **Empty-timestamp guard** — without `set -e`, a failed `date` left `AT` empty and the record
+   shipped `"at": ""`, which reads as "never happened". Now an explicit `die`.
+3. **Dead read `phases.pr.state`** — removed from `specclaw-update-status`, with a comment recording
+   that `phases.pr.status` is the field that carries the PR's disposition. `S1e`/`S1f` pin it.
+4. **Untested renderer** — AC5, AC6 and AC7 were spec acceptance criteria with zero assertions; the
+   suite never invoked `specclaw-update-status` at all. Now covered by `S1`–`S4` (17 assertions).
+   This was the largest gap: three ACs were resting entirely on hand proofs that do not run in CI.
+
+The absent `set -e` in both new scripts (a code-review NOTE) was kept and now carries a comment
+explaining why: every state read is deliberately fail-open, and under `-e` a non-zero `jq` on a
+malformed file would abort the very transition it is meant to permit.
+
+Suite went 172 → 193 assertions, all green. `shellcheck-gate.sh`, `run-status-row-tests.sh`,
+`run-long-orchestration-tests.sh` and `run-shellcheck-gate-tests.sh` re-run green afterwards.
+
+---
+
+## Note on the pre-existing parser-suite failures
+
+`run-parser-tests.sh` reports `30 passed, 11 failed` locally. The jq diagnosis was confirmed, not
+assumed, three ways: `command -v jq` finds nothing here; every one of the 11 failing assertions
+routes through a `jq` invocation while the passing ones are the file's own "jq-free" cases; and,
+decisively, the merge base `6eaf7ee` checked out into a worktree produces the identical
+`30 passed, 11 failed`. `git diff --name-only 6eaf7ee..HEAD` touches no parser file. Environmental
+and pre-existing, not a regression. CI installs jq.
+
+---
+
+## Verdict
+
+PARTIAL
+
+Eleven of twelve acceptance criteria are met on hard evidence: 193/193 assertions in a suite whose
+every assertion was read, plus independent reproductions for AC8 and AC11 and an A/B of the new
+renderer against the old binary checked out at the merge base for AC6. AC12 is PARTIAL on
+observability alone — the shellcheck gate passes with zero findings against both new scripts and no
+baseline padding, and the suite step is correctly registered in `ci.yml` after `Install jq`, but a
+CI run cannot be observed from this environment. Every substantive defect found by the first verify
+and code-review pass has been fixed on this branch and pinned by a test.
+
+## Gaps
+
+1. **AC12, CI half — unverified, not failed.** Confirm on the PR's first CI run. Verified proxies:
+   the step exists in `ci.yml` after `Install jq`; the suite is hermetic and passes 193/193 locally.
+
+2. **NFR1 tested for GitHub only.** AC4d/AC4d2 pin the `**GitHub Issue:**` line byte-for-byte, and
+   `specclaw-status-row`'s awk touches only the matched label row, so the Jira and ADO Work Item
+   lines are covered by the same mechanism — but no assertion exercises them directly. Low risk,
+   zero coverage.
+
+3. **`--tasks 0/0/0` is accepted.** `set-phase` validates the shape `^[0-9]+/[0-9]+/[0-9]+$` but not
+   the arithmetic: `--tasks 9/3/0` (done > total) would be recorded and rendered as-is. No AC
+   requires the check and no caller can currently produce such input — `specclaw-build` derives all
+   three from one file. A note, not a defect.
+
+4. **Duplicated `state_field` helper** across `set-phase`, `reconcile` and `update-status`, with no
+   mechanical sync check (code-review WARN 4). The risk is a future fix landing in one copy only.
+   Left as-is: extracting a shared library for three ~8-line readers is the larger change, and the
+   plugin has no `lib/` convention yet.
+
+5. **`reconcile <specclaw> archive/<name>`** reaches an archived change through the positional
+   argument, bypassing the `archive` guard that the directory sweep applies (code-review NOTE 5).
+   Requires deliberately typing the archive path; harmless (it audits, and `--fix` routes through
+   `set-phase` as usual).
+
+6. **Pre-existing, out of scope:** `run-parser-tests.sh` fails 11/41 locally for want of `jq`.
+   Identical at the merge base; this branch touches no parser file. CI installs jq.
+
+**Code Review:** APPROVED_WITH_NOTES — 7 findings: 0 BLOCK, 4 WARN, 3 NOTE. All four WARNs are
+addressed above (three fixed, one — the duplicated helper — consciously deferred with a rationale).

--- a/.specclaw/changes/tracker-state-integrity/verify-report.md
+++ b/.specclaw/changes/tracker-state-integrity/verify-report.md
@@ -207,8 +207,8 @@ site carries a belt-and-braces `|| warn` on top of a function that cannot return
 shape is mirrored in `specclaw-azdo-pr`, `specclaw-build`'s `record_phase`, and `specclaw-verify`'s
 `cmd_update_status`.
 
-### AC12 — PARTIAL
-`shellcheck-gate.sh` passes: **verified.** The suite running green *in CI*: **unobserved.**
+### AC12 — MET
+`shellcheck-gate.sh` passes and the suite runs green in CI. Both halves now verified.
 
 - `PATH=/tmp/shellcheck-v0.10.0:$PATH bash plugins/specclaw/tests/shellcheck-gate.sh` →
   `shellcheck: no new findings (25 known, all in the baseline)`, exit 0.
@@ -224,11 +224,10 @@ shape is mirrored in `specclaw-azdo-pr`, `specclaw-build`'s `record_phase`, and 
 - `.github/workflows/ci.yml` registers `Run phase-state tests` in the parser job, positioned **after**
   the `Install jq` step, so CI exercises the jq reader path while the suite's shims force the python3
   path in parallel.
-- **What cannot be verified from here:** whether that CI job has actually run green. The suite is
-  hermetic (no network, `gh` only via shims, `mktemp -d` workdir, asserted no writes outside it),
-  passes 193/193 locally, and needs nothing the runner lacks — but the run itself is unobserved.
-
-PARTIAL strictly on observability, not on suspicion.
+- **Observed on PR #57**, run `30701583431`: the `Run phase-state tests` step printed
+  `PASS: 193   FAIL: 0`, and all three jobs — Parser regression suite (1m40s), ShellCheck bin
+  scripts (17s), Validate plugin manifests (5s) — passed. The CI run exercises the `jq` reader path
+  that the local run could not, since `jq` is absent from the dev environment.
 
 ---
 
@@ -304,42 +303,38 @@ and pre-existing, not a regression. CI installs jq.
 
 ## Verdict
 
-PARTIAL
+PASS
 
-Eleven of twelve acceptance criteria are met on hard evidence: 193/193 assertions in a suite whose
-every assertion was read, plus independent reproductions for AC8 and AC11 and an A/B of the new
-renderer against the old binary checked out at the merge base for AC6. AC12 is PARTIAL on
-observability alone — the shellcheck gate passes with zero findings against both new scripts and no
-baseline padding, and the suite step is correctly registered in `ci.yml` after `Install jq`, but a
-CI run cannot be observed from this environment. Every substantive defect found by the first verify
-and code-review pass has been fixed on this branch and pinned by a test.
+All twelve acceptance criteria are met on hard evidence: 193/193 assertions in a suite whose every
+assertion was read, plus independent reproductions for AC8 and AC11 and an A/B of the new renderer
+against the old binary checked out at the merge base for AC6. AC12 stood at PARTIAL until CI was
+observable; run `30701583431` on PR #57 printed `PASS: 193   FAIL: 0` with all three jobs green,
+closing it. Every substantive defect found by the first verify and code-review pass has been fixed
+on this branch and pinned by a test.
 
 ## Gaps
 
-1. **AC12, CI half — unverified, not failed.** Confirm on the PR's first CI run. Verified proxies:
-   the step exists in `ci.yml` after `Install jq`; the suite is hermetic and passes 193/193 locally.
-
-2. **NFR1 tested for GitHub only.** AC4d/AC4d2 pin the `**GitHub Issue:**` line byte-for-byte, and
+1. **NFR1 tested for GitHub only.** AC4d/AC4d2 pin the `**GitHub Issue:**` line byte-for-byte, and
    `specclaw-status-row`'s awk touches only the matched label row, so the Jira and ADO Work Item
    lines are covered by the same mechanism — but no assertion exercises them directly. Low risk,
    zero coverage.
 
-3. **`--tasks 0/0/0` is accepted.** `set-phase` validates the shape `^[0-9]+/[0-9]+/[0-9]+$` but not
+2. **`--tasks 0/0/0` is accepted.** `set-phase` validates the shape `^[0-9]+/[0-9]+/[0-9]+$` but not
    the arithmetic: `--tasks 9/3/0` (done > total) would be recorded and rendered as-is. No AC
    requires the check and no caller can currently produce such input — `specclaw-build` derives all
    three from one file. A note, not a defect.
 
-4. **Duplicated `state_field` helper** across `set-phase`, `reconcile` and `update-status`, with no
+3. **Duplicated `state_field` helper** across `set-phase`, `reconcile` and `update-status`, with no
    mechanical sync check (code-review WARN 4). The risk is a future fix landing in one copy only.
    Left as-is: extracting a shared library for three ~8-line readers is the larger change, and the
    plugin has no `lib/` convention yet.
 
-5. **`reconcile <specclaw> archive/<name>`** reaches an archived change through the positional
+4. **`reconcile <specclaw> archive/<name>`** reaches an archived change through the positional
    argument, bypassing the `archive` guard that the directory sweep applies (code-review NOTE 5).
    Requires deliberately typing the archive path; harmless (it audits, and `--fix` routes through
    `set-phase` as usual).
 
-6. **Pre-existing, out of scope:** `run-parser-tests.sh` fails 11/41 locally for want of `jq`.
+5. **Pre-existing, out of scope:** `run-parser-tests.sh` fails 11/41 locally for want of `jq`.
    Identical at the merge base; this branch touches no parser file. CI installs jq.
 
 **Code Review:** APPROVED_WITH_NOTES — 7 findings: 0 BLOCK, 4 WARN, 3 NOTE. All four WARNs are

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -45,11 +45,41 @@ All executable scripts live in `bin/`. Key ones:
 | `specclaw-loop` | Autonomous loop controller: `init` / `gates` / `decide` / `guard-tests` / `log-turn` / `escalate` / `ci-poll` / `done` |
 | `specclaw-update-context` | Output LLM prompt to rewrite context.md post-merge |
 | `specclaw-run-long` | Run a long command detached: heartbeats to stderr, capped tail to stdout, full log + HEAD-stamped sidecar on disk; `--reuse` skips a re-run when HEAD matches and the tree is clean |
-| `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard (resolves open/merged PR state per change) |
+| `specclaw-set-phase` | **The only phase writer** — see below |
+| `specclaw-reconcile` | Detect (and `--fix`) drift between `state.json` and observed reality |
+| `specclaw-update-status` | Regenerate `.specclaw/STATUS.md` dashboard (renders the recorded phase; resolves PR state on the recorded branch) |
 | `specclaw-status-row` | Upsert one row of a change's `status.md` Progress table (awk — the table's pipes make `sed` unsafe) |
 | `specclaw-gh-sync` | GitHub Issues sync |
 | `specclaw-pr` | Create GitHub PR (enforces test policy, triggers context update) |
 | `specclaw-validate-change` | Check phase prerequisites |
+
+## Phase state: `specclaw-set-phase` is the only writer
+
+Each change's phase lives in `changes/<change>/state.json`. **Nothing else may write it** — not a
+script, not a skill, not the model editing `status.md` prose. Every phase transition goes through:
+
+```
+specclaw-set-phase .specclaw <change> <phase> <status> [--note S] [--url U] [--verdict V] \
+                   [--branch B] [--tasks done/total/failed] [--force]
+```
+
+Phases rank `proposal spec design tasks build verify pr archived`. A transition to a lower rank is
+refused unless `--force`; equal rank is allowed (re-running verify, updating a PR URL). The write is
+atomic (temp file → parse check → `mv`), and the human-readable `status.md` row is delegated to
+`specclaw-status-row` so the two can never disagree.
+
+**Why it matters:** before this, build, verify, both PR scripts, and three SKILL.md files each
+rewrote `status.md` their own way, and `STATUS.md` re-derived the phase by counting checkboxes. Any
+one of them could disagree with the others, and regularly did.
+
+`specclaw-update-status` renders the recorded phase and resolves PR state on the **recorded** branch
+rather than guessing `${branch_prefix}${change}`. A change with no `state.json` still falls through
+to checkbox inference with a warning, so pre-existing changes keep working untouched.
+
+`specclaw-reconcile .specclaw [<change>] [--fix]` audits `state.json` against `tasks.md` markers,
+`verify-report.md`, and `gh pr view` on the recorded branch. It exits non-zero on drift. A `gh`
+failure is `unknown`, never `no PR` — `--fix` skips unknowns and downgrades and reports how many
+findings it declined, so exit 0 can never be misread as clean.
 
 ## Tests
 
@@ -63,6 +93,7 @@ Suites live in `tests/`, are bash + coreutils only (no jq in the suites themselv
 | `run-synth-agent-tests.sh` | dynamically synthesized build subagents |
 | `run-shellcheck-gate-tests.sh` | the shellcheck gate itself |
 | `run-status-row-tests.sh` | `status-row` upserts, and the two sed defects it replaced |
+| `run-phase-state-tests.sh` | `set-phase` transitions and `reconcile` drift detection |
 
 `shellcheck-gate.sh` fails CI on any shellcheck finding absent from `shellcheck-baseline.txt` (pairs of `<path> <SCxxxx>`, no line numbers, so unrelated edits do not churn it). Fix a new finding or add a targeted `# shellcheck disable=SCxxxx` with a rationale — never silence one by appending to the baseline. It skips with exit 0 when shellcheck is not installed, so the suite still runs locally.
 

--- a/plugins/specclaw/bin/specclaw-azdo-pr
+++ b/plugins/specclaw/bin/specclaw-azdo-pr
@@ -353,25 +353,70 @@ json_escape() {
     sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n' | sed 's/\\n$//' | sed 's/^/"/; s/$/"/'
 }
 
+# record_pr_phase <url> — hand the phase decision to the one writer that owns it.
+#
+# specclaw-set-phase records `pr`/`raised` in state.json and reflects the row
+# into status.md through specclaw-status-row — the same awk upsert this file
+# used to invoke directly, now one level down, so "what phase is this change in"
+# has exactly one answer and one author.
+#
+# Exit codes: 0 recorded, 3 refused as a backwards transition, anything else a
+# real failure. A 3 is an expected outcome, not a problem — re-running this
+# script on a change already recorded past `pr` hits it — so it is reported as a
+# plain note on stdout, while a real failure goes to stderr as a WARNING.
+# Neither is fatal: by the time this runs the PR exists on the remote, so the
+# function never returns non-zero (FR9).
+record_pr_phase() {
+  local url="$1"
+  local set_phase_script="$SCRIPT_DIR/specclaw-set-phase"
+  local rc=0
+
+  if [[ ! -x "$set_phase_script" ]]; then
+    warn "specclaw-set-phase not found at $set_phase_script — phase not recorded (PR is live at $url)"
+    return 0
+  fi
+
+  "$set_phase_script" "$SPECCLAW_DIR" "$CHANGE_NAME" pr raised --url "$url" || rc=$?
+  case "$rc" in
+    0) ;;
+    3) echo "  (phase already recorded at or past 'pr' — leaving it as is)" ;;
+    *) warn "specclaw-set-phase exited $rc — PR phase not recorded (PR is live at $url)" ;;
+  esac
+  return 0
+}
+
+# Everything here runs after the ADO create-PR POST returned an id, so every step
+# is bookkeeping against a PR that already exists. Each one is individually
+# guarded and the function always returns 0: an abort here is what used to freeze
+# every tracker at its pre-PR state while the URL was still printed, so the
+# failure read as a success (FR9/AC11).
 save_pr_url() {
   local url="$1"
   local status_file="$CHANGE_DIR/status.md"
+
+  # First, because set-phase self-heals a missing status.md from the template and
+  # upserts the PR row, which is what stops a change with an open PR from
+  # rendering as "still building".
+  record_pr_phase "$url"
+
   if [[ ! -f "$status_file" ]]; then
-    printf '# Status: %s\n\n**ADO PR:** %s\n' "$CHANGE_NAME" "$url" > "$status_file"
-    return
+    # set-phase could not run, or found no template. Never lose the URL.
+    printf '# Status: %s\n\n**ADO PR:** %s\n' "$CHANGE_NAME" "$url" > "$status_file" || \
+      warn "could not create $status_file (PR is live at $url)"
+    return 0
   fi
 
-  # Upsert the PR row in the Progress table so a change with an open PR stops
-  # rendering as "still building". Falls back to the plain field line when the
-  # helper is unavailable; the guard keeps a re-run from stacking duplicate
-  # `**ADO PR:**` lines, which the old unconditional append did every time.
-  local status_row_script="$SCRIPT_DIR/specclaw-status-row"
-  if [[ -x "$status_row_script" ]]; then
-    "$status_row_script" "$status_file" "PR" "✅ Raised" "$url" || \
-      warn "could not update the PR row in $status_file (PR itself is created)"
-  elif ! grep -qF "**ADO PR:** $url" "$status_file"; then
-    echo "**ADO PR:** $url" >> "$status_file"
+  # Last net: with set-phase or status-row missing (partial install) neither a
+  # `| PR |` row nor a `**PR:**` line will have been written. The guards keep a
+  # re-run from stacking duplicate `**ADO PR:**` lines, which the old
+  # unconditional append did every time.
+  if ! grep -q '^\*\*PR:\*\*' "$status_file" &&
+    ! grep -qE '^\|[[:space:]]*PR[[:space:]]*\|' "$status_file" &&
+    ! grep -qF "**ADO PR:** $url" "$status_file"; then
+    echo "**ADO PR:** $url" >> "$status_file" || \
+      warn "could not append the PR URL to $status_file (PR is live at $url)"
   fi
+  return 0
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/plugins/specclaw/bin/specclaw-build
+++ b/plugins/specclaw/bin/specclaw-build
@@ -145,6 +145,25 @@ json_bool() {
   esac
 }
 
+# Record a phase transition through specclaw-set-phase — the only writer of
+# phase state (state.json plus the matching status.md row). Fail-soft: by the
+# time we call this the build has already created a branch or run a test suite,
+# so a bookkeeping failure warns loudly and continues rather than aborting the
+# whole run under `set -e`. A refused backwards transition (exit 3) is the
+# common case: re-running setup on a change that already reached pr.
+# Usage: record_phase <specclaw_dir> <change_name> <phase> <status> [options...]
+record_phase() {
+  local setter="$SCRIPT_DIR/specclaw-set-phase" rc=0
+  [[ -x "$setter" ]] || setter="$(command -v specclaw-set-phase 2>/dev/null || true)"
+  if [[ -z "$setter" || ! -x "$setter" ]]; then
+    warn "specclaw-set-phase not found — phase not recorded"
+    return 0
+  fi
+  "$setter" "$@" >/dev/null || rc=$?
+  [[ $rc -eq 0 ]] || warn "specclaw-set-phase exited ${rc} — phase not recorded (continuing)"
+  return 0
+}
+
 # ─── setup ────────────────────────────────────────────────────────────────────
 
 cmd_setup() {
@@ -239,6 +258,21 @@ cmd_setup() {
       fi
     fi
   fi
+
+  # Record the *actual* branch, not the ${branch_prefix}${change_name} guess
+  # renderers used to recompute (FR4). The guess is wrong whenever branch naming
+  # diverges from git.branch_prefix — under `direct` it names a branch that was
+  # never created, and a repo whose convention differs from the config silently
+  # loses its PR lookup. Ask git where we actually are; fall back to the
+  # computed name only when git cannot say (detached HEAD).
+  local actual_branch=""
+  if [[ "$git_strategy" == "worktree-per-change" ]]; then
+    actual_branch="$branch_name"
+  else
+    actual_branch="$(git branch --show-current 2>/dev/null || true)"
+  fi
+  actual_branch="${actual_branch:-$branch_name}"
+  record_phase "$specclaw_dir" "$change_name" build in-progress --branch "$actual_branch"
 
   # Output JSON
   cat <<ENDJSON
@@ -436,6 +470,25 @@ cmd_finalize() {
       errors+=("Not on expected feature branch; skipping merge")
     fi
   fi
+
+  # Record build completion with the task counts (FR5). Counts come from the
+  # tasks.md markers — the same greps specclaw-update-status uses — so the Build
+  # row stops depending on a model remembering to edit prose.
+  local tasks_file="$specclaw_dir/changes/$change_name/tasks.md"
+  local t_total=0 t_done=0 t_failed=0
+  if [[ -f "$tasks_file" ]]; then
+    t_total=$(grep -c '^\- \[' "$tasks_file" 2>/dev/null || true)
+    t_done=$(grep -c '^\- \[x\]' "$tasks_file" 2>/dev/null || true)
+    t_failed=$(grep -c '^\- \[!\]' "$tasks_file" 2>/dev/null || true)
+    t_total=${t_total:-0}
+    t_done=${t_done:-0}
+    t_failed=${t_failed:-0}
+  fi
+  local build_status="done"
+  if ! $tests_passed || ! $lint_passed || ! $build_passed || [[ "$t_failed" -gt 0 ]]; then
+    build_status="failed"
+  fi
+  record_phase "$specclaw_dir" "$change_name" build "$build_status" --tasks "${t_done}/${t_total}/${t_failed}"
 
   # Build errors JSON array
   local errors_json="[]"

--- a/plugins/specclaw/bin/specclaw-pr
+++ b/plugins/specclaw/bin/specclaw-pr
@@ -435,53 +435,85 @@ EOF
 
 # ─── Save PR URL ──────────────────────────────────────────────────────────────
 
+# record_pr_phase <url> — hand the phase decision to the one writer that owns it.
+#
+# specclaw-set-phase records `pr`/`raised` in state.json and reflects the row
+# into status.md through specclaw-status-row — the same awk upsert this file
+# used to invoke directly, now one level down, so "what phase is this change in"
+# has exactly one answer and one author.
+#
+# Exit codes: 0 recorded, 3 refused as a backwards transition, anything else a
+# real failure. A 3 is an expected outcome, not a problem — re-running
+# specclaw-pr on a change already recorded past `pr` hits it — so it is reported
+# as a plain note on stdout, while a real failure goes to stderr as a WARNING.
+# Neither is fatal: by the time this runs the PR exists on the remote, so the
+# function never returns non-zero (FR9).
+record_pr_phase() {
+  local url="$1"
+  local set_phase_script="$SCRIPT_DIR/specclaw-set-phase"
+  local rc=0
+
+  if [[ ! -x "$set_phase_script" ]]; then
+    warn "specclaw-set-phase not found at $set_phase_script — phase not recorded (PR is live at $url)"
+    return 0
+  fi
+
+  "$set_phase_script" "$SPECCLAW_DIR" "$CHANGE_NAME" pr raised --url "$url" || rc=$?
+  case "$rc" in
+    0) ;;
+    3) echo "  (phase already recorded at or past 'pr' — leaving it as is)" ;;
+    *) warn "specclaw-set-phase exited $rc — PR phase not recorded (PR is live at $url)" ;;
+  esac
+  return 0
+}
+
+# Everything here runs after `gh pr create`, so every step is bookkeeping against
+# a PR that already exists. Each one is individually guarded and the function
+# always returns 0: an abort here is what used to freeze every tracker at its
+# pre-PR state while the URL was still printed, so the failure read as a success
+# (FR9/AC11).
 save_pr_url() {
   local url="$1"
   local status_file="$CHANGE_DIR/status.md"
   local today
   today="$(date +%Y-%m-%d)"
 
+  # First, because set-phase self-heals a missing status.md from the template;
+  # the simple-format fixups below then have a real file to edit.
+  record_pr_phase "$url"
+
   if [[ ! -f "$status_file" ]]; then
-    cat > "$status_file" <<EOF
+    # set-phase could not run, or found no template. Keep the minimal file this
+    # script has always written rather than lose the URL.
+    cat > "$status_file" <<EOF || warn "could not create $status_file (PR is live at $url)"
 # Status: ${CHANGE_NAME}
 
 **Status:** pr-raised
 **PR:** $url
 **Last Updated:** $today
 EOF
-    return
+    return 0
   fi
 
   # Update **Last Updated:** if present, otherwise append it
   if grep -q '^\*\*Last Updated:\*\*' "$status_file"; then
-    sed_i "s|^\*\*Last Updated:\*\*.*|**Last Updated:** $today|" "$status_file"
+    sed_i "s|^\*\*Last Updated:\*\*.*|**Last Updated:** $today|" "$status_file" || \
+      warn "could not refresh the Last Updated line in $status_file"
   fi
 
   # Update **Status:** field (simple format) to pr-raised if present
   if grep -q '^\*\*Status:\*\*' "$status_file"; then
-    sed_i "s|^\*\*Status:\*\*.*|**Status:** pr-raised|" "$status_file"
+    sed_i "s|^\*\*Status:\*\*.*|**Status:** pr-raised|" "$status_file" || \
+      warn "could not refresh the Status line in $status_file"
   fi
 
-  # Upsert the PR row in the Progress table. Delegated to specclaw-status-row,
-  # which edits the row in awk: the table is pipe-delimited, and sed cannot be
-  # trusted with pipes here — `\|` in a BRE address is *alternation* (the old
-  # `/^\|…Verify…\|/a` matched every line and appended 33 PR rows to a stock
-  # status.md), and `s|…| *PR *|…|` collides with its own delimiter
-  # (`sed: unknown option to 's'`, which under `set -e` killed this script
-  # immediately after the PR was created — see the change log for the report).
-  local status_row_script="$SCRIPT_DIR/specclaw-status-row"
-  if [[ -x "$status_row_script" ]]; then
-    "$status_row_script" "$status_file" "PR" "✅ Raised" "$url" || \
-      warn "could not update the PR row in $status_file (PR itself is created)"
-  elif ! grep -qE '^\|[[:space:]]*PR[[:space:]]*\|' "$status_file"; then
-    # Helper missing (partial install) — never lose the URL.
-    echo "**PR:** $url" >> "$status_file"
-  fi
-
-  # If PR URL line doesn't exist yet (non-table simple format), ensure it's present
+  # Last net: with set-phase or status-row missing (partial install) neither a
+  # `| PR |` row nor a `**PR:**` line will have been written. Never lose the URL.
   if ! grep -q '^\*\*PR:\*\*' "$status_file" && ! grep -qE '^\|[[:space:]]*PR[[:space:]]*\|' "$status_file"; then
-    echo "**PR:** $url" >> "$status_file"
+    echo "**PR:** $url" >> "$status_file" || \
+      warn "could not append the PR URL to $status_file (PR is live at $url)"
   fi
+  return 0
 }
 
 # ─── Version Bump ─────────────────────────────────────────────────────────────

--- a/plugins/specclaw/bin/specclaw-reconcile
+++ b/plugins/specclaw/bin/specclaw-reconcile
@@ -1,0 +1,619 @@
+#!/usr/bin/env bash
+# specclaw-reconcile — does the recorded phase still match observable reality?
+# Usage: specclaw-reconcile <specclaw_dir> [<change>] [--fix]
+#
+# `specclaw-set-phase` records the phase; nothing guarantees the record stays
+# true. A build finishes in a session that crashed before the transition, a PR
+# is opened by hand, a verify report lands from a loop turn — and the tracker
+# quietly lies again. keyflow needed a 110-proposal audit to find 104 already
+# shipped entries still marked active. This is that audit as a script (FR8).
+#
+# Four dimensions are observed per change:
+#
+#   tasks   `tasks.md` markers, the same three greps specclaw-update-status
+#           uses: `^- [x]` done, `^- [!]` failed, `^- [` total.
+#   verify  `verify-report.md` presence, and its verdict when parseable.
+#   pr      `gh pr list --head <branch>` on the branch **recorded in
+#           state.json**. Never `${branch_prefix}${change}` — that guess is
+#           wrong in this very repo and a wrong branch reads as "no PR".
+#   git     does the recorded branch actually exist (local or remote ref).
+#
+# The one property worth stating twice: **a dimension that could not be
+# observed is `unknown`, never a negative finding.** `gh` missing, `gh`
+# failing, `gh` unauthenticated, `gh` timing out, no branch recorded — all
+# `unknown`. `--fix` refuses to act on an `unknown` dimension and prints what
+# it skipped and why. Read the other way round, a laptop with no network would
+# see "no PR" everywhere and cheerfully regress every correct state it found:
+# strictly worse than the drift it was sent to fix (Assumption 3, AC10).
+#
+# `--fix` adopts reality by calling `specclaw-set-phase`, never by writing
+# state.json itself. One writer is the entire point of this change, and it is
+# also what makes `--fix` safe by construction: set-phase refuses a backwards
+# transition, so no finding here can silently downgrade a recorded phase.
+#
+# Exit status:
+#   0  report mode: everything agrees (or the change is unmanaged)
+#      --fix mode:  every actionable finding was applied
+#   1  report mode: drift found
+#      --fix mode:  a set-phase call failed
+#   2  usage error
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Same rank order as specclaw-set-phase; position in the list *is* the rank.
+PHASE_ORDER=(proposal spec design tasks build verify pr archived)
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-reconcile <specclaw_dir> [<change>] [--fix]
+
+  specclaw_dir  path to the .specclaw directory
+  change        limit the audit to one change (default: every active change)
+
+Options:
+  --fix         adopt observed reality via specclaw-set-phase; skips any
+                dimension that could not be observed and says which
+  -h, --help    show this message
+
+Exits non-zero when drift is found (report mode) or when a fix failed.
+EOF
+}
+
+die() {
+  echo "specclaw-reconcile: $*" >&2
+  exit 2
+}
+
+# ─── Arguments ───────────────────────────────────────────────────────────────
+
+SPECCLAW_DIR=""
+ONLY_CHANGE=""
+FIX=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --fix) FIX=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    --) shift ;;
+    -*) die "unknown option: $1
+
+$(usage)" ;;
+    *)
+      if [ -z "$SPECCLAW_DIR" ]; then
+        SPECCLAW_DIR="$1"
+      elif [ -z "$ONLY_CHANGE" ]; then
+        ONLY_CHANGE="$1"
+      else
+        die "unexpected argument: $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -n "$SPECCLAW_DIR" ] || {
+  usage
+  exit 0
+}
+[ -d "$SPECCLAW_DIR" ] || die "no such specclaw dir: ${SPECCLAW_DIR}"
+
+CHANGES_DIR="${SPECCLAW_DIR}/changes"
+[ -d "$CHANGES_DIR" ] || die "no changes directory under ${SPECCLAW_DIR}"
+
+# The repo the specclaw dir lives in, for the local-only git dimension.
+REPO_DIR="$(cd "${SPECCLAW_DIR}/.." 2>/dev/null && pwd)" || REPO_DIR=""
+
+SET_PHASE="${SCRIPT_DIR}/specclaw-set-phase"
+[ -x "$SET_PHASE" ] || SET_PHASE="$(command -v specclaw-set-phase 2>/dev/null || true)"
+
+# ─── Reading state ───────────────────────────────────────────────────────────
+# Third copy of the reader shared with specclaw-set-phase and
+# specclaw-update-status, kept byte-identical on purpose: these scripts are
+# installed as standalone executables with no sourcing convention between them,
+# and a second *behaviour* for reading state.json is exactly the divergence this
+# change exists to remove. Any edit here belongs in all three.
+
+# state_field <file> <dotted.path> — jq when installed, else python3; neither is
+# required. Any failure — no file, bad JSON, absent key — prints nothing.
+state_field() {
+  local file="$1" path="$2"
+  [ -f "$file" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -rc ".${path} // empty" "$file" 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys
+try:
+    v = json.load(open(sys.argv[1]))
+    for k in sys.argv[2].split("."):
+        v = v[k]
+except Exception:
+    sys.exit(0)
+if v is None:
+    sys.exit(0)
+sys.stdout.write(v if isinstance(v, str) else json.dumps(v, separators=(",", ":"), ensure_ascii=False))
+' "$file" "$path" 2>/dev/null || true
+  fi
+}
+
+# state_str <file> <path> — a state_field read reduced to its first line, so a
+# stray newline in the JSON can break neither a report row nor a `gh` argument.
+state_str() {
+  local v
+  v="$(state_field "$1" "$2")"
+  printf '%s' "${v%%$'\n'*}"
+}
+
+# True when the file parses. With neither interpreter installed nothing can be
+# read anyway, so it reports parseable and the empty reads take the fallback.
+state_parses() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -e . "$1" >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$1" >/dev/null 2>&1
+  fi
+}
+
+phase_rank() {
+  local want="$1" i
+  for i in "${!PHASE_ORDER[@]}"; do
+    [ "${PHASE_ORDER[$i]}" = "$want" ] && { printf '%s' "$i"; return 0; }
+  done
+  return 1
+}
+
+BUILD_RANK="$(phase_rank build)"
+
+# ─── Observers ───────────────────────────────────────────────────────────────
+
+# Bounded invocation (NFR5): no observation may stall the audit. `gh` on a dead
+# network is the realistic hang, and a hang here reads as a broken tool rather
+# than as the `unknown` it actually is.
+bounded() {
+  if command -v timeout >/dev/null 2>&1; then timeout 10 "$@"; else "$@"; fi
+}
+
+# obs_tasks <change_dir> → T_DONE T_TOTAL T_FAILED, and T_PRESENT.
+T_DONE=0 T_TOTAL=0 T_FAILED=0 T_PRESENT=0
+obs_tasks() {
+  local f="$1/tasks.md"
+  T_DONE=0 T_TOTAL=0 T_FAILED=0 T_PRESENT=0
+  [ -f "$f" ] || return 0
+  T_PRESENT=1
+  T_TOTAL=$(grep -c '^\- \[' "$f" 2>/dev/null || true)
+  T_DONE=$(grep -c '^\- \[x\]' "$f" 2>/dev/null || true)
+  T_FAILED=$(grep -c '^\- \[!\]' "$f" 2>/dev/null || true)
+  T_TOTAL=${T_TOTAL:-0} T_DONE=${T_DONE:-0} T_FAILED=${T_FAILED:-0}
+}
+
+# obs_verify <change_dir> → V_PRESENT, V_VERDICT ("" when unparseable).
+# Both report shapes in the wild are accepted: the template's `**Verdict:** X`
+# and the heading `## Verdict: X` that specclaw-verify actually emits. The
+# verdict is matched against the known set rather than "first word", so a
+# decorated line (`## Verdict: ✅ PASS`) still reads correctly.
+V_PRESENT=0 V_VERDICT=""
+obs_verify() {
+  local f="$1/verify-report.md" line
+  V_PRESENT=0 V_VERDICT=""
+  [ -f "$f" ] || return 0
+  V_PRESENT=1
+  line="$(grep -m1 -E '^(\*\*Verdict:\*\*|##[[:space:]]*Verdict:)' "$f" 2>/dev/null || true)"
+  [ -n "$line" ] || return 0
+  V_VERDICT="$(printf '%s' "$line" | tr '[:lower:]' '[:upper:]' |
+    grep -o -E 'PARTIAL|PASS|FAIL' | head -1 || true)"
+}
+
+# obs_pr <branch> → PR_OBS (unknown|none|open|merged|closed), PR_NUM, PR_URL,
+# PR_REASON. Everything that is not a *successful* lookup returning rows is
+# `unknown`; only a successful, empty lookup is `none` (AC10).
+PR_OBS="unknown" PR_NUM="" PR_URL="" PR_REASON=""
+obs_pr() {
+  local branch="$1" rows="" rc=0 newest=""
+  PR_OBS="unknown" PR_NUM="" PR_URL="" PR_REASON=""
+
+  if [ -z "$branch" ]; then
+    PR_REASON="no branch recorded in state.json; refusing to guess one"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    PR_REASON="gh is not installed"
+    return 0
+  fi
+
+  rows="$(bounded gh pr list --head "$branch" --state all --limit 20 \
+    --json number,state,updatedAt,url \
+    --template '{{range .}}{{.updatedAt}} {{.number}} {{.state}} {{.url}}{{"\n"}}{{end}}' 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # 124 is timeout(1)'s. Everything else is gh: no auth, no remote, no
+    # network, rate limit. None of them means "no PR".
+    if [ "$rc" -eq 124 ]; then
+      PR_REASON="gh timed out after 10s"
+    else
+      PR_REASON="gh exited ${rc} (offline, unauthenticated, or no GitHub remote)"
+    fi
+    return 0
+  fi
+
+  # ISO-8601 sorts lexically, so `sort -r | head -1` is the most recent PR.
+  newest="$(printf '%s' "$rows" | tr '\t' ' ' | grep -v '^[[:space:]]*$' | sort -r | head -1 || true)"
+  if [ -z "$newest" ]; then
+    PR_OBS="none"
+    return 0
+  fi
+  # shellcheck disable=SC2086  # deliberate split of "<ts> <num> <state> <url>"
+  set -- $newest
+  if [ "$#" -lt 3 ]; then
+    PR_REASON="gh returned a row this script could not parse: ${newest}"
+    return 0
+  fi
+  PR_NUM="$2"
+  PR_OBS="$(printf '%s' "$3" | tr '[:upper:]' '[:lower:]')"
+  PR_URL="${4:-}"
+}
+
+# obs_git <branch> → G_OBS (unknown|present|missing), G_REASON. Local refs only:
+# a `git ls-remote` here would be a second network call with the same failure
+# modes, and the question "does this branch exist" is answerable offline.
+G_OBS="unknown" G_REASON=""
+obs_git() {
+  local branch="$1"
+  G_OBS="unknown" G_REASON=""
+  if [ -z "$branch" ]; then
+    G_REASON="no branch recorded in state.json"
+    return 0
+  fi
+  if [ -z "$REPO_DIR" ] || ! command -v git >/dev/null 2>&1 ||
+    ! git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    G_REASON="${REPO_DIR:-.} is not a git work tree"
+    return 0
+  fi
+  if git -C "$REPO_DIR" show-ref --verify --quiet "refs/heads/${branch}" ||
+    git -C "$REPO_DIR" show-ref --quiet "refs/remotes/origin/${branch}"; then
+    G_OBS="present"
+  else
+    G_OBS="missing"
+  fi
+}
+
+# ─── Report plumbing ─────────────────────────────────────────────────────────
+
+row() { printf '    %-8s %s\n' "$1" "$2"; }
+
+DRIFTS=()
+UNKNOWNS=()
+drift() {
+  DRIFTS+=("$1|$2")
+}
+unknown() {
+  UNKNOWNS+=("$1|$2")
+}
+
+CHANGE=""
+EXAMINED=0
+DRIFTED=0
+UNMANAGED=0
+FIX_FAILED=0
+FIX_APPLIED=0
+
+# run_set_phase <phase> <status> [opts…] — the only mutation this script makes.
+run_set_phase() {
+  local out=""
+  if [ -z "$SET_PHASE" ] || [ ! -x "$SET_PHASE" ]; then
+    printf '    %-8s %s\n' "FAILED" "specclaw-set-phase not found; cannot apply anything"
+    FIX_FAILED=$((FIX_FAILED + 1))
+    return 1
+  fi
+  printf '    %-8s specclaw-set-phase … %s\n' "FIX" "$*"
+  if out="$("$SET_PHASE" "$SPECCLAW_DIR" "$CHANGE" "$@" 2>&1)"; then
+    FIX_APPLIED=$((FIX_APPLIED + 1))
+    return 0
+  fi
+  printf '    %-8s %s\n' "FAILED" "${out%%$'\n'*}"
+  FIX_FAILED=$((FIX_FAILED + 1))
+  return 1
+}
+
+# ─── Per-change audit ────────────────────────────────────────────────────────
+
+reconcile_one() {
+  local change_dir="$1"
+  CHANGE="$(basename "$change_dir")"
+  EXAMINED=$((EXAMINED + 1))
+  DRIFTS=()
+  UNKNOWNS=()
+
+  local state_file="${change_dir}/state.json"
+  local rec_phase="" rec_branch="" rec_pr_url="" rec_pr_status="" rec_verdict=""
+  local rec_done="" rec_total="" rec_failed=""
+  local unreadable=0 unmanaged=0
+
+  if [ ! -f "$state_file" ]; then
+    unmanaged=1
+  elif [ -r "$state_file" ] && state_parses "$state_file"; then
+    rec_phase="$(state_str "$state_file" phase)"
+    rec_branch="$(state_str "$state_file" branch)"
+    rec_pr_url="$(state_str "$state_file" phases.pr.url)"
+    rec_pr_status="$(state_str "$state_file" phases.pr.status)"
+    rec_verdict="$(state_str "$state_file" phases.verify.verdict)"
+    rec_done="$(state_str "$state_file" phases.build.tasks.done)"
+    rec_total="$(state_str "$state_file" phases.build.tasks.total)"
+    rec_failed="$(state_str "$state_file" phases.build.tasks.failed)"
+  else
+    unreadable=1
+  fi
+
+  obs_tasks "$change_dir"
+  obs_verify "$change_dir"
+  obs_pr "$rec_branch"
+  obs_git "$rec_branch"
+
+  # Observed phase: the highest rank reality supports. Artefacts on disk carry
+  # the early phases; the later ones need an actual observation.
+  local obs_phase=""
+  [ -f "${change_dir}/proposal.md" ] && obs_phase="proposal"
+  [ -f "${change_dir}/spec.md" ] && obs_phase="spec"
+  [ -f "${change_dir}/design.md" ] && obs_phase="design"
+  [ "$T_PRESENT" -eq 1 ] && obs_phase="tasks"
+  [ "$T_PRESENT" -eq 1 ] && [ "$T_DONE" -gt 0 ] && obs_phase="build"
+  [ "$V_PRESENT" -eq 1 ] && obs_phase="verify"
+  case "$PR_OBS" in open | merged | closed) obs_phase="pr" ;; esac
+
+  # Rank -1 means "nothing recorded / nothing observed", which is below every
+  # real phase — so an unrecorded or unrecognised phase constrains nothing and
+  # any observation counts as forward progress.
+  local rec_rank=-1 obs_rank=-1
+  if [ -n "$rec_phase" ]; then rec_rank="$(phase_rank "$rec_phase")" || rec_rank=-1; fi
+  if [ -n "$obs_phase" ]; then obs_rank="$(phase_rank "$obs_phase")" || obs_rank=-1; fi
+
+  # ── the report block ──
+  echo
+  echo "▸ ${CHANGE}"
+  if [ "$unmanaged" -eq 1 ]; then
+    row "state" "unmanaged — no state.json (renders via checkbox inference, FR7)"
+  elif [ "$unreadable" -eq 1 ]; then
+    row "state" "unreadable — state.json exists but does not parse"
+  else
+    row "state" "phase=${rec_phase:-<none>}  branch=${rec_branch:-<none>}"
+  fi
+
+  if [ "$T_PRESENT" -eq 1 ]; then
+    row "tasks" "${T_DONE}/${T_TOTAL} done, ${T_FAILED} failed"
+  else
+    row "tasks" "none — no tasks.md"
+  fi
+  if [ "$V_PRESENT" -eq 1 ]; then
+    row "verify" "verify-report.md present${V_VERDICT:+, verdict ${V_VERDICT}}"
+  else
+    row "verify" "none — no verify-report.md"
+  fi
+  case "$PR_OBS" in
+    unknown) row "pr" "unknown — ${PR_REASON}" ;;
+    none) row "pr" "none — gh finds no PR on '${rec_branch}'" ;;
+    *) row "pr" "#${PR_NUM} ${PR_OBS}${PR_URL:+ (${PR_URL})}" ;;
+  esac
+  case "$G_OBS" in
+    unknown) row "git" "unknown — ${G_REASON}" ;;
+    present) row "git" "branch '${rec_branch}' exists" ;;
+    missing) row "git" "branch '${rec_branch}' not found locally or on origin" ;;
+  esac
+  row "observed" "${obs_phase:-<nothing observable>}"
+
+  # An unmanaged change is the FR7 fallback case, not an error and not drift:
+  # there is no record for reality to contradict. Reported, then left alone —
+  # `--fix` inventing a state.json here would change how STATUS.md renders it
+  # (AC6) as a side effect of an audit.
+  if [ "$unmanaged" -eq 1 ]; then
+    UNMANAGED=$((UNMANAGED + 1))
+    row "result" "no drift (unmanaged)"
+    return 0
+  fi
+
+  # ── findings ──
+  local d_tasks=0 d_verify=0 d_pr=0 d_git=0
+
+  if [ "$unreadable" -eq 1 ]; then
+    drift "state" "state.json does not parse; nothing recorded can be trusted"
+  fi
+
+  if [ "$obs_rank" -gt "$rec_rank" ]; then
+    drift "phase" "state.json says '${rec_phase:-<none>}'; observation supports '${obs_phase}'"
+  fi
+
+  # Task counts only mean something once a build record exists to disagree with.
+  if [ "$T_PRESENT" -eq 1 ] && [ -n "$rec_total" ]; then
+    if [ "$rec_done" != "$T_DONE" ] || [ "$rec_total" != "$T_TOTAL" ] || [ "$rec_failed" != "$T_FAILED" ]; then
+      d_tasks=1
+      drift "tasks" "state.json records ${rec_done}/${rec_total} (${rec_failed} failed); tasks.md shows ${T_DONE}/${T_TOTAL} (${T_FAILED} failed)"
+    fi
+  fi
+
+  if [ "$V_PRESENT" -eq 1 ] && [ -n "$V_VERDICT" ] && [ -n "$rec_verdict" ] && [ "$V_VERDICT" != "$rec_verdict" ]; then
+    d_verify=1
+    drift "verify" "state.json records verdict '${rec_verdict}'; verify-report.md says '${V_VERDICT}'"
+  fi
+
+  case "$PR_OBS" in
+    unknown)
+      unknown "pr" "$PR_REASON"
+      ;;
+    none)
+      if [ -n "$rec_pr_url" ] || [ "$rec_phase" = "pr" ]; then
+        d_pr=1
+        drift "pr" "state.json records a PR (${rec_pr_url:-no url}); gh finds none on '${rec_branch}'"
+      fi
+      ;;
+    *)
+      if [ -z "$rec_pr_url" ]; then
+        d_pr=1
+        drift "pr" "PR #${PR_NUM} is ${PR_OBS} on '${rec_branch}'; state.json records no PR"
+      elif [ -n "$PR_URL" ] && [ "$rec_pr_url" != "$PR_URL" ]; then
+        d_pr=1
+        drift "pr" "state.json records ${rec_pr_url}; gh reports ${PR_URL}"
+      elif [ "$PR_OBS" = "merged" ] && [ "$rec_pr_status" != "merged" ]; then
+        d_pr=1
+        drift "pr" "PR #${PR_NUM} is merged; state.json still records it as '${rec_pr_status}'"
+      fi
+      ;;
+  esac
+
+  case "$G_OBS" in
+    unknown) [ -n "$rec_branch" ] && unknown "git" "$G_REASON" ;;
+    missing)
+      d_git=1
+      drift "git" "recorded branch '${rec_branch}' does not exist locally or on origin"
+      ;;
+  esac
+
+  local f
+  for f in "${DRIFTS[@]+"${DRIFTS[@]}"}"; do
+    printf '    %-8s %-7s %s\n' "DRIFT" "${f%%|*}" "${f#*|}"
+  done
+
+  local has_drift=0
+  [ "${#DRIFTS[@]}" -gt 0 ] && has_drift=1
+  [ "$has_drift" -eq 1 ] && DRIFTED=$((DRIFTED + 1))
+
+  if [ "$FIX" -eq 0 ]; then
+    if [ "$has_drift" -eq 0 ]; then
+      row "result" "no drift"
+    else
+      row "result" "${#DRIFTS[@]} finding(s) — rerun with --fix to adopt what was observed"
+    fi
+    return 0
+  fi
+
+  # ── --fix ──
+  # Never acts on an unknown, ever. Printed first so the skip is visible even
+  # when the fix below succeeds and scrolls the eye past it.
+  for f in "${UNKNOWNS[@]+"${UNKNOWNS[@]}"}"; do
+    printf '    %-8s %-7s %s\n' "SKIP" "${f%%|*}" \
+      "observation is 'unknown' (${f#*|}); --fix never acts on an unobserved dimension and never clears a recorded PR from one"
+  done
+
+  if [ "$has_drift" -eq 0 ]; then
+    row "result" "no drift; nothing to fix"
+    return 0
+  fi
+
+  # Step 1 — refresh the build record, but only while the recorded phase is
+  # still at or below build. Past it, rewriting the build row would be a
+  # backwards transition, and reconcile does not pass --force.
+  local bstatus="in-progress"
+  if [ "$T_FAILED" -gt 0 ]; then
+    bstatus="failed"
+  elif [ "$T_TOTAL" -gt 0 ] && [ "$T_DONE" -eq "$T_TOTAL" ]; then
+    bstatus="done"
+  fi
+
+  if [ "$d_tasks" -eq 1 ]; then
+    if [ "$rec_rank" -le "$BUILD_RANK" ]; then
+      run_set_phase build "$bstatus" --tasks "${T_DONE}/${T_TOTAL}/${T_FAILED}"
+    else
+      printf '    %-8s %-7s %s\n' "SKIP" "tasks" \
+        "recorded phase '${rec_phase}' is past build; refreshing the build record would be a backwards transition — run specclaw-set-phase --force deliberately"
+    fi
+  fi
+
+  # Step 2 — adopt the observed phase, if it is forward of the recorded one, or
+  # refresh the current one when it is the current phase's own detail that drifted.
+  local target="$rec_phase" advance=0
+  if [ "$obs_rank" -gt "$rec_rank" ]; then
+    target="$obs_phase"
+    advance=1
+  elif [ "$rec_phase" = "verify" ] && [ "$d_verify" -eq 1 ]; then
+    advance=1
+  elif [ "$rec_phase" = "pr" ] && [ "$d_pr" -eq 1 ]; then
+    case "$PR_OBS" in
+      open | merged | closed) advance=1 ;;
+      *)
+        printf '    %-8s %-7s %s\n' "SKIP" "pr" \
+          "gh finds no PR on '${rec_branch}'; clearing a recorded PR is a downgrade reconcile will not make automatically"
+        ;;
+    esac
+  fi
+
+  if [ "$advance" -eq 1 ]; then
+    case "$target" in
+      build)
+        # Already applied by step 1 unless the counts happened to agree.
+        if [ "$d_tasks" -eq 0 ]; then
+          run_set_phase build "$bstatus" --tasks "${T_DONE}/${T_TOTAL}/${T_FAILED}"
+        fi
+        ;;
+      verify)
+        local vstatus="done"
+        case "$V_VERDICT" in
+          PASS) vstatus="passed" ;;
+          FAIL) vstatus="failed" ;;
+          PARTIAL) vstatus="partial" ;;
+        esac
+        if [ -n "$V_VERDICT" ]; then
+          run_set_phase verify "$vstatus" --verdict "$V_VERDICT"
+        else
+          run_set_phase verify "$vstatus"
+        fi
+        ;;
+      pr)
+        local pstatus="raised"
+        [ "$PR_OBS" = "merged" ] && pstatus="merged"
+        [ "$PR_OBS" = "closed" ] && pstatus="closed"
+        if [ -n "$PR_URL" ]; then
+          run_set_phase pr "$pstatus" --url "$PR_URL"
+        else
+          run_set_phase pr "$pstatus"
+        fi
+        ;;
+      proposal | spec | design | tasks)
+        run_set_phase "$target" done
+        ;;
+      *)
+        printf '    %-8s %-7s %s\n' "SKIP" "phase" "no fix defined for target phase '${target}'"
+        ;;
+    esac
+  fi
+
+  if [ "$d_git" -eq 1 ]; then
+    printf '    %-8s %-7s %s\n' "SKIP" "git" \
+      "reconcile does not create, rename, or re-record branches; fix with specclaw-set-phase --branch"
+  fi
+
+  # Nothing may drift *and* pass in silence: a --fix run that found drift and
+  # applied nothing has to say so, or the operator reads the zero exit as "clean".
+  if [ "$advance" -eq 0 ] && [ "$d_tasks" -eq 0 ]; then
+    row "result" "${#DRIFTS[@]} finding(s) found, none applied — see the SKIP lines above"
+  fi
+  return 0
+}
+
+# ─── Drive ───────────────────────────────────────────────────────────────────
+
+echo "specclaw-reconcile: ${SPECCLAW_DIR}${ONLY_CHANGE:+ (change: ${ONLY_CHANGE})}"
+if [ "$FIX" -eq 1 ]; then
+  echo "mode: --fix (adopting observed reality via specclaw-set-phase)"
+fi
+
+if [ -n "$ONLY_CHANGE" ]; then
+  [ "$ONLY_CHANGE" = "archive" ] && die "'archive' is not a change"
+  [ -d "${CHANGES_DIR}/${ONLY_CHANGE}" ] || die "no such change: ${ONLY_CHANGE}"
+  reconcile_one "${CHANGES_DIR}/${ONLY_CHANGE}"
+else
+  for d in "$CHANGES_DIR"/*/; do
+    [ -d "$d" ] || continue
+    # Edge case 7: archived changes are terminal. state.json travels with the
+    # directory but nothing under archive/ is worth auditing.
+    [ "$(basename "$d")" = "archive" ] && continue
+    reconcile_one "$d"
+  done
+fi
+
+echo
+echo "─────────────────────────────"
+if [ "$FIX" -eq 1 ]; then
+  echo "examined: ${EXAMINED}   unmanaged: ${UNMANAGED}   with drift: ${DRIFTED}   fixes applied: ${FIX_APPLIED}   failed: ${FIX_FAILED}"
+  [ "$FIX_FAILED" -eq 0 ] || exit 1
+  exit 0
+fi
+echo "examined: ${EXAMINED}   unmanaged: ${UNMANAGED}   with drift: ${DRIFTED}"
+[ "$DRIFTED" -eq 0 ] || exit 1
+exit 0

--- a/plugins/specclaw/bin/specclaw-reconcile
+++ b/plugins/specclaw/bin/specclaw-reconcile
@@ -565,7 +565,8 @@ reconcile_one() {
         fi
         ;;
       proposal | spec | design | tasks)
-        run_set_phase "$target" done
+        # 'done' quoted: bare, bash parses it as the loop keyword (SC1010).
+        run_set_phase "$target" "done"
         ;;
       *)
         printf '    %-8s %-7s %s\n' "SKIP" "phase" "no fix defined for target phase '${target}'"

--- a/plugins/specclaw/bin/specclaw-set-phase
+++ b/plugins/specclaw/bin/specclaw-set-phase
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# specclaw-set-phase — the only writer of a change's phase.
+# Usage: specclaw-set-phase <specclaw_dir> <change> <phase> <status> [options]
+#
+# Phase used to be *derived* — from tasks.md checkbox counts and a `gh pr list`
+# guess — and edited from half a dozen call sites, so trackers lied: a change
+# with an open PR rendered as 🔨 build. This script records the phase once, in
+# `changes/<change>/state.json`, and then reflects it into the human-readable
+# `status.md`. Every other script reads; only this one writes.
+#
+# Four choices worth explaining:
+#
+#   1. Atomic write. The document is built in a temp file *inside the change
+#      directory* (so the final `mv` is a same-filesystem rename, not a copy),
+#      validated as parseable JSON, and only then moved over the target. A crash
+#      mid-write leaves the previous state.json intact. Two racing writers mean
+#      the loser's write is lost — never a corrupt file. Not locked, by design.
+#
+#   2. The status.md row is delegated to `specclaw-status-row`, never edited
+#      here. The Progress table is pipe-delimited and `sed` cannot be trusted
+#      with pipes (a `\|` in a BRE address is alternation, and `s|…| *PR *|…|`
+#      collides with its own delimiter) — that bug appended 33 PR rows to a
+#      stock status.md and killed specclaw-pr under `set -e`. status-row does
+#      the edit in awk, collapses duplicates, and leaves every other line
+#      byte-identical, which is what keeps the `GitHub Issue` / `Jira Issue` /
+#      Work Item lines that three integration scripts grep for untouched.
+#
+#   3. Per-phase records are emitted on one compact line each. A carried-over
+#      record is re-emitted exactly as it was read (jq -c and python's json.dumps
+#      agree on that form), so re-running a transition cannot reflow the file.
+#      For the same reason `at` is *preserved* when the rest of the record is
+#      unchanged: idempotency (FR3) beats a fresh-but-meaningless timestamp.
+#      A changed status/verdict/url/tasks does refresh it.
+#
+#   4. Monotonic, not strict. Phases may be re-entered (re-verify after a loop
+#      fix is normal); only a move to a *lower* rank is refused, and `--force`
+#      overrides. Every read is fail-open: unreadable or malformed state never
+#      blocks a transition, it just means no constraint to check.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Rank order for the monotonicity check (FR3). Position in this list *is* the rank.
+PHASE_ORDER=(proposal spec design tasks build verify pr archived)
+
+usage() {
+  cat <<'EOF'
+Usage: specclaw-set-phase <specclaw_dir> <change> <phase> <status> [options]
+
+  specclaw_dir  path to the .specclaw directory
+  change        change name (directory under changes/)
+  phase         one of: proposal spec design tasks build verify pr archived
+  status        free-form, e.g. approved | done | passed | failed | raised
+
+Options:
+  --note S              extra text for the status.md Notes column
+  --url U               PR/issue URL (recorded and shown in Notes)
+  --verdict V           verify verdict, e.g. PASS | FAIL | PARTIAL
+  --branch B            the real branch name for this change
+  --tasks done/total/failed
+                        task counts, e.g. 7/11/0
+  --force               allow a transition to an earlier phase
+  -h, --help            show this message
+EOF
+}
+
+die() {
+  echo "specclaw-set-phase: $*" >&2
+  exit 2
+}
+warn() { echo "specclaw-set-phase: WARN: $*" >&2; }
+
+# ─── Argument parsing ────────────────────────────────────────────────────────
+
+case "${1:-}" in
+  -h | --help | '')
+    usage
+    exit 0
+    ;;
+esac
+
+SPECCLAW_DIR="$1"
+CHANGE="${2:-}"
+PHASE="${3:-}"
+STATUS="${4:-}"
+shift 4 2>/dev/null || die "missing required arguments
+
+$(usage)"
+
+NOTE=""
+URL=""
+VERDICT=""
+BRANCH=""
+TASKS=""
+FORCE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --note) NOTE="${2:-}"; shift 2 || die "--note needs a value" ;;
+    --url) URL="${2:-}"; shift 2 || die "--url needs a value" ;;
+    --verdict) VERDICT="${2:-}"; shift 2 || die "--verdict needs a value" ;;
+    --branch) BRANCH="${2:-}"; shift 2 || die "--branch needs a value" ;;
+    --tasks) TASKS="${2:-}"; shift 2 || die "--tasks needs a value" ;;
+    --force) FORCE=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$CHANGE" ] || die "change name is required"
+[ -n "$PHASE" ] || die "phase is required"
+[ -n "$STATUS" ] || die "status is required"
+
+# Edge case 8: an unknown phase would write state nothing can render, so reject
+# it here rather than later.
+phase_rank() {
+  local want="$1" i
+  for i in "${!PHASE_ORDER[@]}"; do
+    [ "${PHASE_ORDER[$i]}" = "$want" ] && { printf '%s' "$i"; return 0; }
+  done
+  return 1
+}
+
+NEW_RANK="$(phase_rank "$PHASE")" || die "unknown phase: ${PHASE}
+valid phases: ${PHASE_ORDER[*]}"
+
+T_DONE=""
+T_TOTAL=""
+T_FAILED=""
+if [ -n "$TASKS" ]; then
+  [[ "$TASKS" =~ ^[0-9]+/[0-9]+/[0-9]+$ ]] || die "--tasks must be done/total/failed, e.g. 7/11/0 (got: ${TASKS})"
+  IFS='/' read -r T_DONE T_TOTAL T_FAILED <<<"$TASKS"
+fi
+
+CHANGE_DIR="${SPECCLAW_DIR}/changes/${CHANGE}"
+STATE_FILE="${CHANGE_DIR}/state.json"
+STATUS_FILE="${CHANGE_DIR}/status.md"
+
+[ -d "$SPECCLAW_DIR" ] || die "no such specclaw dir: ${SPECCLAW_DIR}"
+
+# ─── Reading state ───────────────────────────────────────────────────────────
+
+# state_field <file> <dotted.path> — the single read path (FR7). Uses jq when
+# installed, else python3; both are CI dependencies, neither is required. Any
+# failure — no file, bad JSON, absent key — prints nothing and exits 0, so a
+# broken state file degrades to "no recorded state" instead of an error.
+state_field() {
+  local file="$1" path="$2"
+  [ -f "$file" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -rc ".${path} // empty" "$file" 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    # ensure_ascii=False and the tight separators match jq -rc's output byte for
+    # byte, so which interpreter ran is invisible to the written file.
+    python3 -c 'import json, sys
+try:
+    v = json.load(open(sys.argv[1]))
+    for k in sys.argv[2].split("."):
+        v = v[k]
+except Exception:
+    sys.exit(0)
+if v is None:
+    sys.exit(0)
+sys.stdout.write(v if isinstance(v, str) else json.dumps(v, separators=(",", ":"), ensure_ascii=False))
+' "$file" "$path" 2>/dev/null || true
+  fi
+}
+
+# Parseability check for the freshly built document, same optional-dependency
+# rule. With neither interpreter present the write proceeds unvalidated — the
+# generator is the only writer, so that is a lint we lose, not a correctness one.
+json_parses() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -e . "$1" >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$1" >/dev/null 2>&1
+  fi
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# ─── Monotonicity (FR3) ──────────────────────────────────────────────────────
+
+CUR_PHASE="$(state_field "$STATE_FILE" phase)"
+if [ -n "$CUR_PHASE" ] && [ "$FORCE" -eq 0 ]; then
+  # An unrecognised recorded phase carries no rank, so it constrains nothing.
+  if cur_rank="$(phase_rank "$CUR_PHASE")" && [ "$NEW_RANK" -lt "$cur_rank" ]; then
+    echo "specclaw-set-phase: refusing to move ${CHANGE} backwards: recorded phase is '${CUR_PHASE}', requested '${PHASE}'. Pass --force to override." >&2
+    exit 3
+  fi
+fi
+
+# ─── Build and write state.json (FR1) ────────────────────────────────────────
+
+# One phase record, compact and single-line. `at` is the caller's argument so
+# the idempotency check below can rebuild the previous record verbatim.
+build_record() {
+  local at="$1" out
+  out="{\"status\":\"$(json_escape "$STATUS")\",\"at\":\"$(json_escape "$at")\""
+  [ -n "$TASKS" ] && out="${out},\"tasks\":{\"done\":${T_DONE},\"total\":${T_TOTAL},\"failed\":${T_FAILED}}"
+  [ -n "$VERDICT" ] && out="${out},\"verdict\":\"$(json_escape "$VERDICT")\""
+  [ -n "$URL" ] && out="${out},\"url\":\"$(json_escape "$URL")\""
+  printf '%s}' "$out"
+}
+
+OLD_REC="$(state_field "$STATE_FILE" "phases.${PHASE}")"
+OLD_AT="$(state_field "$STATE_FILE" "phases.${PHASE}.at")"
+AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# Re-running the same transition must not churn the timestamp (AC2).
+if [ -n "$OLD_AT" ] && [ "$(build_record "$OLD_AT")" = "$OLD_REC" ]; then
+  AT="$OLD_AT"
+fi
+
+[ -n "$BRANCH" ] || BRANCH="$(state_field "$STATE_FILE" branch)"
+
+mkdir -p "$CHANGE_DIR" || die "cannot create ${CHANGE_DIR}"
+tmpfile="$(mktemp "${CHANGE_DIR}/.state.json.XXXXXX")" || die "cannot create a temp file in ${CHANGE_DIR}"
+trap 'rm -f "$tmpfile"' EXIT
+
+{
+  printf '{\n'
+  printf '  "change": "%s",\n' "$(json_escape "$CHANGE")"
+  printf '  "phase": "%s",\n' "$(json_escape "$PHASE")"
+  printf '  "branch": "%s",\n' "$(json_escape "$BRANCH")"
+  printf '  "phases": {\n'
+  sep=""
+  for p in "${PHASE_ORDER[@]}"; do
+    if [ "$p" = "$PHASE" ]; then
+      rec="$(build_record "$AT")"
+    else
+      rec="$(state_field "$STATE_FILE" "phases.${p}")"
+      # Only objects belong here; anything else is corruption we decline to copy.
+      case "$rec" in '{'*) ;; *) rec="" ;; esac
+    fi
+    [ -n "$rec" ] || continue
+    printf '%s    "%s": %s' "$sep" "$p" "$rec"
+    sep=$',\n'
+  done
+  printf '\n  }\n}\n'
+} >"$tmpfile" || die "failed to build the new state document"
+
+json_parses "$tmpfile" || die "refusing to write unparseable JSON to ${STATE_FILE}"
+
+# mktemp is 0600; state.json is committed and read by every renderer.
+chmod 644 "$tmpfile" 2>/dev/null || true
+mv "$tmpfile" "$STATE_FILE" || die "failed to install ${STATE_FILE}"
+trap - EXIT
+
+# ─── Reflect into status.md (FR2) ────────────────────────────────────────────
+
+# Edge case 4: status.md may not exist yet. Same self-heal as specclaw-verify.
+if [ ! -f "$STATUS_FILE" ]; then
+  template_file="$(cd "${SCRIPT_DIR}/.." && pwd)/templates/status.md"
+  if [ -f "$template_file" ]; then
+    today="$(date +%Y-%m-%d)"
+    sed -e "s/{{title}}/${CHANGE}/g" \
+      -e "s/{{change_name}}/${CHANGE}/g" \
+      -e "s/{{date}}/${today}/g" \
+      -e "s/{{updated}}/${today}/g" \
+      -e "s/{{[a-zA-Z_]*}}/-/g" \
+      "$template_file" >"$STATUS_FILE" || die "could not create ${STATUS_FILE} from the template"
+    warn "status.md not found; created from template at ${STATUS_FILE}"
+  else
+    warn "no status.md at ${STATUS_FILE} and no template at ${template_file}; state.json written, row skipped"
+    echo "OK: ${CHANGE} → ${PHASE} (${STATUS})"
+    exit 0
+  fi
+fi
+
+# Row label per the template's Progress table; `PR` and `Archived` have no
+# template row, so status-row inserts them after the last one.
+case "$PHASE" in
+  pr) LABEL="PR" ;;
+  *) LABEL="$(printf '%s' "${PHASE:0:1}" | tr '[:lower:]' '[:upper:]')${PHASE:1}" ;;
+esac
+
+STATUS_TEXT_BODY="$(printf '%s' "${STATUS:0:1}" | tr '[:lower:]' '[:upper:]')${STATUS:1}"
+case "$(printf '%s' "$STATUS" | tr '[:upper:]' '[:lower:]')" in
+  pass | passed | done | complete | completed | approved | raised | merged | archived) ICON="✅" ;;
+  fail | failed | blocked) ICON="❌" ;;
+  partial | warning | warn) ICON="⚠️" ;;
+  in-progress | in_progress | running | started | building) ICON="🔨" ;;
+  pending | todo | skipped) ICON="⏳" ;;
+  *) ICON="" ;;
+esac
+STATUS_TEXT="${ICON:+$ICON }${STATUS_TEXT_BODY}"
+
+# Notes column: everything the caller gave, most specific first. Joined rather
+# than ranked so a `--url` plus a `--note` cannot silently drop either. A URL
+# containing pipes travels through verbatim — status-row matches on the label
+# column only, so the row's own delimiters are never re-parsed.
+ROW_NOTE=""
+add_note() {
+  [ -n "$1" ] || return 0
+  ROW_NOTE="${ROW_NOTE:+${ROW_NOTE} — }$1"
+}
+add_note "$URL"
+add_note "$VERDICT"
+if [ -n "$TASKS" ]; then
+  tasks_note="${T_DONE}/${T_TOTAL} tasks"
+  [ "$T_FAILED" -gt 0 ] && tasks_note="${tasks_note}, ${T_FAILED} failed"
+  add_note "$tasks_note"
+fi
+add_note "$NOTE"
+
+# Edge case 5: with no Progress table, status-row appends a standalone
+# `**<label>:** …` line and exits 0. That is a success, not a fallback failure.
+row_script="${SCRIPT_DIR}/specclaw-status-row"
+[ -x "$row_script" ] || row_script="$(command -v specclaw-status-row 2>/dev/null || true)"
+if [ -n "$row_script" ] && [ -x "$row_script" ]; then
+  "$row_script" "$STATUS_FILE" "$LABEL" "$STATUS_TEXT" "$ROW_NOTE" ||
+    warn "could not update the ${LABEL} row in ${STATUS_FILE} (state.json is written)"
+else
+  warn "specclaw-status-row not found; ${STATUS_FILE} left unchanged (state.json is written)"
+fi
+
+echo "OK: ${CHANGE} → ${PHASE} (${STATUS})"

--- a/plugins/specclaw/bin/specclaw-set-phase
+++ b/plugins/specclaw/bin/specclaw-set-phase
@@ -37,6 +37,10 @@
 #      overrides. Every read is fail-open: unreadable or malformed state never
 #      blocks a transition, it just means no constraint to check.
 
+# `-e` is deliberately absent: every state read is fail-open (rule 4 above), and
+# under `-e` a non-zero `jq` on a malformed file would abort the transition it is
+# meant to permit. Anything that must not silently continue is checked explicitly
+# and routed through `die`.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -215,6 +219,9 @@ build_record() {
 OLD_REC="$(state_field "$STATE_FILE" "phases.${PHASE}")"
 OLD_AT="$(state_field "$STATE_FILE" "phases.${PHASE}.at")"
 AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# Without `set -e` a failed `date` leaves AT empty and the record ships with
+# `"at": ""`, which reads as "never happened". Refuse instead of recording a lie.
+[ -n "$AT" ] || die "date -u produced no timestamp; refusing to write a record without one"
 # Re-running the same transition must not churn the timestamp (AC2).
 if [ -n "$OLD_AT" ] && [ "$(build_record "$OLD_AT")" = "$OLD_REC" ]; then
   AT="$OLD_AT"
@@ -262,8 +269,12 @@ if [ ! -f "$STATUS_FILE" ]; then
   template_file="$(cd "${SCRIPT_DIR}/.." && pwd)/templates/status.md"
   if [ -f "$template_file" ]; then
     today="$(date +%Y-%m-%d)"
-    sed -e "s/{{title}}/${CHANGE}/g" \
-      -e "s/{{change_name}}/${CHANGE}/g" \
+    # The change name lands in a sed *replacement*, where `\`, `&` and the `/`
+    # delimiter are all special. Escape them, or a change called `a&b` expands
+    # to the whole match and one called `a/b` aborts the template self-heal.
+    change_sed="$(printf '%s' "$CHANGE" | sed -e 's/[\\&/]/\\&/g')"
+    sed -e "s/{{title}}/${change_sed}/g" \
+      -e "s/{{change_name}}/${change_sed}/g" \
       -e "s/{{date}}/${today}/g" \
       -e "s/{{updated}}/${today}/g" \
       -e "s/{{[a-zA-Z_]*}}/-/g" \

--- a/plugins/specclaw/bin/specclaw-status-row
+++ b/plugins/specclaw/bin/specclaw-status-row
@@ -23,7 +23,23 @@
 #                    appended as a standalone `**<label>:** <note>` line when the
 #                    file has no table at all.
 #
-# Idempotent: re-running with the same values leaves the file byte-identical.
+# Two things the first cut of this script got wrong, both only visible against a
+# status.md richer than the test fixture:
+#
+#   3. "After the last row of the Progress table" was implemented as "after the
+#      last table row in the *file*". The shipped templates/status.md has a
+#      second table under `## Agent Runs`, so a new PR row landed in there —
+#      invisible to a `grep -c '^| PR |'` assertion, wrong to every human reader.
+#      The Progress table is now located explicitly: the first run of table rows
+#      under the `## Progress` heading (bounded by the next heading), falling
+#      back to the first table in the file when there is no such heading.
+#   4. The no-table fallback *appended* its `**<label>:** …` line every run, so
+#      `**Verify:** PASS` and `**Verify:** FAIL` stacked up and idempotency did
+#      not hold for a table-less file. That line is now upserted in place, on
+#      exactly the same rules as a table row.
+#
+# Idempotent: re-running with the same values leaves the file byte-identical,
+# whether the record lives in the Progress table or on a standalone line.
 
 set -uo pipefail
 
@@ -71,41 +87,72 @@ SR_LABEL="$LABEL" SR_STATUS="$STATUS_TEXT" SR_NOTE="$NOTE" awk '
     status_text = ENVIRON["SR_STATUS"]
     note = ENVIRON["SR_NOTE"]
     row = "| " label " | " status_text " | " note " |"
-    written = 0
-    last_table_line = 0
+    field_prefix = "**" label ":**"
+    field_line = field_prefix " " (note != "" ? note : status_text)
+    field_len = length(field_prefix)
+    n = 0
+    progress_heading = 0
+    next_heading = 0
   }
-  # A Progress-table row for this label: `| <label> | … |`. `[|]` is a bracket
-  # expression, so the pipe is literal — the whole point of not using sed here.
-  {
-    is_target = ($0 ~ "^[[:space:]]*[|][[:space:]]*" label "[[:space:]]*[|]")
-    is_table_row = ($0 ~ "^[[:space:]]*[|]")
-  }
-  is_target {
-    # First occurrence becomes the canonical row; any further copies (left behind
-    # by the old sed) are dropped rather than re-emitted.
-    if (!written) { lines[++n] = row; written = 1; last_table_line = n }
-    next
-  }
+  # Buffer the whole file, classifying each line once. A record for this label is
+  # either a table row (`| <label> | … |`) or, in a file with no table, a
+  # standalone `**<label>:** …` line — both are upserted, never stacked.
+  #
+  # `[|]` is a bracket expression, so the pipe is literal: the whole point of not
+  # using sed here. The field-line test is a literal prefix compare rather than a
+  # regex so a label with regex metacharacters cannot misfire — and so that
+  # `**GitHub Issue:**` / `**Jira Issue:**`, which three integration scripts
+  # grep for, are only ever touched when they *are* the label.
   {
     lines[++n] = $0
-    if (is_table_row) last_table_line = n
+    is_table[n] = ($0 ~ "^[[:space:]]*[|]")
+    is_row[n] = ($0 ~ "^[[:space:]]*[|][[:space:]]*" label "[[:space:]]*[|]")
+    is_field[n] = (substr($0, 1, field_len) == field_prefix)
+    if ($0 ~ /^[[:space:]]*#+[[:space:]]/) {
+      if (!progress_heading && tolower($0) ~ /^[[:space:]]*#+[[:space:]]*progress[[:space:]]*$/)
+        progress_heading = n
+      else if (progress_heading && !next_heading)
+        next_heading = n
+    }
   }
   END {
-    if (!written) {
-      if (last_table_line > 0) {
-        # Insert after the final table row, keeping the row inside the table.
-        for (i = 1; i <= n; i++) {
-          print lines[i]
-          if (i == last_table_line) print row
-        }
-      } else {
-        # No table in this file — fall back to a standalone field line.
-        for (i = 1; i <= n; i++) print lines[i]
-        print "**" label ":** " (note != "" ? note : status_text)
-      }
-    } else {
-      for (i = 1; i <= n; i++) print lines[i]
+    # Locate the table the Progress rows belong to. Every contiguous run of table
+    # rows is a table; the one that opens under `## Progress` (and before the
+    # next heading) is ours. With no such heading, the first table in the file is
+    # the best guess — the Progress table is always the first one the template
+    # emits, and the alternative, "the last table", is what put PR rows in the
+    # Agent Runs table.
+    first_table_end = 0
+    progress_table_end = 0
+    i = 1
+    while (i <= n) {
+      if (!is_table[i]) { i++; continue }
+      start = i
+      while (i <= n && is_table[i]) i++
+      if (!first_table_end) first_table_end = i - 1
+      if (progress_heading && !progress_table_end && start > progress_heading &&
+          (next_heading == 0 || start < next_heading))
+        progress_table_end = i - 1
     }
+    insert_after = progress_table_end ? progress_table_end : first_table_end
+    # A file with a table records the label as a row; one without records it as a
+    # field line. Either way there is exactly one record when we are done.
+    use_row = (first_table_end > 0)
+
+    written = 0
+    for (i = 1; i <= n; i++) {
+      if (is_row[i] || is_field[i]) {
+        # First occurrence of the right kind becomes the canonical record; every
+        # other copy — duplicates from the old sed, or a field line superseded by
+        # a table — is dropped rather than re-emitted.
+        if (!written && use_row && is_row[i]) { print row; written = 1 }
+        else if (!written && !use_row && is_field[i]) { print field_line; written = 1 }
+        continue
+      }
+      print lines[i]
+      if (use_row && !written && i == insert_after) { print row; written = 1 }
+    }
+    if (!written) print (use_row ? row : field_line)
   }
 ' "$STATUS_FILE" >"$tmpfile" || {
   echo "specclaw-status-row: awk failed; $STATUS_FILE left unchanged" >&2

--- a/plugins/specclaw/bin/specclaw-update-status
+++ b/plugins/specclaw/bin/specclaw-update-status
@@ -90,8 +90,13 @@ state_parses() {
 }
 
 # phase_render <state_file> <phase> — sets PHASE_EMOJI and PHASE_TEXT for the
-# recorded phase (`🔀` / `pr open`). The qualifier is the most specific field
+# recorded phase (`🔀` / `pr raised`). The qualifier is the most specific field
 # that phase records, falling back to its status; empty when nothing is recorded.
+#
+# Only `verify` has a more specific field than `status`. `pr` deliberately does
+# not: specclaw-set-phase records the PR's disposition *in* `phases.pr.status`
+# (raised | merged | closed), so a second `phases.pr.state` read would be dead
+# code — nothing writes that field.
 PHASE_EMOJI=""
 PHASE_TEXT=""
 phase_render() {
@@ -105,7 +110,6 @@ phase_render() {
     *) PHASE_EMOJI="🔨" ;;
   esac
   case "$phase" in
-    pr) qual="$(state_str "$file" "phases.pr.state")" ;;
     verify) qual="$(state_str "$file" "phases.verify.verdict")" ;;
   esac
   [ -n "$qual" ] || qual="$(state_str "$file" "phases.${phase}.status")"

--- a/plugins/specclaw/bin/specclaw-update-status
+++ b/plugins/specclaw/bin/specclaw-update-status
@@ -35,9 +35,82 @@ cfg_val() {
   printf '%s' "$v"
 }
 
-# Branch names must match what specclaw actually pushes: <branch_prefix><change>.
+# Fallback only (FR4): the branch recorded in state.json wins when present. The
+# `<branch_prefix><change>` guess silently misses whenever branch naming diverges
+# from `git.branch_prefix` — it does in this very repo.
 BRANCH_PREFIX="$(cfg_val git branch_prefix)"
 BRANCH_PREFIX="${BRANCH_PREFIX:-specclaw/}"
+
+# ─── Recorded phase (FR6/FR7) ────────────────────────────────────────────────
+# `changes/<change>/state.json`, written solely by `specclaw-set-phase`, is the
+# recorded phase. Reading it is what lets "verified", "PR raised" and "build
+# finished" render differently — the checkbox counts below cannot tell them
+# apart. Every read is fail-open: absent, unreadable or malformed state falls
+# through to the checkbox inference, warns, and still exits 0 (FR7/AC7), which
+# keeps output byte-identical for changes that have no state.json (AC6).
+
+# state_field <file> <dotted.path> — same reader as specclaw-set-phase: jq when
+# installed, else python3, neither required. Any failure prints nothing.
+state_field() {
+  local file="$1" path="$2"
+  [ -f "$file" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -rc ".${path} // empty" "$file" 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys
+try:
+    v = json.load(open(sys.argv[1]))
+    for k in sys.argv[2].split("."):
+        v = v[k]
+except Exception:
+    sys.exit(0)
+if v is None:
+    sys.exit(0)
+sys.stdout.write(v if isinstance(v, str) else json.dumps(v, separators=(",", ":"), ensure_ascii=False))
+' "$file" "$path" 2>/dev/null || true
+  fi
+}
+
+# state_str <file> <path> — a state_field read reduced to its first line, so a
+# stray newline in the JSON can break neither a markdown row nor a `gh` argument.
+state_str() {
+  local v
+  v="$(state_field "$1" "$2")"
+  printf '%s' "${v%%$'\n'*}"
+}
+
+# True when the file parses. With neither interpreter installed nothing can be
+# read anyway, so it reports parseable and the empty reads take the fallback.
+state_parses() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -e . "$1" >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$1" >/dev/null 2>&1
+  fi
+}
+
+# phase_render <state_file> <phase> — sets PHASE_EMOJI and PHASE_TEXT for the
+# recorded phase (`🔀` / `pr open`). The qualifier is the most specific field
+# that phase records, falling back to its status; empty when nothing is recorded.
+PHASE_EMOJI=""
+PHASE_TEXT=""
+phase_render() {
+  local file="$1" phase="$2" qual=""
+  case "$phase" in
+    proposal) PHASE_EMOJI="📋" ;;
+    spec | design | tasks) PHASE_EMOJI="📝" ;;
+    verify) PHASE_EMOJI="🔍" ;;
+    pr) PHASE_EMOJI="🔀" ;;
+    archived) PHASE_EMOJI="✅" ;;
+    *) PHASE_EMOJI="🔨" ;;
+  esac
+  case "$phase" in
+    pr) qual="$(state_str "$file" "phases.pr.state")" ;;
+    verify) qual="$(state_str "$file" "phases.verify.verdict")" ;;
+  esac
+  [ -n "$qual" ] || qual="$(state_str "$file" "phases.${phase}.status")"
+  PHASE_TEXT="${phase}${qual:+ $qual}"
+}
 
 # Bounded invocation (NFR5) — a network call must never stall status generation.
 pr_bounded() {
@@ -60,17 +133,19 @@ pr_rows() {
   printf '%s' "$rows"
 }
 
-# pr_state_for <change> — `PR #123 open` for the most recently updated PR on the
-# change's branch, rendering its real state (edge case 15: a merged PR reads as
-# merged, never as open). Empty when nothing is discoverable. Memoised per run.
+# pr_state_for <change> [branch] — `PR #123 open` for the most recently updated
+# PR on the change's branch, rendering its real state (edge case 15: a merged PR
+# reads as merged, never as open). Empty when nothing is discoverable. Memoised
+# per run. `branch` is the one recorded in state.json when there is one (FR6);
+# only without it do we fall back to guessing from `git.branch_prefix`.
 pr_state_for() {
-  local change="$1" branch newest state rendered=""
+  local change="$1" branch="${2:-}" newest state rendered=""
   [ "$PR_LOOKUP" = "1" ] || return 0
   if [ -n "${PR_STATE_CACHE[$change]+set}" ]; then
     printf '%s' "${PR_STATE_CACHE[$change]}"
     return 0
   fi
-  branch="${BRANCH_PREFIX}${change}"
+  [ -n "$branch" ] || branch="${BRANCH_PREFIX}${change}"
   # ISO-8601 timestamps sort lexically, so `sort -r | head -1` is the newest PR.
   # `|| true`: a no-match grep in this pipeline must not abort the script ([L2]).
   newest=$(pr_rows "$branch" | tr '\t' ' ' | grep -v '^[[:space:]]*$' | sort -r | head -1 || true)
@@ -98,7 +173,26 @@ for change_dir in "$CHANGES_DIR"/*/; do
   [ "$(basename "$change_dir")" = "archive" ] && continue
 
   change_name=$(basename "$change_dir")
-  pr_state="$(pr_state_for "$change_name")"
+
+  # FR7: a state file that exists but cannot be read is reported once and then
+  # ignored — this loop must degrade, never abort (the script exits 0 either way).
+  state_file="$change_dir/state.json"
+  phase=""
+  state_branch=""
+  if [ -f "$state_file" ]; then
+    if [ -r "$state_file" ] && state_parses "$state_file"; then
+      phase="$(state_str "$state_file" phase)"
+      state_branch="$(state_str "$state_file" branch)"
+    else
+      echo "specclaw-update-status: WARN: unreadable state.json for ${change_name}; falling back to task inference" >&2
+    fi
+  fi
+  # A change still at `proposal` has not started: it keeps its Pending Proposals
+  # placement below rather than being promoted into Active by its own state file.
+  [ "$phase" = "proposal" ] && phase=""
+  [ -n "$phase" ] && phase_render "$state_file" "$phase"
+
+  pr_state="$(pr_state_for "$change_name" "$state_branch")"
 
   if [ -f "$change_dir/tasks.md" ]; then
     total=$(grep -c '^\- \[' "$change_dir/tasks.md" 2>/dev/null || true)
@@ -114,11 +208,25 @@ for change_dir in "$CHANGES_DIR"/*/; do
       pct=0
     fi
 
-    status_emoji="🔨"
-    [ "$failed" -gt 0 ] && status_emoji="⚠️"
-    [ "$done" -eq "$total" ] && [ "$total" -gt 0 ] && status_emoji="✅"
+    if [ -n "$phase" ]; then
+      # FR6: the recorded phase leads, the counts stay as the progress detail —
+      # `🔀 pr open — 11/11 tasks (100%)` instead of an indistinguishable 🔨.
+      status_emoji="$PHASE_EMOJI"
+      [ "$failed" -gt 0 ] && status_emoji="⚠️"
+      phase_prefix="$PHASE_TEXT | "
+    else
+      status_emoji="🔨"
+      [ "$failed" -gt 0 ] && status_emoji="⚠️"
+      [ "$done" -eq "$total" ] && [ "$total" -gt 0 ] && status_emoji="✅"
+      phase_prefix=""
+    fi
 
-    ACTIVE_LINES="${ACTIVE_LINES}\n- $status_emoji **$change_name** — $done/$total tasks ($pct%) ${failed:+| $failed failed}${pr_state:+ | $pr_state}"
+    ACTIVE_LINES="${ACTIVE_LINES}\n- $status_emoji **$change_name** — $phase_prefix$done/$total tasks ($pct%) ${failed:+| $failed failed}${pr_state:+ | $pr_state}"
+    ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
+  elif [ -n "$phase" ]; then
+    # Phase recorded before tasks.md exists (mid-plan), or a PR on a change that
+    # never had one. AC5: this renders without consulting the network at all.
+    ACTIVE_LINES="${ACTIVE_LINES}\n- $PHASE_EMOJI **$change_name** — $PHASE_TEXT${pr_state:+ | $pr_state}"
     ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
   elif [ -n "$pr_state" ]; then
     # Unplanned but already in review — in flight, not "awaiting planning" (AC15).
@@ -129,7 +237,9 @@ for change_dir in "$CHANGES_DIR"/*/; do
   fi
 done
 
-# Scan archived changes
+# Scan archived changes. state.json travels with the directory into archive/
+# (edge case 7); archived rows are terminal, so it is deliberately not read here
+# — nothing under archive/ can affect this listing, malformed or not.
 if [ -d "$ARCHIVE_DIR" ]; then
   for arch_dir in "$ARCHIVE_DIR"/*/; do
     [ -d "$arch_dir" ] || continue

--- a/plugins/specclaw/bin/specclaw-verify
+++ b/plugins/specclaw/bin/specclaw-verify
@@ -40,7 +40,8 @@ Subcommands:
                 Read verify-report.md and output verdict summary.
 
   update-status <specclaw_dir> <change_name> <verdict>
-                Update the Verify row in status.md.
+                Record the verify phase via specclaw-set-phase (state.json +
+                the Verify row in status.md).
                 verdict: PASS | FAIL | PARTIAL
 
 Options:
@@ -535,82 +536,39 @@ cmd_update_status() {
   local specclaw_dir="$1"
   local change_name="$2"
   local verdict="$3"
-  local change_dir="${specclaw_dir}/changes/${change_name}"
-  local status_file="${change_dir}/status.md"
 
-  # Self-heal: if status.md is absent, create it from the template so the
-  # Verify-row update below can proceed.
-  if [ ! -f "$status_file" ]; then
-    local template_file="$(cd "$(dirname "$0")/.." && pwd)/templates/status.md"
-    if [ -f "$template_file" ]; then
-      mkdir -p "$change_dir"
-      local today
-      today=$(date +%Y-%m-%d)
-      sed -e "s/{{title}}/${change_name}/g" \
-          -e "s/{{change_name}}/${change_name}/g" \
-          -e "s/{{date}}/${today}/g" \
-          -e "s/{{updated}}/${today}/g" \
-          -e "s/{{[a-zA-Z_]*}}/-/g" \
-          "$template_file" > "$status_file"
-      warn "status.md not found; created from template at ${status_file}"
-    else
-      die "status.md not found at ${status_file} and template missing at ${template_file}"
-    fi
-  fi
-
-  # Determine status emoji
-  local status_text
+  # Normalize and validate before writing anything.
+  local norm_verdict status_word
   case "$(printf '%s' "$verdict" | tr '[:upper:]' '[:lower:]')" in
-    pass)    status_text="✅ Passed" ;;
-    fail)    status_text="❌ Failed" ;;
-    partial) status_text="⚠️ Partial" ;;
+    pass)    norm_verdict="PASS";    status_word="passed" ;;
+    fail)    norm_verdict="FAIL";    status_word="failed" ;;
+    partial) norm_verdict="PARTIAL"; status_word="partial" ;;
     *)       die "Invalid verdict: ${verdict}. Must be PASS, FAIL, or PARTIAL" ;;
   esac
 
-  # Check if Verify row exists in the table
-  if grep -qE '^\|[[:space:]]*Verify[[:space:]]*\|' "$status_file"; then
-    # Update existing Verify row — replace the status column
-    local tmpfile
-    tmpfile=$(mktemp)
-    while IFS= read -r line; do
-      if printf '%s' "$line" | grep -qE '^\|[[:space:]]*Verify[[:space:]]*\|'; then
-        # Rebuild the row preserving the Notes column
-        local notes
-        notes=$(printf '%s' "$line" | awk -F'|' '{print $4}' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
-        printf '| Verify | %s | %s |\n' "$status_text" "$notes"
-      else
-        printf '%s\n' "$line"
-      fi
-    done < "$status_file" > "$tmpfile"
-    mv "$tmpfile" "$status_file"
-  else
-    # Append a Verify row — find the table and add after the last row
-    # Or just append if we can't find the table
-    local tmpfile
-    tmpfile=$(mktemp)
-    local in_table=false table_ended=false appended=false
-    while IFS= read -r line; do
-      printf '%s\n' "$line"
-      # Detect table rows (lines starting with |)
-      if printf '%s' "$line" | grep -qE '^\|.*(Phase|Build|Tasks|Design|Spec|Proposal).*\|'; then
-        in_table=true
-      elif $in_table && ! printf '%s' "$line" | grep -qE '^\|'; then
-        # Table ended, insert Verify row before this line
-        if ! $appended; then
-          printf '| Verify | %s |  |\n' "$status_text"
-          appended=true
-        fi
-        in_table=false
-      fi
-    done < "$status_file" > "$tmpfile"
-    # If we never left the table (file ends with table), append
-    if ! $appended; then
-      printf '| Verify | %s |  |\n' "$status_text" >> "$tmpfile"
-    fi
-    mv "$tmpfile" "$status_file"
+  # specclaw-set-phase is the only writer of phase state: it records the verdict
+  # in state.json and upserts the Verify row through specclaw-status-row (awk —
+  # the Progress table's pipes make sed unsafe). It also self-heals a missing
+  # status.md from templates/status.md, which is what the hand-rolled block that
+  # used to live here did.
+  local setter="${SCRIPT_DIR}/specclaw-set-phase"
+  [ -x "$setter" ] || setter="$(command -v specclaw-set-phase 2>/dev/null || true)"
+  if [ -z "$setter" ] || [ ! -x "$setter" ]; then
+    warn "specclaw-set-phase not found — Verify phase not recorded (verify-report.md is unaffected)"
+    return 0
   fi
 
-  echo "Updated status.md: Verify → ${status_text}"
+  # Fail-soft: the verdict already exists in verify-report.md, so a bookkeeping
+  # failure — most likely a refused backwards transition (exit 3) on a change
+  # that already reached pr — warns loudly and returns 0 rather than aborting
+  # the verify run under `set -e`.
+  local rc=0
+  "$setter" "$specclaw_dir" "$change_name" verify "$status_word" --verdict "$norm_verdict" >/dev/null || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "Updated status.md: Verify → ${norm_verdict}"
+  else
+    warn "specclaw-set-phase exited ${rc} — Verify row not updated (verify-report.md is unaffected)"
+  fi
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/plugins/specclaw/skills/archive/SKILL.md
+++ b/plugins/specclaw/skills/archive/SKILL.md
@@ -10,8 +10,9 @@ Archive a completed change.
 
 1. **Validate:** `specclaw-validate-change .specclaw <change> archive`. If it fails, report and stop.
 2. Verify the change is complete (all tasks done, verification passed, PR merged).
-3. Move to `.specclaw/changes/archive/YYYY-MM-DD-<change>/`.
-4. Update the dashboard: `specclaw-update-status .specclaw`.
-5. **GitHub sync** (if enabled): `specclaw-gh-sync close .specclaw <change>` to close the issue.
-6. **Azure Boards sync** (if `azdo.boards.sync: true`): `specclaw-azdo-issue close .specclaw <change>` to post a closing comment and add a `closed-by-specclaw` tag. (Does not transition Work Item state — humans drive state in ADO.)
-7. Optionally create a git tag for the release.
+3. Record the phase: `specclaw-set-phase .specclaw <change> archived done`. `specclaw-set-phase` is the only writer of phase state — it records `state.json` and upserts the Archived row in `status.md`. Never hand-edit those rows. Run it **before** the move, so the recorded state travels with the directory.
+4. Move to `.specclaw/changes/archive/YYYY-MM-DD-<change>/`.
+5. Update the dashboard: `specclaw-update-status .specclaw`.
+6. **GitHub sync** (if enabled): `specclaw-gh-sync close .specclaw <change>` to close the issue.
+7. **Azure Boards sync** (if `azdo.boards.sync: true`): `specclaw-azdo-issue close .specclaw <change>` to post a closing comment and add a `closed-by-specclaw` tag. (Does not transition Work Item state — humans drive state in ADO.)
+8. Optionally create a git tag for the release.

--- a/plugins/specclaw/skills/plan/SKILL.md
+++ b/plugins/specclaw/skills/plan/SKILL.md
@@ -27,10 +27,17 @@ Turn an approved proposal into an executable plan.
      - **If `spec.md` already exists** (e.g. authored previously via `/specclaw:author-spec`): do not overwrite it; skip the spec step and proceed to `design.md` / `tasks.md`.
    - `design.md` — technical approach, architecture, file changes map, key decisions, risks. Template: `$CLAUDE_PLUGIN_ROOT/templates/design.md`. **When discovery produced docs, add a "Grounding sources" section** listing the discovered files you actually used — each entry cites the path plus the specific convention or quoted line applied. The paper trail for what informed the design, backed by quotable evidence rather than vague attribution.
    - `tasks.md` — ordered tasks grouped into waves with dependencies. Template: `$CLAUDE_PLUGIN_ROOT/templates/tasks.md`. **Tag each task with an optional `Kind:` hint** (`docs | test | config | refactor | impl | migration`) inferred from what the task does — it lets `build.dynamic_agents` (when enabled) synthesize a specialized subagent with the right role, minimal tools, and cost-appropriate model. When a task's nature is genuinely mixed or unclear, omit `Kind` and build will classify heuristically (default `impl`).
-5. Present a plan summary to the user (counts of FRs, ACs, tasks, waves).
-6. Update status: `specclaw-update-status .specclaw`.
-7. **GitHub sync** (if enabled): `specclaw-gh-sync update .specclaw <change>` to attach the task checklist to the GitHub Issue.
-8. **Azure Boards sync** (if `azdo.boards.sync: true`): `specclaw-azdo-issue update .specclaw <change>` to refresh the Work Item description with the rendered task checklist.
+5. Record each phase as its file lands — one call per artifact, immediately after writing it:
+   ```bash
+   specclaw-set-phase .specclaw <change> spec done
+   specclaw-set-phase .specclaw <change> design done
+   specclaw-set-phase .specclaw <change> tasks done
+   ```
+   `specclaw-set-phase` is the only writer of phase state — it records `state.json` and upserts the matching row in `status.md`. Never hand-edit those rows. With `--author-spec`, run the `spec` call before pausing for approval, and the other two after.
+6. Present a plan summary to the user (counts of FRs, ACs, tasks, waves).
+7. Update status: `specclaw-update-status .specclaw`.
+8. **GitHub sync** (if enabled): `specclaw-gh-sync update .specclaw <change>` to attach the task checklist to the GitHub Issue.
+9. **Azure Boards sync** (if `azdo.boards.sync: true`): `specclaw-azdo-issue update .specclaw <change>` to refresh the Work Item description with the rendered task checklist.
 
 ## Planner guardrails
 

--- a/plugins/specclaw/skills/propose/SKILL.md
+++ b/plugins/specclaw/skills/propose/SKILL.md
@@ -18,5 +18,6 @@ Create a new proposal for a change.
 5. Update `.specclaw/STATUS.md` via `specclaw-update-status .specclaw`.
 6. **GitHub sync** (if `github.sync: true` in `config.yaml`): run `specclaw-gh-sync create .specclaw <change-name>` to create a GitHub Issue for the proposal. Validation (proposal.md must exist) is enforced by `specclaw-validate-change`.
 7. **Azure Boards sync** (if `azdo.boards.sync: true` in `config.yaml`): run `specclaw-azdo-issue create .specclaw <change-name>` to create a Work Item. Idempotent — safe to re-run.
+8. **Once the user approves the proposal**, record the phase: `specclaw-set-phase .specclaw <change-name> proposal approved`. `specclaw-set-phase` is the only writer of phase state — it records `state.json` and upserts the Proposal row in `status.md`. Never hand-edit those rows. Until approval the template's `🟡 Draft` row stands.
 
 Do not proceed to `/specclaw:plan` until the user has approved the proposal.

--- a/plugins/specclaw/tests/run-phase-state-tests.sh
+++ b/plugins/specclaw/tests/run-phase-state-tests.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+# run-phase-state-tests.sh — regression suite for bin/specclaw-set-phase, the one
+# writer of a change's phase, and for the two `specclaw-status-row` defects that
+# only surface once set-phase drives it against a stock status.md.
+#
+# What this pins:
+#
+#   AC1  a fresh change gets valid JSON with the right phase + phase record
+#   AC2  the identical transition twice is byte-identical in both files
+#   AC3  a backwards transition is refused and mutates nothing; --force wins
+#   AC4  one `| PR |` row carrying the URL, `**GitHub Issue:**` untouched (NFR1)
+#   E4   status.md absent → self-healed from templates/status.md
+#   E5   status.md with no Progress table → standalone `**<label>:**` line, exit 0
+#   E6   a status.md already corrupted with duplicate PR rows collapses to one
+#   E8   an unknown phase is refused, lists the valid phases, writes nothing
+#   E9   a --url full of literal pipes lands intact in both files
+#   E10  verify → verify with a changed verdict is allowed and overwrites
+#   plus a corrupt state.json (fail-open, FR7) and the python3 read fallback.
+#
+# Two of these double as defect pins for `specclaw-status-row`:
+#
+#   D3: a new row was inserted after the *last table row in the whole file*, so
+#       against the shipped template a PR row landed in the **Agent Runs** table
+#       instead of the Progress table. Pinned by AC4 and E4.
+#   D4: the no-table fallback appended a fresh `**<label>:** …` line every run
+#       instead of replacing the existing one, so AC2 did not hold for a
+#       table-less status.md. Pinned by E5.
+#
+# Plain bash + coreutils only (jq is used when installed, python3 otherwise —
+# exactly the optional-dependency rule set-phase itself follows). Run from
+# anywhere:
+#   bash plugins/specclaw/tests/run-phase-state-tests.sh
+# Exits non-zero if any case fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/../bin" && pwd)"
+TEMPLATE="$(cd "$SCRIPT_DIR/.." && pwd)/templates/status.md"
+
+SET_PHASE="$BIN_DIR/specclaw-set-phase"
+STATUS_ROW="$BIN_DIR/specclaw-status-row"
+
+for f in "$SET_PHASE" "$STATUS_ROW" "$TEMPLATE"; do
+  if [[ ! -f "$f" ]]; then
+    echo "FATAL: missing file: $f" >&2
+    exit 2
+  fi
+done
+
+if ! command -v jq >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
+  echo "FATAL: this suite needs jq or python3 to read the JSON it asserts on" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SPECCLAW="$WORK/.specclaw"
+mkdir -p "$SPECCLAW/changes"
+
+PASS=0
+FAIL=0
+pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+fail() {
+  echo "FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label (= '$actual')"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label (contains '$needle')"
+  else
+    fail "$label — '$needle' not found in: $haystack"
+  fi
+}
+
+assert_same_file() {
+  local label="$1" a="$2" b="$3"
+  if cmp -s "$a" "$b"; then
+    pass "$label"
+  else
+    fail "$label — files differ: $(diff "$a" "$b" | head -5 | tr '\n' ' ')"
+  fi
+}
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+RC=0
+# run_sp <args…> — invoke set-phase, capture rc/stdout/stderr, never abort.
+run_sp() {
+  RC=0
+  "$SET_PHASE" "$@" >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+}
+
+# json_get <file> <dotted.path> — same optional-dependency rule as set-phase.
+json_get() {
+  local file="$1" path="$2"
+  [[ -f "$file" ]] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -rc ".${path} // empty" "$file" 2>/dev/null || true
+  else
+    python3 -c 'import json, sys
+try:
+    v = json.load(open(sys.argv[1]))
+    for k in sys.argv[2].split("."):
+        v = v[k]
+except Exception:
+    sys.exit(0)
+if v is None:
+    sys.exit(0)
+sys.stdout.write(v if isinstance(v, str) else json.dumps(v, separators=(",", ":"), ensure_ascii=False))
+' "$file" "$path" 2>/dev/null || true
+  fi
+}
+
+json_ok() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -e . "$1" >/dev/null 2>&1
+  else
+    python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$1" >/dev/null 2>&1
+  fi
+}
+
+new_change() {
+  local name="$1"
+  mkdir -p "$SPECCLAW/changes/$name"
+  printf '%s' "$SPECCLAW/changes/$name"
+}
+
+# A status.md in the shape the template renders to once a change is underway:
+# a Progress table, a *second* table under `## Agent Runs`, and the
+# `**GitHub Issue:**` line three integration scripts grep for (NFR1).
+make_status() {
+  cat >"$1" <<'EOF'
+# Status: Tracker State Integrity
+
+**Change:** tracker-state-integrity
+**Started:** 2026-08-01
+**Last Updated:** 2026-08-01
+
+## Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Proposal | ✅ Approved | Operator approved |
+| Spec | ✅ Done | 9 FRs, 12 ACs |
+| Design | ✅ Done | state.json + one writer |
+| Tasks | ✅ Done | 7 tasks / 4 waves |
+| Build | ✅ Done | 7/7 tasks |
+| Verify | ✅ Passed | All 12 ACs |
+
+## Task Progress
+
+**Completed:** 7 / 7
+**Failed:** 0
+
+## Agent Runs
+
+| Task | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+| T1 | builder | sonnet | ✅ Done | 4m |
+| T2 | builder | sonnet | ✅ Done | 6m |
+
+## Issues
+
+_None._
+
+**GitHub Issue:** #56
+EOF
+}
+
+# A status.md with no table at all — what edge case 5 describes.
+make_bare_status() {
+  cat >"$1" <<'EOF'
+# Status: bare
+
+**Change:** bare
+**Started:** 2026-08-01
+
+**GitHub Issue:** #56
+EOF
+}
+
+URL="https://github.com/chan4lk/specclaw/pull/417"
+
+# ─── AC1: a fresh change, no state.json ──────────────────────────────────────
+C="$(new_change ac1)"
+make_status "$C/status.md"
+run_sp "$SPECCLAW" ac1 build done --tasks 7/11/0
+assert_eq "AC1a exits 0" "0" "$RC"
+if [[ -f "$C/state.json" ]]; then
+  pass "AC1b state.json created"
+else
+  fail "AC1b state.json not created"
+fi
+if json_ok "$C/state.json"; then
+  pass "AC1c state.json is valid JSON"
+else
+  fail "AC1c state.json is not valid JSON: $(cat "$C/state.json")"
+fi
+assert_eq "AC1d change recorded" "ac1" "$(json_get "$C/state.json" change)"
+assert_eq "AC1e phase recorded" "build" "$(json_get "$C/state.json" phase)"
+assert_eq "AC1f phases.build.status" "done" "$(json_get "$C/state.json" phases.build.status)"
+assert_eq "AC1g phases.build.tasks" '{"done":7,"total":11,"failed":0}' \
+  "$(json_get "$C/state.json" phases.build.tasks)"
+AT="$(json_get "$C/state.json" phases.build.at)"
+if [[ "$AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+  pass "AC1h phases.build.at is a UTC timestamp (= '$AT')"
+else
+  fail "AC1h phases.build.at not a UTC timestamp: '$AT'"
+fi
+assert_eq "AC1i only the build record exists" "" "$(json_get "$C/state.json" phases.verify)"
+assert_eq "AC1j Build row reflected into status.md" "| Build | ✅ Done | 7/11 tasks |" \
+  "$(grep '^| Build |' "$C/status.md")"
+
+# ─── AC2: the identical transition twice is byte-identical ───────────────────
+C="$(new_change ac2)"
+make_status "$C/status.md"
+run_sp "$SPECCLAW" ac2 verify passed --verdict PASS --note "All 12 ACs"
+assert_eq "AC2a first run exits 0" "0" "$RC"
+cp "$C/state.json" "$WORK/ac2.state.snap"
+cp "$C/status.md" "$WORK/ac2.status.snap"
+run_sp "$SPECCLAW" ac2 verify passed --verdict PASS --note "All 12 ACs"
+assert_eq "AC2b second run exits 0" "0" "$RC"
+assert_same_file "AC2c state.json byte-identical" "$WORK/ac2.state.snap" "$C/state.json"
+assert_same_file "AC2d status.md byte-identical" "$WORK/ac2.status.snap" "$C/status.md"
+
+# ─── AC3: backwards transitions are refused, --force overrides ───────────────
+C="$(new_change ac3)"
+make_status "$C/status.md"
+run_sp "$SPECCLAW" ac3 pr raised --url "$URL"
+assert_eq "AC3a reaching pr exits 0" "0" "$RC"
+cp "$C/state.json" "$WORK/ac3.state.snap"
+cp "$C/status.md" "$WORK/ac3.status.snap"
+
+run_sp "$SPECCLAW" ac3 build done
+if [[ "$RC" -ne 0 ]]; then
+  pass "AC3b build after pr exits non-zero (= $RC)"
+else
+  fail "AC3b build after pr should have been refused, exited 0"
+fi
+ERR="$(cat "$WORK/last.err")"
+assert_contains "AC3c message names the recorded phase" "'pr'" "$ERR"
+assert_contains "AC3d message names the requested phase" "'build'" "$ERR"
+assert_contains "AC3e message points at --force" "--force" "$ERR"
+assert_same_file "AC3f refused transition left state.json alone" "$WORK/ac3.state.snap" "$C/state.json"
+assert_same_file "AC3g refused transition left status.md alone" "$WORK/ac3.status.snap" "$C/status.md"
+
+run_sp "$SPECCLAW" ac3 build done --force
+assert_eq "AC3h --force exits 0" "0" "$RC"
+assert_eq "AC3i --force moved the phase back" "build" "$(json_get "$C/state.json" phase)"
+assert_eq "AC3j the earlier pr record is retained" "raised" "$(json_get "$C/state.json" phases.pr.status)"
+assert_eq "AC3k the pr record keeps its url" "$URL" "$(json_get "$C/state.json" phases.pr.url)"
+
+# ─── AC4: one PR row with the URL, GitHub Issue line untouched ───────────────
+# Also pins status-row defect D3: the row must land in the Progress table, not
+# in the Agent Runs table further down the file.
+C="$(new_change ac4)"
+make_status "$C/status.md"
+ISSUE_BEFORE="$(grep '^\*\*GitHub Issue:\*\*' "$C/status.md")"
+AGENT_ROWS_BEFORE="$(grep -c '^| T[0-9] |' "$C/status.md")"
+run_sp "$SPECCLAW" ac4 pr raised --url "$URL"
+assert_eq "AC4a exits 0" "0" "$RC"
+assert_eq "AC4b exactly one PR row" "1" "$(grep -c '^| PR |' "$C/status.md")"
+assert_eq "AC4c the PR row carries the URL" "| PR | ✅ Raised | $URL |" \
+  "$(grep '^| PR |' "$C/status.md")"
+assert_eq "AC4d GitHub Issue line byte-unchanged (NFR1)" "$ISSUE_BEFORE" \
+  "$(grep '^\*\*GitHub Issue:\*\*' "$C/status.md")"
+assert_eq "AC4d2 exactly one GitHub Issue line, still the last line" "**GitHub Issue:** #56" \
+  "$(tail -1 "$C/status.md")"
+assert_eq "AC4e other Progress rows untouched" "| Verify | ✅ Passed | All 12 ACs |" \
+  "$(grep '^| Verify |' "$C/status.md")"
+
+PR_LN="$(grep -n '^| PR |' "$C/status.md" | head -1 | cut -d: -f1)"
+AR_LN="$(grep -n '^## Agent Runs' "$C/status.md" | head -1 | cut -d: -f1)"
+if [[ -n "$PR_LN" && -n "$AR_LN" && "$PR_LN" -lt "$AR_LN" ]]; then
+  pass "AC4f/D3 the PR row is in the Progress table, above '## Agent Runs' (line $PR_LN < $AR_LN)"
+else
+  fail "AC4f/D3 the PR row landed at line $PR_LN, at or below '## Agent Runs' (line $AR_LN)"
+fi
+assert_eq "AC4g/D3 the PR row directly follows the last Progress row" \
+  "| Verify | ✅ Passed | All 12 ACs |" "$(grep -B1 '^| PR |' "$C/status.md" | head -1)"
+assert_eq "AC4h/D3 the Agent Runs table is unchanged" "$AGENT_ROWS_BEFORE" \
+  "$(grep -c '^| T[0-9] |' "$C/status.md")"
+
+# ─── Edge 4: status.md absent → self-healed from the template ────────────────
+# The stock template carries two tables, so this is D3's other pin.
+C="$(new_change edge4)"
+run_sp "$SPECCLAW" edge4 pr raised --url "$URL"
+assert_eq "E4a exits 0" "0" "$RC"
+if [[ -f "$C/status.md" ]]; then
+  pass "E4b status.md self-healed from the template"
+else
+  fail "E4b status.md not created"
+fi
+assert_contains "E4c warns that it created the file" "created from template" "$(cat "$WORK/last.err")"
+assert_eq "E4d template placeholders are gone" "0" "$(grep -c '{{' "$C/status.md")"
+assert_eq "E4e exactly one PR row" "1" "$(grep -c '^| PR |' "$C/status.md")"
+PR_LN="$(grep -n '^| PR |' "$C/status.md" | head -1 | cut -d: -f1)"
+AR_LN="$(grep -n '^## Agent Runs' "$C/status.md" | head -1 | cut -d: -f1)"
+if [[ -n "$PR_LN" && -n "$AR_LN" && "$PR_LN" -lt "$AR_LN" ]]; then
+  pass "E4f/D3 the PR row is inside the template's Progress table (line $PR_LN < $AR_LN)"
+else
+  fail "E4f/D3 the PR row landed at line $PR_LN, at or below '## Agent Runs' (line $AR_LN)"
+fi
+assert_eq "E4g/D3 the PR row directly follows the Verify row" "| Verify | - | - |" \
+  "$(grep -B1 '^| PR |' "$C/status.md" | head -1)"
+
+# ─── Edge 5: no Progress table → standalone field line, exit 0 ───────────────
+# Also pins status-row defect D4: repeated runs must replace that line, not
+# stack a second one beside it.
+C="$(new_change edge5)"
+make_bare_status "$C/status.md"
+run_sp "$SPECCLAW" edge5 verify passed --verdict PASS
+assert_eq "E5a no-table status.md is not a failure" "0" "$RC"
+assert_eq "E5b standalone field line written" "**Verify:** PASS" \
+  "$(grep '^\*\*Verify:\*\*' "$C/status.md")"
+assert_eq "E5c state.json still written" "verify" "$(json_get "$C/state.json" phase)"
+assert_eq "E5d GitHub Issue line survives" "1" "$(grep -c '^\*\*GitHub Issue:\*\* #56$' "$C/status.md")"
+
+cp "$C/state.json" "$WORK/e5.state.snap"
+cp "$C/status.md" "$WORK/e5.status.snap"
+run_sp "$SPECCLAW" edge5 verify passed --verdict PASS
+assert_eq "E5e/D4 re-running exits 0" "0" "$RC"
+assert_same_file "E5f/D4 AC2 holds for a table-less status.md" "$WORK/e5.status.snap" "$C/status.md"
+assert_same_file "E5g/D4 state.json still byte-identical" "$WORK/e5.state.snap" "$C/state.json"
+
+run_sp "$SPECCLAW" edge5 verify failed --verdict FAIL
+assert_eq "E5h/D4 a changed verdict exits 0" "0" "$RC"
+assert_eq "E5i/D4 still exactly one Verify field line" "1" "$(grep -c '^\*\*Verify:\*\*' "$C/status.md")"
+assert_eq "E5j/D4 the field line was replaced in place" "**Verify:** FAIL" \
+  "$(grep '^\*\*Verify:\*\*' "$C/status.md")"
+
+# ─── Edge 6: a status.md already corrupted with duplicate PR rows ────────────
+C="$(new_change edge6)"
+make_status "$C/status.md"
+# The old `sed` address `/^\|…\|/a` matched every line, so the PR row was
+# appended after all of them. Reproduce that shape exactly.
+awk -v row="| PR | ✅ Raised | $URL |" '{ print; print row }' \
+  "$C/status.md" >"$WORK/e6.corrupt" && mv "$WORK/e6.corrupt" "$C/status.md"
+CORRUPT_ROWS="$(grep -c '^| PR |' "$C/status.md")"
+if [[ "$CORRUPT_ROWS" -gt 10 ]]; then
+  pass "E6a fixture starts corrupted ($CORRUPT_ROWS PR rows)"
+else
+  fail "E6a fixture should have many duplicate PR rows, has $CORRUPT_ROWS"
+fi
+run_sp "$SPECCLAW" edge6 pr raised --url "$URL"
+assert_eq "E6b exits 0" "0" "$RC"
+assert_eq "E6c duplicates collapsed to exactly one PR row" "1" "$(grep -c '^| PR |' "$C/status.md")"
+assert_eq "E6d the surviving row carries the URL" "| PR | ✅ Raised | $URL |" \
+  "$(grep '^| PR |' "$C/status.md")"
+assert_eq "E6e GitHub Issue line survived the collapse" "1" \
+  "$(grep -c '^\*\*GitHub Issue:\*\* #56$' "$C/status.md")"
+
+# ─── Edge 8: an unknown phase writes nothing ─────────────────────────────────
+C="$(new_change edge8)"
+make_status "$C/status.md"
+cp "$C/status.md" "$WORK/e8.status.snap"
+run_sp "$SPECCLAW" edge8 shipped done
+if [[ "$RC" -ne 0 ]]; then
+  pass "E8a unknown phase exits non-zero (= $RC)"
+else
+  fail "E8a unknown phase should have been refused, exited 0"
+fi
+ERR="$(cat "$WORK/last.err")"
+assert_contains "E8b message names the offending phase" "unknown phase: shipped" "$ERR"
+assert_contains "E8c message lists the valid phases" "valid phases:" "$ERR"
+assert_contains "E8d the list is the real phase order" "proposal spec design tasks build verify pr archived" "$ERR"
+if [[ -f "$C/state.json" ]]; then
+  fail "E8e no state.json should have been written"
+else
+  pass "E8e no state.json written"
+fi
+assert_same_file "E8f status.md untouched" "$WORK/e8.status.snap" "$C/status.md"
+
+# ─── Edge 9: a --url full of literal pipes ───────────────────────────────────
+C="$(new_change edge9)"
+make_status "$C/status.md"
+PIPE_URL='https://ex.com/p/1?a=b|c=[d]|e\f'
+run_sp "$SPECCLAW" edge9 pr raised --url "$PIPE_URL"
+assert_eq "E9a exits 0" "0" "$RC"
+assert_eq "E9b the pipes survive into state.json" "$PIPE_URL" "$(json_get "$C/state.json" phases.pr.url)"
+assert_eq "E9c the pipes survive into status.md" "| PR | ✅ Raised | $PIPE_URL |" \
+  "$(grep '^| PR |' "$C/status.md")"
+assert_eq "E9d still exactly one PR row" "1" "$(grep -c '^| PR |' "$C/status.md")"
+assert_eq "E9e the Progress table gained exactly the PR row" \
+  "Proposal Spec Design Tasks Build Verify PR" \
+  "$(awk '/^## Progress/,/^## Task Progress/' "$C/status.md" |
+    awk -F'|' '/^\|/ && $2 !~ /^-+$/ && $2 !~ /Phase/ { gsub(/^ +| +$/, "", $2); printf "%s%s", sep, $2; sep = " " }')"
+
+# ─── Edge 10: verify → verify with a changed verdict ─────────────────────────
+C="$(new_change edge10)"
+make_status "$C/status.md"
+run_sp "$SPECCLAW" edge10 verify failed --verdict FAIL --note "AC7 red"
+assert_eq "E10a first verify exits 0" "0" "$RC"
+assert_eq "E10b FAIL recorded" "FAIL" "$(json_get "$C/state.json" phases.verify.verdict)"
+run_sp "$SPECCLAW" edge10 verify passed --verdict PASS --note "AC7 green"
+assert_eq "E10c re-verify is allowed, not a backwards move" "0" "$RC"
+assert_eq "E10d the verdict was overwritten" "PASS" "$(json_get "$C/state.json" phases.verify.verdict)"
+assert_eq "E10e the status was overwritten" "passed" "$(json_get "$C/state.json" phases.verify.status)"
+assert_eq "E10f status.md shows the new verdict" "| Verify | ✅ Passed | PASS — AC7 green |" \
+  "$(grep '^| Verify |' "$C/status.md")"
+assert_eq "E10g exactly one Verify row" "1" "$(grep -c '^| Verify |' "$C/status.md")"
+
+# ─── FR7: a corrupt state.json must fail open, never block ───────────────────
+C="$(new_change corrupt)"
+make_status "$C/status.md"
+printf '{"change":"corrupt","phase":"pr","phases":{"pr":{"status":"rai' >"$C/state.json"
+run_sp "$SPECCLAW" corrupt build done --tasks 3/3/0
+assert_eq "FR7a a truncated state.json does not block the transition" "0" "$RC"
+if json_ok "$C/state.json"; then
+  pass "FR7b the rewritten state.json is valid JSON"
+else
+  fail "FR7b state.json still unparseable: $(cat "$C/state.json")"
+fi
+assert_eq "FR7c phase recorded despite the corruption" "build" "$(json_get "$C/state.json" phase)"
+assert_eq "FR7d the unreadable pr record was not copied forward" "" \
+  "$(json_get "$C/state.json" phases.pr)"
+
+C="$(new_change notjson)"
+make_status "$C/status.md"
+printf 'this is not json at all\n' >"$C/state.json"
+run_sp "$SPECCLAW" notjson verify passed --verdict PASS
+assert_eq "FR7e a non-JSON state.json does not block the transition" "0" "$RC"
+if json_ok "$C/state.json"; then
+  pass "FR7f the rewritten state.json is valid JSON"
+else
+  fail "FR7f state.json still unparseable: $(cat "$C/state.json")"
+fi
+assert_eq "FR7g phase recorded" "verify" "$(json_get "$C/state.json" phase)"
+
+# ─── The python3 read fallback ───────────────────────────────────────────────
+# set-phase prefers jq and falls back to python3. jq is absent on plenty of dev
+# boxes (and on this one), so the fallback is the default path there — but the
+# suite must exercise it either way. A PATH holding only the binaries set-phase
+# and status-row need, minus jq, forces the fallback without skipping anything.
+SHIM="$WORK/nojq-bin"
+mkdir -p "$SHIM"
+for b in bash sh env python3 date mktemp chmod mv cp rm mkdir tr sed awk cat dirname grep; do
+  p="$(command -v "$b" 2>/dev/null)" || continue
+  case "$p" in /*) ln -sf "$p" "$SHIM/$b" ;; esac
+done
+assert_eq "FBa the shim PATH really has no jq" "" "$(PATH="$SHIM" bash -c 'command -v jq' 2>/dev/null)"
+if [[ -x "$SHIM/python3" ]]; then
+  pass "FBb the shim PATH has python3"
+else
+  fail "FBb the shim PATH has no python3 — the fallback cannot be exercised"
+fi
+
+C="$(new_change fallback)"
+make_status "$C/status.md"
+RC=0
+PATH="$SHIM" "$SET_PHASE" "$SPECCLAW" fallback build done --tasks 5/5/0 \
+  >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+assert_eq "FBc jq-less write exits 0" "0" "$RC"
+if json_ok "$C/state.json"; then
+  pass "FBd jq-less write produced valid JSON"
+else
+  fail "FBd jq-less write produced invalid JSON: $(cat "$C/state.json")"
+fi
+assert_eq "FBe phase recorded via the python3 path" "build" "$(json_get "$C/state.json" phase)"
+
+# The read fallback is what the monotonicity check and the record carry-forward
+# depend on, so assert both under the same jq-less PATH.
+RC=0
+PATH="$SHIM" "$SET_PHASE" "$SPECCLAW" fallback pr raised --url "$URL" \
+  >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+assert_eq "FBf forward move exits 0" "0" "$RC"
+assert_eq "FBg the earlier build record was carried forward by the fallback reader" \
+  '{"done":5,"total":5,"failed":0}' "$(json_get "$C/state.json" phases.build.tasks)"
+
+RC=0
+PATH="$SHIM" "$SET_PHASE" "$SPECCLAW" fallback build done --tasks 5/5/0 \
+  >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+if [[ "$RC" -ne 0 ]]; then
+  pass "FBh the fallback reader still enforces monotonicity (= $RC)"
+else
+  fail "FBh backwards move was allowed under the jq-less PATH"
+fi
+
+cp "$C/state.json" "$WORK/fb.state.snap"
+cp "$C/status.md" "$WORK/fb.status.snap"
+RC=0
+PATH="$SHIM" "$SET_PHASE" "$SPECCLAW" fallback pr raised --url "$URL" \
+  >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+assert_eq "FBi repeat under the jq-less PATH exits 0" "0" "$RC"
+assert_same_file "FBj idempotent under the fallback reader (state.json)" \
+  "$WORK/fb.state.snap" "$C/state.json"
+assert_same_file "FBk idempotent under the fallback reader (status.md)" \
+  "$WORK/fb.status.snap" "$C/status.md"
+
+# ─── Hermeticity: nothing was written outside the temp workdir ───────────────
+assert_eq "Ha every change directory lives under the temp workdir" "0" \
+  "$(find "$SPECCLAW" -name state.json -not -path "$WORK/*" | wc -l)"
+
+echo
+echo "─────────────────────────────"
+echo "PASS: $PASS   FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/plugins/specclaw/tests/run-phase-state-tests.sh
+++ b/plugins/specclaw/tests/run-phase-state-tests.sh
@@ -17,6 +17,17 @@
 #   E10  verify → verify with a changed verdict is allowed and overwrites
 #   plus a corrupt state.json (fail-open, FR7) and the python3 read fallback.
 #
+# and, for `bin/specclaw-reconcile` (FR8):
+#
+#   AC9  state.json says build while tasks.md is complete and verify-report.md
+#        exists → drift, non-zero exit; --fix advances and exits 0
+#   AC10 `gh` unavailable → the pr dimension is `unknown`, a recorded PR is not
+#        cleared, and --fix names what it skipped
+#   plus the `unknown` vs `none` distinction that AC10 turns on: a *failing* gh
+#   is unknown (not drift, never actionable) while a *successful* gh finding no
+#   PR is drift that --fix still refuses to adopt, because clearing a recorded
+#   PR is a downgrade.
+#
 # Two of these double as defect pins for `specclaw-status-row`:
 #
 #   D3: a new row was inserted after the *last table row in the whole file*, so
@@ -40,8 +51,9 @@ TEMPLATE="$(cd "$SCRIPT_DIR/.." && pwd)/templates/status.md"
 
 SET_PHASE="$BIN_DIR/specclaw-set-phase"
 STATUS_ROW="$BIN_DIR/specclaw-status-row"
+RECONCILE="$BIN_DIR/specclaw-reconcile"
 
-for f in "$SET_PHASE" "$STATUS_ROW" "$TEMPLATE"; do
+for f in "$SET_PHASE" "$STATUS_ROW" "$RECONCILE" "$TEMPLATE"; do
   if [[ ! -f "$f" ]]; then
     echo "FATAL: missing file: $f" >&2
     exit 2
@@ -85,6 +97,15 @@ assert_contains() {
     pass "$label (contains '$needle')"
   else
     fail "$label — '$needle' not found in: $haystack"
+  fi
+}
+
+assert_lacks() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$label (no '$needle')"
+  else
+    fail "$label — '$needle' should not appear, but does"
   fi
 }
 
@@ -503,9 +524,356 @@ assert_same_file "FBj idempotent under the fallback reader (state.json)" \
 assert_same_file "FBk idempotent under the fallback reader (status.md)" \
   "$WORK/fb.status.snap" "$C/status.md"
 
+# ═════════════════════════════════════════════════════════════════════════════
+# specclaw-reconcile (FR8, AC9, AC10)
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Hermetic by construction: a second .specclaw tree under the same temp workdir
+# (so the counts in the summary line are this section's alone), no network, and
+# `gh` only ever reached through a shim on PATH. The three states that matter —
+# gh absent, gh failing, gh answering — are three PATHs, not three mocks.
+
+RSPEC="$WORK/.specclaw-recon"
+mkdir -p "$RSPEC/changes"
+
+# make_shim <dir> — a PATH holding only what reconcile, set-phase and status-row
+# need. No jq (so every reconcile assertion below also exercises the python3
+# read fallback) and, unless one is added afterwards, no gh.
+make_shim() {
+  local dir="$1" b p
+  mkdir -p "$dir"
+  for b in bash sh env python3 date mktemp chmod mv cp rm mkdir tr sed awk cat \
+    dirname basename grep sort head tail cut wc find timeout git printf ls; do
+    p="$(command -v "$b" 2>/dev/null)" || continue
+    case "$p" in /*) ln -sf "$p" "$dir/$b" ;; esac
+  done
+}
+
+NOGH="$WORK/recon-nogh"
+GHFAIL="$WORK/recon-ghfail"
+GHOK="$WORK/recon-ghok"
+make_shim "$NOGH"
+make_shim "$GHFAIL"
+make_shim "$GHOK"
+
+# A `gh` that always fails, the way an unauthenticated or offline one does.
+cat >"$GHFAIL/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh: To get started with GitHub CLI, please run: gh auth login" >&2
+exit 4
+EOF
+chmod +x "$GHFAIL/gh"
+
+# A `gh` that succeeds, answering `pr list` with whatever SPECCLAW_TEST_PR_ROW
+# holds — empty meaning "authenticated, and there is genuinely no PR".
+cat >"$GHOK/gh" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list") ;;
+  *) echo "gh shim: unsupported: $*" >&2; exit 1 ;;
+esac
+[ -n "${SPECCLAW_TEST_PR_ROW:-}" ] || exit 0
+printf '%s\n' "$SPECCLAW_TEST_PR_ROW"
+EOF
+chmod +x "$GHOK/gh"
+
+assert_eq "Ra the reconcile shims carry no jq" "" "$(PATH="$NOGH" bash -c 'command -v jq' 2>/dev/null)"
+assert_eq "Rb the no-gh shim really has no gh" "" "$(PATH="$NOGH" bash -c 'command -v gh' 2>/dev/null)"
+
+ROUT=""
+# run_recon <shim_path> <args…>
+run_recon() {
+  local p="$1"
+  shift
+  RC=0
+  PATH="$p" "$RECONCILE" "$@" >"$WORK/recon.out" 2>"$WORK/recon.err" || RC=$?
+  ROUT="$(cat "$WORK/recon.out" "$WORK/recon.err")"
+}
+
+# run_sp_p <shim_path> <args…> — set-phase under a shim PATH, for building the
+# fixtures the same way the lifecycle would.
+run_sp_p() {
+  local p="$1"
+  shift
+  RC=0
+  PATH="$p" "$SET_PHASE" "$@" >"$WORK/last.out" 2>"$WORK/last.err" || RC=$?
+}
+
+rchange() {
+  local name="$1"
+  mkdir -p "$RSPEC/changes/$name"
+  printf '%s' "$RSPEC/changes/$name"
+}
+
+# make_tasks <file> <done> <total> [failed] — the three markers reconcile greps.
+make_tasks() {
+  local f="$1" nd="$2" nt="$3" nf="${4:-0}" i n=1
+  printf '# Tasks\n\n' >"$f"
+  for ((i = 0; i < nd; i++)); do
+    printf -- '- [x] `T%d` — done\n' "$n" >>"$f"
+    n=$((n + 1))
+  done
+  for ((i = 0; i < nf; i++)); do
+    printf -- '- [!] `T%d` — failed\n' "$n" >>"$f"
+    n=$((n + 1))
+  done
+  while [ "$n" -le "$nt" ]; do
+    printf -- '- [ ] `T%d` — pending\n' "$n" >>"$f"
+    n=$((n + 1))
+  done
+}
+
+make_verify_report() {
+  cat >"$1" <<EOF
+# Verify Report: $(basename "$(dirname "$1")")
+
+**Date:** 2026-08-01
+
+## Verdict: $2
+
+Evidence elided.
+EOF
+}
+
+# ─── R1: everything agrees → exit 0, no findings ─────────────────────────────
+C="$(rchange clean)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 3 3
+make_verify_report "$C/verify-report.md" PASS
+run_sp_p "$NOGH" "$RSPEC" clean build done --tasks 3/3/0 --branch claude/clean
+run_sp_p "$NOGH" "$RSPEC" clean verify passed --verdict PASS
+cp "$C/state.json" "$WORK/r1.state.snap"
+
+run_recon "$NOGH" "$RSPEC" clean
+assert_eq "R1a an agreeing change exits 0" "0" "$RC"
+assert_contains "R1b it reports no drift" "no drift" "$ROUT"
+assert_lacks "R1c no DRIFT lines" "DRIFT" "$ROUT"
+assert_same_file "R1d the report mode wrote nothing" "$WORK/r1.state.snap" "$C/state.json"
+
+# ─── R2 / AC9: build recorded, reality is verified ───────────────────────────
+C="$(rchange ac9)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 4 4
+make_verify_report "$C/verify-report.md" PASS
+run_sp_p "$NOGH" "$RSPEC" ac9 build done --tasks 2/4/0 --branch claude/ac9
+assert_eq "R2a fixture recorded phase is build" "build" "$(json_get "$C/state.json" phase)"
+cp "$C/state.json" "$WORK/r2.state.snap"
+
+run_recon "$NOGH" "$RSPEC" ac9
+if [[ "$RC" -ne 0 ]]; then
+  pass "AC9a drift exits non-zero (= $RC)"
+else
+  fail "AC9a drift should exit non-zero, exited 0"
+fi
+assert_contains "AC9b the phase drift is named" "state.json says 'build'; observation supports 'verify'" "$ROUT"
+assert_contains "AC9c the stale task counts are named" "state.json records 2/4" "$ROUT"
+assert_contains "AC9d the observed counts are named" "tasks.md shows 4/4" "$ROUT"
+assert_same_file "AC9e reporting drift changed nothing" "$WORK/r2.state.snap" "$C/state.json"
+
+run_recon "$NOGH" "$RSPEC" ac9 --fix
+assert_eq "AC9f --fix exits 0" "0" "$RC"
+assert_eq "AC9g the phase advanced to verify" "verify" "$(json_get "$C/state.json" phase)"
+assert_eq "AC9h the verdict was adopted from verify-report.md" "PASS" \
+  "$(json_get "$C/state.json" phases.verify.verdict)"
+assert_eq "AC9i the build record was refreshed from tasks.md" '{"done":4,"total":4,"failed":0}' \
+  "$(json_get "$C/state.json" phases.build.tasks)"
+# status.md only moves if set-phase did the write — reconcile never touches it.
+assert_eq "AC9j --fix routed through set-phase: the Verify row was rewritten" \
+  "| Verify | ✅ Passed | PASS |" "$(grep '^| Verify |' "$C/status.md")"
+assert_eq "AC9k --fix routed through set-phase: the Build row too" \
+  "| Build | ✅ Done | 4/4 tasks |" "$(grep '^| Build |' "$C/status.md")"
+
+run_recon "$NOGH" "$RSPEC" ac9
+assert_eq "AC9l the audit is idempotent: no drift after --fix" "0" "$RC"
+assert_lacks "AC9m and no findings remain" "DRIFT" "$ROUT"
+
+# ─── R3 / AC10: gh absent → unknown, and a recorded PR survives --fix ────────
+C="$(rchange ac10)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 4 4
+make_verify_report "$C/verify-report.md" PASS
+run_sp_p "$NOGH" "$RSPEC" ac10 build done --tasks 4/4/0 --branch claude/ac10
+run_sp_p "$NOGH" "$RSPEC" ac10 pr raised --url "$URL"
+cp "$C/state.json" "$WORK/r3.state.snap"
+cp "$C/status.md" "$WORK/r3.status.snap"
+
+run_recon "$NOGH" "$RSPEC" ac10
+assert_eq "AC10a an unobservable dimension is not drift" "0" "$RC"
+assert_contains "AC10b the pr dimension reads unknown" "pr       unknown" "$ROUT"
+assert_contains "AC10c and says why" "gh is not installed" "$ROUT"
+assert_lacks "AC10d it never claims there is no PR" "gh finds no PR" "$ROUT"
+assert_lacks "AC10e no drift is invented from the unknown" "DRIFT" "$ROUT"
+
+run_recon "$NOGH" "$RSPEC" ac10 --fix
+assert_eq "AC10f --fix exits 0" "0" "$RC"
+assert_contains "AC10g --fix says it skipped the pr dimension" "SKIP     pr" "$ROUT"
+assert_contains "AC10h and that the reason was 'unknown'" "observation is 'unknown'" "$ROUT"
+assert_contains "AC10i and states the rule it is following" "never clears a recorded PR" "$ROUT"
+assert_same_file "AC10j state.json is byte-identical after --fix" "$WORK/r3.state.snap" "$C/state.json"
+assert_same_file "AC10k status.md is byte-identical after --fix" "$WORK/r3.status.snap" "$C/status.md"
+assert_eq "AC10l the recorded pr phase survived untouched" "pr" "$(json_get "$C/state.json" phase)"
+assert_eq "AC10m the recorded PR url was not cleared" "$URL" "$(json_get "$C/state.json" phases.pr.url)"
+
+# ─── R4 / AC10: real drift alongside an unknown → fix one, skip the other ────
+C="$(rchange ac10b)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 4 4
+make_verify_report "$C/verify-report.md" FAIL
+run_sp_p "$NOGH" "$RSPEC" ac10b build done --tasks 1/4/0 --branch claude/ac10b
+
+run_recon "$NOGH" "$RSPEC" ac10b
+if [[ "$RC" -ne 0 ]]; then
+  pass "AC10n observable drift still exits non-zero with an unknown present (= $RC)"
+else
+  fail "AC10n observable drift alongside an unknown should exit non-zero"
+fi
+
+run_recon "$NOGH" "$RSPEC" ac10b --fix
+assert_eq "AC10o --fix exits 0" "0" "$RC"
+assert_eq "AC10p the observable dimensions were adopted" "verify" "$(json_get "$C/state.json" phase)"
+assert_eq "AC10q including the FAIL verdict" "FAIL" "$(json_get "$C/state.json" phases.verify.verdict)"
+assert_contains "AC10r the unknown pr dimension was still skipped out loud" "SKIP     pr" "$ROUT"
+assert_eq "AC10s and no pr record was invented for it" "" "$(json_get "$C/state.json" phases.pr)"
+
+# ─── R5: a failing gh is `unknown`, never `no PR` ────────────────────────────
+# The distinction AC10 rests on. `gh` exiting 4 (auth) must read exactly like
+# `gh` being absent — otherwise an unauthenticated laptop clears every PR it
+# cannot see.
+C="$(rchange ghfail)"
+make_status "$C/status.md"
+run_sp_p "$GHFAIL" "$RSPEC" ghfail pr raised --url "$URL" --branch claude/ghfail
+cp "$C/state.json" "$WORK/r5.state.snap"
+
+run_recon "$GHFAIL" "$RSPEC" ghfail
+assert_eq "R5a a failing gh is not drift" "0" "$RC"
+assert_contains "R5b the pr dimension reads unknown" "pr       unknown" "$ROUT"
+assert_contains "R5c the exit status is reported" "gh exited 4" "$ROUT"
+assert_lacks "R5d a failing gh never reads as 'no PR'" "gh finds no PR" "$ROUT"
+
+run_recon "$GHFAIL" "$RSPEC" ghfail --fix
+assert_eq "R5e --fix exits 0" "0" "$RC"
+assert_same_file "R5f --fix left the recorded PR alone" "$WORK/r5.state.snap" "$C/state.json"
+
+# ─── R6: a *succeeding* gh finding no PR is drift — and still not adopted ────
+# `none` is a real observation, so it is reported. Adopting it would mean
+# pr → verify, a downgrade; reconcile refuses and says so rather than passing
+# --force behind the operator's back.
+C="$(rchange ghnone)"
+make_status "$C/status.md"
+run_sp_p "$GHOK" "$RSPEC" ghnone pr raised --url "$URL" --branch claude/ghnone
+cp "$C/state.json" "$WORK/r6.state.snap"
+
+export SPECCLAW_TEST_PR_ROW=""
+run_recon "$GHOK" "$RSPEC" ghnone
+if [[ "$RC" -ne 0 ]]; then
+  pass "R6a an authenticated gh finding no PR is drift (= $RC)"
+else
+  fail "R6a gh answering 'no PR' against a recorded one should be drift"
+fi
+assert_contains "R6b the pr dimension reads none, not unknown" "none — gh finds no PR" "$ROUT"
+assert_contains "R6c the finding names the recorded url" "state.json records a PR (${URL})" "$ROUT"
+
+run_recon "$GHOK" "$RSPEC" ghnone --fix
+assert_eq "R6d --fix exits 0" "0" "$RC"
+assert_contains "R6e --fix refuses to clear the PR" "clearing a recorded PR is a downgrade" "$ROUT"
+assert_contains "R6e2 a --fix that applied nothing says so, so exit 0 cannot read as clean" \
+  "finding(s) found, none applied" "$ROUT"
+assert_same_file "R6f the recorded PR is still there" "$WORK/r6.state.snap" "$C/state.json"
+assert_eq "R6g the phase is still pr" "pr" "$(json_get "$C/state.json" phase)"
+
+# ─── R7: a succeeding gh that finds a PR → drift, and --fix adopts it ────────
+C="$(rchange ghok)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 2 2
+make_verify_report "$C/verify-report.md" PASS
+run_sp_p "$GHOK" "$RSPEC" ghok build done --tasks 2/2/0 --branch feature/odd-name
+run_sp_p "$GHOK" "$RSPEC" ghok verify passed --verdict PASS
+
+PR_URL_OBS="https://github.com/chan4lk/specclaw/pull/417"
+export SPECCLAW_TEST_PR_ROW="2026-08-01T10:00:00Z 417 OPEN ${PR_URL_OBS}"
+run_recon "$GHOK" "$RSPEC" ghok
+if [[ "$RC" -ne 0 ]]; then
+  pass "R7a an unrecorded open PR is drift (= $RC)"
+else
+  fail "R7a an unrecorded open PR should be drift"
+fi
+assert_contains "R7b the PR is reported with its number and state" "#417 open" "$ROUT"
+assert_contains "R7c the finding names the recorded branch, not a prefix guess" \
+  "on 'feature/odd-name'; state.json records no PR" "$ROUT"
+
+run_recon "$GHOK" "$RSPEC" ghok --fix
+assert_eq "R7d --fix exits 0" "0" "$RC"
+assert_eq "R7e the phase advanced to pr" "pr" "$(json_get "$C/state.json" phase)"
+assert_eq "R7f the observed url was recorded" "$PR_URL_OBS" "$(json_get "$C/state.json" phases.pr.url)"
+assert_eq "R7g --fix routed through set-phase: one PR row in status.md" "1" \
+  "$(grep -c '^| PR |' "$C/status.md")"
+assert_eq "R7h the PR row carries the url" "| PR | ✅ Raised | $PR_URL_OBS |" \
+  "$(grep '^| PR |' "$C/status.md")"
+unset SPECCLAW_TEST_PR_ROW
+
+# ─── R8: no state.json at all is "unmanaged", not drift ──────────────────────
+C="$(rchange unmanaged)"
+make_status "$C/status.md"
+printf '# Proposal\n' >"$C/proposal.md"
+make_tasks "$C/tasks.md" 2 5
+run_recon "$NOGH" "$RSPEC" unmanaged
+assert_eq "R8a an unmanaged change exits 0" "0" "$RC"
+assert_contains "R8b it is reported as unmanaged" "unmanaged — no state.json" "$ROUT"
+assert_contains "R8c and explicitly not as drift" "no drift (unmanaged)" "$ROUT"
+assert_lacks "R8d no findings are raised against it" "DRIFT" "$ROUT"
+
+run_recon "$NOGH" "$RSPEC" unmanaged --fix
+assert_eq "R8e --fix on an unmanaged change exits 0" "0" "$RC"
+if [[ -f "$C/state.json" ]]; then
+  fail "R8f --fix must not backfill state.json for an unmanaged change (AC6 rendering)"
+else
+  pass "R8f --fix left the unmanaged change unmanaged"
+fi
+
+# ─── R9: a corrupt state.json is drift, and --fix rewrites it ────────────────
+C="$(rchange broken)"
+make_status "$C/status.md"
+make_tasks "$C/tasks.md" 3 3
+printf '{"change":"broken","phase":"bui' >"$C/state.json"
+run_recon "$NOGH" "$RSPEC" broken
+if [[ "$RC" -ne 0 ]]; then
+  pass "R9a an unparseable state.json is drift (= $RC)"
+else
+  fail "R9a an unparseable state.json should be drift"
+fi
+assert_contains "R9b it is named as unreadable, not treated as unmanaged" \
+  "state.json does not parse" "$ROUT"
+run_recon "$NOGH" "$RSPEC" broken --fix
+assert_eq "R9c --fix exits 0" "0" "$RC"
+if json_ok "$C/state.json"; then
+  pass "R9d --fix rewrote it as valid JSON"
+else
+  fail "R9d state.json still unparseable: $(cat "$C/state.json")"
+fi
+assert_eq "R9e with the observed phase" "build" "$(json_get "$C/state.json" phase)"
+
+# ─── R10: sweeping every change, and skipping archive/ ───────────────────────
+mkdir -p "$RSPEC/changes/archive/2026-07-01-old"
+printf '{"change":"2026-07-01-old","phase":"nonsense","phases":{}}\n' \
+  >"$RSPEC/changes/archive/2026-07-01-old/state.json"
+make_tasks "$RSPEC/changes/archive/2026-07-01-old/tasks.md" 9 9
+
+run_recon "$NOGH" "$RSPEC"
+assert_lacks "R10a archived changes are skipped (edge 7)" "2026-07-01-old" "$ROUT"
+assert_lacks "R10b and the archive directory is not itself a change" "▸ archive" "$ROUT"
+assert_contains "R10c the sweep covers every active change" "examined: 9" "$ROUT"
+assert_contains "R10d and counts the unmanaged one separately" "unmanaged: 1" "$ROUT"
+
+run_recon "$NOGH" "$RSPEC" 2026-07-01-old
+assert_eq "R10e naming an archived change is a usage error" "2" "$RC"
+
+run_recon "$NOGH" "$RSPEC" no-such-change
+assert_eq "R10f naming an unknown change is a usage error" "2" "$RC"
+assert_contains "R10g with a message naming it" "no such change: no-such-change" "$ROUT"
+
 # ─── Hermeticity: nothing was written outside the temp workdir ───────────────
 assert_eq "Ha every change directory lives under the temp workdir" "0" \
-  "$(find "$SPECCLAW" -name state.json -not -path "$WORK/*" | wc -l)"
+  "$(find "$SPECCLAW" "$RSPEC" -name state.json -not -path "$WORK/*" | wc -l)"
 
 echo
 echo "─────────────────────────────"

--- a/plugins/specclaw/tests/run-phase-state-tests.sh
+++ b/plugins/specclaw/tests/run-phase-state-tests.sh
@@ -871,9 +871,129 @@ run_recon "$NOGH" "$RSPEC" no-such-change
 assert_eq "R10f naming an unknown change is a usage error" "2" "$RC"
 assert_contains "R10g with a message naming it" "no such change: no-such-change" "$ROUT"
 
+# ─── S: the renderer — specclaw-update-status against state.json (AC5–AC7) ───
+#
+# The writer and the auditor were covered above; the *reader* is the third side
+# of the contract and the one a user actually looks at. These three cases were
+# proved by hand during verify, which is exactly why they belong here: a hand
+# proof does not run in CI.
+#
+# Every case runs under the no-gh shim with SPECCLAW_STATUS_NO_PR=1, so the
+# rendered line is a pure function of the fixture — no network, no clock beyond
+# the `Last Updated` header, which no assertion reads.
+
+USTATUS="$BIN_DIR/specclaw-update-status"
+if [[ ! -f "$USTATUS" ]]; then
+  fail "Sa specclaw-update-status exists"
+else
+  USPEC="$WORK/.specclaw-render"
+  mkdir -p "$USPEC/changes"
+  cat >"$USPEC/config.yaml" <<'EOF'
+version: 1
+project:
+  name: "render-fixture"
+git:
+  branch_prefix: "specclaw/"
+EOF
+
+  SOUT=""
+  SERR=""
+  # run_us — regenerate STATUS.md, capture rc and stderr, read back the dashboard.
+  run_us() {
+    RC=0
+    PATH="$NOGH" SPECCLAW_STATUS_NO_PR=1 "$USTATUS" "$USPEC" \
+      >"$WORK/us.out" 2>"$WORK/us.err" || RC=$?
+    SERR="$(cat "$WORK/us.err")"
+    SOUT="$(cat "$USPEC/STATUS.md" 2>/dev/null || true)"
+  }
+
+  # line_for <change> — the one dashboard bullet naming this change.
+  line_for() {
+    grep -F -- "**$1**" "$USPEC/STATUS.md" 2>/dev/null | head -1
+  }
+
+  # AC5 — a recorded `pr` phase renders as PR-in-review with no network reachable.
+  # Pre-change this rendered `✅ … 2/2 tasks`, indistinguishable from "build done",
+  # which is the whole reason state.json exists.
+  mkdir -p "$USPEC/changes/recorded"
+  make_tasks "$USPEC/changes/recorded/tasks.md" 2 2
+  run_sp_p "$NOGH" "$USPEC" recorded build done --tasks 2/2/0
+  run_sp_p "$NOGH" "$USPEC" recorded pr raised --url "$URL"
+  run_us
+  assert_eq "S1a rendering a recorded phase exits 0" "0" "$RC"
+  assert_eq "S1b the pr phase leads the line, counts follow" \
+    "- 🔀 **recorded** — pr raised | 2/2 tasks (100%) | 0 failed" "$(line_for recorded)"
+  assert_lacks "S1c and it is not rendered as a finished build" \
+    "✅ **recorded**" "$SOUT"
+  assert_eq "S1d a recorded phase needs no gh at all" "" "$SERR"
+
+  # The `pr` qualifier comes from phases.pr.status. phases.pr.state is written by
+  # nothing, so a renderer reading it would silently print a bare `pr`.
+  assert_eq "S1e the qualifier is the recorded status, not an unwritten field" \
+    "raised" "$(json_get "$USPEC/changes/recorded/state.json" phases.pr.status)"
+  assert_eq "S1f nothing writes phases.pr.state" \
+    "" "$(json_get "$USPEC/changes/recorded/state.json" phases.pr.state)"
+
+  # AC6 — no state.json: byte-for-byte the pre-change checkbox inference, and no
+  # warning. Every change that predates this feature takes this path.
+  mkdir -p "$USPEC/changes/unmanaged"
+  make_tasks "$USPEC/changes/unmanaged/tasks.md" 1 2
+  run_us
+  assert_eq "S2a a change with no state.json still renders" "0" "$RC"
+  assert_eq "S2b via checkbox inference, exactly as before the change" \
+    "- 🔨 **unmanaged** — 1/2 tasks (50%) | 0 failed" "$(line_for unmanaged)"
+  assert_eq "S2c and silently — an absent state.json is not a fault" "" "$SERR"
+
+  # AC7 — corrupt state.json: fall back, warn, exit 0. A half-written file must
+  # never be believed, and must never take the dashboard down with it.
+  mkdir -p "$USPEC/changes/corrupt"
+  make_tasks "$USPEC/changes/corrupt/tasks.md" 1 2
+  printf '%s' '{"change":"corrupt","phase":"pr","phas' \
+    >"$USPEC/changes/corrupt/state.json"
+  run_us
+  assert_eq "S3a a corrupt state.json still exits 0" "0" "$RC"
+  assert_contains "S3b with a warning naming the change" \
+    "unreadable state.json for corrupt" "$SERR"
+  assert_eq "S3c and renders via inference, not the phase it half-claims" \
+    "- 🔨 **corrupt** — 1/2 tasks (50%) | 0 failed" "$(line_for corrupt)"
+  assert_lacks "S3d the truncated 'pr' is not believed" "🔀 **corrupt**" "$SOUT"
+
+  # Not JSON at all — the other corruption shape, same contract.
+  printf '%s' 'garbage not json' >"$USPEC/changes/corrupt/state.json"
+  run_us
+  assert_eq "S3e non-JSON content is handled identically" "0" "$RC"
+  assert_eq "S3f and renders identically" \
+    "- 🔨 **corrupt** — 1/2 tasks (50%) | 0 failed" "$(line_for corrupt)"
+
+  # Edge case 7 — a corrupt state.json under archive/ is never read at all.
+  mkdir -p "$USPEC/changes/archive/2026-01-01-gone"
+  make_tasks "$USPEC/changes/archive/2026-01-01-gone/tasks.md" 3 3
+  printf '%s' 'totally broken {{{' \
+    >"$USPEC/changes/archive/2026-01-01-gone/state.json"
+  run_us
+  assert_eq "S4a an archived change's state.json is never read" "0" "$RC"
+  assert_lacks "S4b so it raises no warning" "2026-01-01-gone" "$SERR"
+fi
+
+# ─── E11: a change name with sed metacharacters ──────────────────────────────
+#
+# The template self-heal interpolates the change name into a sed *replacement*,
+# where `&` means "the whole match" and `/` closes the expression. An unescaped
+# name here wrote `{{title}}` back as the literal `{{title}}` (for `&`) or
+# aborted the run outright (for `/`), after state.json was already written.
+
+C="$(new_change 'a&b')"
+run_sp "$SPECCLAW" 'a&b' build done --tasks 1/1/0
+assert_eq "E11a a change name containing & is written" "0" "$RC"
+assert_eq "E11b state.json records it verbatim" "a&b" "$(json_get "$C/state.json" change)"
+assert_contains "E11c and the template title is the name, not the match" \
+  "a&b" "$(head -3 "$C/status.md" 2>/dev/null)"
+assert_lacks "E11d with no unsubstituted placeholder left behind" \
+  "{{title}}" "$(cat "$C/status.md" 2>/dev/null)"
+
 # ─── Hermeticity: nothing was written outside the temp workdir ───────────────
 assert_eq "Ha every change directory lives under the temp workdir" "0" \
-  "$(find "$SPECCLAW" "$RSPEC" -name state.json -not -path "$WORK/*" | wc -l)"
+  "$(find "$SPECCLAW" "$RSPEC" ${USPEC:+"$USPEC"} -name state.json -not -path "$WORK/*" | wc -l)"
 
 echo
 echo "─────────────────────────────"

--- a/plugins/specclaw/tests/shellcheck-baseline.txt
+++ b/plugins/specclaw/tests/shellcheck-baseline.txt
@@ -33,7 +33,5 @@ plugins/specclaw/bin/specclaw-pr SC2034
 plugins/specclaw/bin/specclaw-pr SC2295
 plugins/specclaw/bin/specclaw-validate-change SC2168
 plugins/specclaw/bin/specclaw-validate-change SC2295
-plugins/specclaw/bin/specclaw-verify SC2034
-plugins/specclaw/bin/specclaw-verify SC2155
 plugins/specclaw/bin/specclaw-verify-context SC2016
 plugins/specclaw/bin/specclaw-verify-context SC2034

--- a/plugins/specclaw/tests/shellcheck-gate.sh
+++ b/plugins/specclaw/tests/shellcheck-gate.sh
@@ -42,8 +42,12 @@ shellcheck -f gcc plugins/specclaw/bin/specclaw-* 2>/dev/null |
 
 grep -vE '^[[:space:]]*(#|$)' "$baseline" | LC_ALL=C sort -u > "$expected"
 
-new_findings="$(comm -13 "$expected" "$current")"
-fixed_findings="$(comm -23 "$expected" "$current")"
+# comm must read in the same collation the files were sorted in. Without
+# LC_ALL=C here it applies the ambient locale, where `specclaw-verify SC2034`
+# and `specclaw-verify-context SC2016` order differently than under C — and a
+# mis-collated comm reports the same pair as both fixed and new.
+new_findings="$(LC_ALL=C comm -13 "$expected" "$current")"
+fixed_findings="$(LC_ALL=C comm -23 "$expected" "$current")"
 
 if [[ -n "$fixed_findings" ]]; then
   echo "These baseline entries no longer occur — prune them from shellcheck-baseline.txt:"


### PR DESCRIPTION
## Why

A change's phase was tracked in five places at once. `specclaw-build`, `specclaw-verify`, both PR
scripts and three SKILL.md files each rewrote `status.md` their own way, and `STATUS.md` re-derived
the phase by counting checkboxes in `tasks.md`. Any one of them could disagree with the others, and
regularly did — a change with a PR open rendered as `✅ build done`, indistinguishable from one that
had never left the builder.

Two consequences worth naming:

- `specclaw-update-status` guessed the branch as `${branch_prefix}${change}`. A change built on a
  branch named anything else had its PR silently invisible on the dashboard.
- `skills/build/SKILL.md` instructed the *model* to edit `status.md` prose. That is why the Build row
  drifted.

## What

`state.json` per change, with exactly one writer.

- **`specclaw-set-phase`** — the sole phase writer. Atomic (temp file in the change dir → parse check
  → `mv`), monotonic (a lower rank is refused unless `--force`; equal rank is fine, re-verify is
  normal), idempotent (re-running a transition preserves `at` rather than churning it). The human
  `status.md` row is delegated to `specclaw-status-row`, so the two files cannot disagree.
- **`specclaw-reconcile`** — audits `state.json` against `tasks.md` markers, `verify-report.md`, and
  `gh pr view` on the *recorded* branch. Exits non-zero on drift; `--fix` adopts reality through
  `set-phase`, so `--fix` cannot become a second writer.
- Every call site routed through it: build (recording the real `git branch --show-current`), verify
  (~50 lines of hand-rolled table surgery deleted), both PR scripts, and the propose/plan/archive
  skills.
- `specclaw-update-status` renders the recorded phase and resolves PRs on the recorded branch.

### The distinction the design turns on

A failing `gh` is **`unknown`**, never **`no PR`**. Conflating them means an unauthenticated laptop
clears every PR it cannot see. Three PATH shims — gh absent, gh failing, gh answering — pin all three
states separately. `--fix` skips unknowns and downgrades, and reports how many findings it declined,
so exit 0 can never be misread as clean.

## Backwards compatibility

A change with no `state.json` falls through to the existing checkbox inference, silently, exit 0.
Proven rather than asserted: the merge base was checked out into a worktree and both versions of
`specclaw-update-status` run over identical fixtures — byte-identical output, modulo the wall-clock
`Last Updated` line. A *corrupt* `state.json` also falls back, but warns.

## Verification

`run-phase-state-tests.sh` — **193 assertions, all green**, registered in CI after `Install jq`.
Hermetic: `mktemp -d` workdir, `gh` only via shims, no network, and a closing assertion that nothing
was written outside the temp dir. `jq` is used when installed and `python3` otherwise; the suite
forces the fallback path and re-runs the write, monotonicity, carry-forward and idempotency checks
under it.

Verify verdict **PARTIAL**, code review **APPROVED_WITH_NOTES** (0 BLOCK). PARTIAL on one point only:
AC12 claims the suite runs green *in CI*, which cannot be observed locally. This PR's first run
settles it.

Four defects the review found are fixed in `7649200`:

- `set-phase` interpolated the change name unescaped into a `sed` replacement — `a&b` wrote its title
  as the literal `a{{title}}b`, `a/b` aborted after `state.json` was already written.
- AC5/AC6/AC7 had **zero** assertions; the suite never invoked `specclaw-update-status`. Now covered.
- A dead read of `phases.pr.state`, a field nothing writes.
- A failed `date` shipped `"at": ""`, a record that reads as "never happened".

Two pre-existing bugs surfaced on the way and are fixed here: `shellcheck-gate.sh` ran `comm` in the
ambient locale against C-sorted input, reporting the same finding as both fixed and new; and
`specclaw-reconcile` had a bare `done` argument that bash parses as the loop keyword.

Dogfooded — this change records its own phase through `set-phase`, and `specclaw-reconcile` reports
no drift.

Version bumped `0.6.2 → 0.6.3` in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)