### PR TITLE
Read the loop gate reports by structure, not by word search

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "specclaw",
       "source": "./plugins/specclaw",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle.",
       "author": {
         "name": "Chandima Ranaweera"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: bash plugins/specclaw/tests/run-status-row-tests.sh
       - name: Run phase-state tests
         run: bash plugins/specclaw/tests/run-phase-state-tests.sh
+      - name: Run loop-gate tests
+        run: bash plugins/specclaw/tests/run-loop-gate-tests.sh
 
   shellcheck:
     name: ShellCheck bin scripts

--- a/plugins/specclaw/.claude-plugin/plugin.json
+++ b/plugins/specclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specclaw",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Spec-driven development framework for Claude Code. Manages the propose \u2192 plan \u2192 build \u2192 verify \u2192 pr lifecycle with structured proposals, specs, designs, task lists, and GitHub/Azure DevOps/Jira integrations.",
   "author": {
     "name": "Chandima Ranaweera",

--- a/plugins/specclaw/CLAUDE.md
+++ b/plugins/specclaw/CLAUDE.md
@@ -94,6 +94,7 @@ Suites live in `tests/`, are bash + coreutils only (no jq in the suites themselv
 | `run-shellcheck-gate-tests.sh` | the shellcheck gate itself |
 | `run-status-row-tests.sh` | `status-row` upserts, and the two sed defects it replaced |
 | `run-phase-state-tests.sh` | `set-phase` transitions and `reconcile` drift detection |
+| `run-loop-gate-tests.sh` | `loop gates` report readers — BLOCK counting and verdict extraction |
 
 `shellcheck-gate.sh` fails CI on any shellcheck finding absent from `shellcheck-baseline.txt` (pairs of `<path> <SCxxxx>`, no line numbers, so unrelated edits do not churn it). Fix a new finding or add a targeted `# shellcheck disable=SCxxxx` with a rationale — never silence one by appending to the baseline. It skips with exit 0 when shellcheck is not installed, so the suite still runs locally.
 

--- a/plugins/specclaw/bin/specclaw-loop
+++ b/plugins/specclaw/bin/specclaw-loop
@@ -159,10 +159,21 @@ cmd_init() {
 
 # Extract a normalized PASS/FAIL/PARTIAL verdict token from a report file.
 # Prints the token (PASS|FAIL|PARTIAL|UNKNOWN) to stdout.
+#
+# Reads the `**Verdict:** X` line that templates/verify-report.md emits, rather
+# than the first verdict-shaped word anywhere in the file: report prose says
+# things like "all criteria pass" and "the lint gate did not fail", and a
+# whole-file scan lets whichever of those appears first decide the gate.
 extract_verdict() {
   local file="$1"
   local raw
-  raw=$(grep -ioE '\b(PASS|FAIL|PARTIAL)\b' "$file" 2>/dev/null | head -1 | tr '[:lower:]' '[:upper:]') || true
+  raw=$(grep -iE '^\*\*Verdict:\*\*' "$file" 2>/dev/null | head -1 \
+        | grep -ioE '\b(PASS|FAIL|PARTIAL)\b' | head -1 | tr '[:lower:]' '[:upper:]') || true
+  # Reports predating the template have no Verdict line; fall back to the
+  # whole-file scan so they keep resolving as they did before.
+  if [ -z "$raw" ] && ! grep -qiE '^\*\*Verdict:\*\*' "$file" 2>/dev/null; then
+    raw=$(grep -ioE '\b(PASS|FAIL|PARTIAL)\b' "$file" 2>/dev/null | head -1 | tr '[:lower:]' '[:upper:]') || true
+  fi
   [ -z "$raw" ] && raw="UNKNOWN"
   printf '%s' "$raw"
 }
@@ -272,14 +283,24 @@ ${cmd_name}_command failed (exit ${rc}): ${snippet}"
       g4_green=true
     fi
   else
+    # Count BLOCK *finding headings* only. agents/code-reviewer.md also prints
+    # BLOCK in its "N findings: X BLOCK, Y WARN, Z NOTE" summary and again in the
+    # verdict rationale, so a whole-file word scan reads a clean report as two
+    # blockers and pins this gate red for every report the reviewer can write.
     local block_count
-    block_count=$(grep -oE '\bBLOCK\b' "$review_file" 2>/dev/null | wc -l | tr -d ' ') || true
+    block_count=$(grep -cE '^### \[BLOCK\]' "$review_file" 2>/dev/null) || true
     [ -z "$block_count" ] && block_count=0
-    if [ "$block_count" -eq 0 ]; then
-      g4_green=true
-    else
+    local review_verdict
+    review_verdict=$(grep -iE '^\*\*Verdict:\*\*' "$review_file" 2>/dev/null | head -1) || true
+    if [ "$block_count" -gt 0 ]; then
       g4_green=false
       g4_errors="${block_count} BLOCK-severity finding(s)"
+    elif printf '%s' "$review_verdict" | grep -q 'CHANGES_REQUESTED'; then
+      # Verdict is authoritative: honour it even if the findings list is malformed.
+      g4_green=false
+      g4_errors="review verdict: CHANGES_REQUESTED"
+    else
+      g4_green=true
     fi
   fi
 

--- a/plugins/specclaw/tests/run-loop-gate-tests.sh
+++ b/plugins/specclaw/tests/run-loop-gate-tests.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# run-loop-gate-tests.sh — regression suite for the two report readers behind
+# `specclaw-loop gates`: the review gate's BLOCK counter and extract_verdict.
+#
+# The defects, both reproduced against the shipped report formats:
+#
+#   D1: the review gate counted BLOCK with `grep -oE '\bBLOCK\b' | wc -l` over the
+#       whole file. agents/code-reviewer.md prints the word twice in every clean
+#       report — once in "N findings: 0 BLOCK, 2 WARN, 2 NOTE" and again in the
+#       verdict rationale — so an APPROVED_WITH_NOTES report scored 2 blockers.
+#       With workflow.code_review: true the review gate could never be green, so
+#       the loop burned every iteration on a change that was already done and then
+#       halted on the cap.
+#
+#   D2: extract_verdict took the first case-insensitive PASS|FAIL|PARTIAL token
+#       anywhere in the file. Verification prose says "the lint gate did not fail"
+#       and "all criteria pass", so whichever phrase a model happened to write
+#       above the `**Verdict:**` line decided the verify gate.
+#
+# Plain bash + coreutils only (no jq). Run from anywhere:
+#   bash plugins/specclaw/tests/run-loop-gate-tests.sh
+# Exits non-zero if any case fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/../bin" && pwd)"
+LOOP="$BIN_DIR/specclaw-loop"
+
+if [[ ! -x "$LOOP" ]]; then
+  echo "FATAL: missing or non-executable: $LOOP" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label (= '$actual')"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+CHANGE="gate-fixture"
+
+# ── Fixture builders ──────────────────────────────────────────────────────────
+
+# A .specclaw tree whose tasks + tests + verify gates are all green, so any red
+# gate in a case below is attributable to the report under test.
+# $1 = destination dir, $2 = workflow.code_review value (true|false)
+make_specclaw() {
+  local dir="$1" code_review="$2"
+  mkdir -p "$dir/changes/$CHANGE"
+  cat > "$dir/config.yaml" <<EOF
+version: 1
+
+build:
+  test_command: ""
+  lint_command: ""
+  build_command: ""
+
+workflow:
+  code_review: ${code_review}
+EOF
+  cat > "$dir/changes/$CHANGE/tasks.md" <<'EOF'
+# Tasks: gate fixture
+
+## Tasks
+
+### Wave 1 — only wave
+
+- [x] `T1` — a task that is done
+  - Files: none
+  - Estimate: small
+EOF
+  write_verify "$dir" PASS
+}
+
+# $1 = specclaw dir, $2 = verdict token
+write_verify() {
+  cat > "$1/changes/$CHANGE/verify-report.md" <<EOF
+# Verification Report: ${CHANGE}
+
+**Verified:** 2026-08-10
+**Model:** test
+**Verdict:** $2
+
+## Summary
+
+**Passed:** 1/1 criteria
+EOF
+}
+
+# ── Gate JSON accessors (grep/sed — the suites stay jq-free) ───────────────────
+
+gate_obj() { printf '%s' "$1" | grep -oE "\{\"name\": \"$2\"[^}]*\}"; }
+gate_green() { gate_obj "$1" "$2" | sed -E 's/.*"green": (true|false).*/\1/'; }
+gate_errors() { gate_obj "$1" "$2" | sed -E 's/.*"errors": "([^"]*)".*/\1/'; }
+top_field() { printf '%s' "$1" | sed -nE "s/.*\"$2\": ([^,]*),.*/\1/p" | head -1; }
+
+run_gates() { "$LOOP" gates "$1" "$CHANGE" 2>/dev/null; }
+
+echo "=== specclaw-loop gates: review + verdict readers ==="
+echo
+
+# ── D1: review gate ───────────────────────────────────────────────────────────
+
+# R1 — the reported failure. A clean APPROVED_WITH_NOTES report, byte-shaped like
+# the one code-reviewer.md writes: the word BLOCK appears twice, in the summary
+# count and in the rationale, but there is no [BLOCK] finding heading.
+D="$WORK/r1"; make_specclaw "$D" true
+cat > "$D/changes/$CHANGE/review-report.md" <<'EOF'
+# Code Review Report: gate-fixture
+
+**Reviewed:** 2026-08-10
+**Model:** test
+**Verdict:** APPROVED_WITH_NOTES
+
+## Summary
+
+4 findings: 0 BLOCK, 2 WARN, 2 NOTE
+
+## Findings
+
+### [WARN] a.sh:1 — Test quality
+**Problem:** a warning.
+
+### [NOTE] b.sh:2 — Naming
+**Problem:** a note.
+
+## Verdict Rationale
+
+Zero BLOCK findings; APPROVED_WITH_NOTES.
+EOF
+J="$(run_gates "$D")"
+assert_eq "R1 review gate green on a 0-BLOCK report (D1)" "true" "$(gate_green "$J" review)"
+assert_eq "R1 review gate reports no errors" "" "$(gate_errors "$J" review)"
+assert_eq "R1 all_green with every other gate green" "true" "$(top_field "$J" all_green)"
+assert_eq "R1 passing_count is 4" "4" "$(top_field "$J" passing_count)"
+
+# R2 — real blockers must still stop the loop, and the count must be the number
+# of finding headings, not the number of times the word appears.
+D="$WORK/r2"; make_specclaw "$D" true
+cat > "$D/changes/$CHANGE/review-report.md" <<'EOF'
+# Code Review Report: gate-fixture
+
+**Verdict:** CHANGES_REQUESTED
+
+## Summary
+
+2 findings: 2 BLOCK, 0 WARN, 0 NOTE
+
+## Findings
+
+### [BLOCK] a.sh:1 — Correctness
+**Problem:** off-by-one.
+**Fix:** use <=.
+
+### [BLOCK] b.sh:2 — Security
+**Problem:** unquoted expansion.
+**Fix:** quote it.
+
+## Verdict Rationale
+
+Two BLOCK findings, so CHANGES_REQUESTED.
+EOF
+J="$(run_gates "$D")"
+assert_eq "R2 review gate red on real blockers" "false" "$(gate_green "$J" review)"
+assert_eq "R2 counts headings, not word hits" "2 BLOCK-severity finding(s)" "$(gate_errors "$J" review)"
+assert_eq "R2 all_green false" "false" "$(top_field "$J" all_green)"
+
+# R3 — the "No findings." shape.
+D="$WORK/r3"; make_specclaw "$D" true
+cat > "$D/changes/$CHANGE/review-report.md" <<'EOF'
+# Code Review Report: gate-fixture
+
+**Verdict:** APPROVED
+
+## Findings
+
+No findings.
+EOF
+assert_eq "R3 review gate green on APPROVED" "true" "$(gate_green "$(run_gates "$D")" review)"
+
+# R4 — malformed report: the verdict says blockers exist but no heading does.
+# The verdict wins, so a truncated findings list cannot smuggle a change through.
+D="$WORK/r4"; make_specclaw "$D" true
+cat > "$D/changes/$CHANGE/review-report.md" <<'EOF'
+# Code Review Report: gate-fixture
+
+**Verdict:** CHANGES_REQUESTED
+
+## Summary
+
+3 findings: 3 BLOCK, 0 WARN, 0 NOTE
+EOF
+J="$(run_gates "$D")"
+assert_eq "R4 verdict is authoritative when headings are missing" "false" "$(gate_green "$J" review)"
+assert_eq "R4 names the verdict as the reason" "review verdict: CHANGES_REQUESTED" "$(gate_errors "$J" review)"
+
+# R5 — absent report: required when code_review is on, ignored when off.
+D="$WORK/r5a"; make_specclaw "$D" true
+J="$(run_gates "$D")"
+assert_eq "R5a missing report is red under code_review: true" "false" "$(gate_green "$J" review)"
+assert_eq "R5a names the missing report" "no review-report.md yet" "$(gate_errors "$J" review)"
+
+D="$WORK/r5b"; make_specclaw "$D" false
+assert_eq "R5b missing report is green under code_review: false" "true" "$(gate_green "$(run_gates "$D")" review)"
+
+# ── D2: extract_verdict ───────────────────────────────────────────────────────
+
+# V1 — prose above the verdict line that contains a competing token. Under D2 the
+# first match won and this PASS report failed its own gate.
+D="$WORK/v1"; make_specclaw "$D" false
+cat > "$D/changes/$CHANGE/verify-report.md" <<'EOF'
+# Verification Report: gate-fixture
+
+**Note:** the lint gate did not fail and no criterion is partial.
+
+**Verdict:** PASS
+
+## Summary
+
+**Verdict:** PASS
+EOF
+J="$(run_gates "$D")"
+assert_eq "V1 verdict line beats earlier prose (D2)" "true" "$(gate_green "$J" verify)"
+assert_eq "V1 verify gate reports no errors" "" "$(gate_errors "$J" verify)"
+
+# V2 — the inverse: a real PARTIAL must not be rescued by upbeat prose.
+D="$WORK/v2"; make_specclaw "$D" false
+cat > "$D/changes/$CHANGE/verify-report.md" <<'EOF'
+# Verification Report: gate-fixture
+
+All the unit criteria pass on the first attempt.
+
+**Verdict:** PARTIAL
+
+## Summary
+
+E2E skipped, so AC4 is unverified.
+EOF
+J="$(run_gates "$D")"
+assert_eq "V2 PARTIAL is not rescued by prose" "false" "$(gate_green "$J" verify)"
+assert_eq "V2 names the verdict" "verify verdict: PARTIAL" "$(gate_errors "$J" verify)"
+
+# V3 — FAIL still reads as FAIL.
+D="$WORK/v3"; make_specclaw "$D" false
+write_verify "$D" FAIL
+assert_eq "V3 FAIL is red" "verify verdict: FAIL" "$(gate_errors "$(run_gates "$D")" verify)"
+
+# V4 — a report predating the template has no Verdict line; the whole-file
+# fallback keeps it resolving exactly as it did before this fix.
+D="$WORK/v4"; make_specclaw "$D" false
+cat > "$D/changes/$CHANGE/verify-report.md" <<'EOF'
+# Verification Report: gate-fixture
+
+Every acceptance criterion PASS after the rerun.
+EOF
+assert_eq "V4 legacy report with no Verdict line still resolves" "true" \
+  "$(gate_green "$(run_gates "$D")" verify)"
+
+# V5 — a report with neither a Verdict line nor any verdict token is UNKNOWN,
+# never an accidental pass.
+D="$WORK/v5"; make_specclaw "$D" false
+printf '# Verification Report: gate-fixture\n\nNothing conclusive here.\n' \
+  > "$D/changes/$CHANGE/verify-report.md"
+J="$(run_gates "$D")"
+assert_eq "V5 unreadable verdict is UNKNOWN and red" "verify verdict: UNKNOWN" "$(gate_errors "$J" verify)"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Problem

Both report readers behind `specclaw-loop gates` scanned the whole report file for a keyword, so the report's own prose decided the gate.

**D1 — review gate (`bin/specclaw-loop:276`).** BLOCK findings were counted with `grep -oE '\bBLOCK\b' | wc -l`. Every report `agents/code-reviewer.md` writes names BLOCK twice *outside* the findings list — in the `N findings: X BLOCK, Y WARN, Z NOTE` summary and again in the verdict rationale — so a clean `APPROVED_WITH_NOTES` report scored two blockers.

With `workflow.code_review: true` this pinned the review gate red for every report the reviewer can produce. `/specclaw:loop` could never reach all-green: it spent its full iteration budget "fixing" a change that was already done, then halted on the cap. Found live on `specclaw/numbered-change-folders`, whose report reads `0 BLOCK, 2 WARN` / `APPROVED_WITH_NOTES` and still gated red with "2 BLOCK-severity finding(s)".

**D2 — `extract_verdict` (`bin/specclaw-loop:165`).** Same shape: the first case-insensitive `PASS|FAIL|PARTIAL` token anywhere in the file. Verification prose says "the lint gate did not fail" and "all criteria pass", so whichever phrase a model happened to write above the `**Verdict:**` line won. This one also failed in the **unsafe** direction — a `PARTIAL` report whose prose mentioned "pass" read as `PASS` and let the verify gate go green.

## Fix

- Review gate counts `^### [BLOCK]` finding headings, and additionally treats a `CHANGES_REQUESTED` verdict as red on its own, so a truncated findings list cannot smuggle a change through.
- `extract_verdict` anchors on the `**Verdict:**` line that `templates/verify-report.md` emits. The whole-file scan is kept only as a fallback for reports written before that template, so existing reports resolve exactly as they did.

## Tests

New `tests/run-loop-gate-tests.sh` (20 assertions, bash + coreutils, no jq), registered in `ci.yml`. **10 of the 20 fail against the pre-fix script** — verified by stashing the fix and re-running.

Coverage: clean 0-BLOCK report is green; real blockers still red with the heading count (pre-fix reported 4 for 2 findings); `No findings.`; malformed report where verdict and headings disagree; absent report under `code_review` true/false; verdict line beating competing prose in both directions; `FAIL`; legacy no-Verdict-line fallback; unreadable verdict → `UNKNOWN` and red.

Other suites pass locally. `run-parser-tests.sh` fails 11 here for lack of `jq` — identical on unmodified `main`, and CI installs it. The shellcheck gate skipped locally (shellcheck not installed); CI runs it.

## Notes

- Version bumped 0.6.3 → 0.6.4. `specclaw/numbered-change-folders` also sits at 0.6.4 off the same base; whichever merges second needs to re-bump.
- `numbered-change-folders` is otherwise ready — its review report is `APPROVED_WITH_NOTES` and both WARNs were already addressed in 4417944. Once this lands, its loop should reach all-green immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)